### PR TITLE
feat: セーブ/ロード + バックログ (#11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,7 +375,7 @@ uv sync
 - ⬜ RPGプレイヤーのPixiJS移行（現在はPhaser）
 - ⬜ 立ち絵表示・退場（未Issue化）
 - ✅ 選択肢・分岐 + フラグ・条件分岐（#10）— GameState / ChoiceOverlay / シーンジャンプ
-- ⬜ セーブ/ロード + バックログ（#11）
+- ✅ セーブ/ロード + バックログ（#11）— SaveManager / SaveLoadOverlay / BacklogOverlay / localStorage 3スロット / JSON エクスポート・インポート
 
 ## 参考ドキュメント
 

--- a/frontend/src/game/BacklogOverlay.ts
+++ b/frontend/src/game/BacklogOverlay.ts
@@ -1,0 +1,210 @@
+/**
+ * バックログUI
+ *
+ * 過去のダイアログ/ナレーションを全画面オーバーレイで表示する。
+ * スクロールで遡って読める。
+ */
+
+import { Container, Graphics, Text as PixiText, TextStyle } from 'pixi.js'
+
+const OVERLAY_ALPHA = 0.85
+const TEXT_PADDING_X = 40
+const TEXT_PADDING_TOP = 60
+const TEXT_PADDING_BOTTOM = 40
+const LINE_HEIGHT = 28
+const NAME_COLOR = 0xa8dadc
+const TEXT_COLOR = 0xf1faee
+const NARRATION_COLOR = 0xcccccc
+const TITLE_COLOR = 0xf1faee
+
+export interface BacklogEntry {
+  character: string | null
+  text: string
+}
+
+export class BacklogOverlay extends Container {
+  private screenWidth: number
+  private screenHeight: number
+  private entries: BacklogEntry[] = []
+  private scrollOffset = 0
+  private contentContainer: Container
+  private maskGraphics: Graphics
+  private totalContentHeight = 0
+
+  constructor(screenWidth: number, screenHeight: number) {
+    super()
+    this.screenWidth = screenWidth
+    this.screenHeight = screenHeight
+    this.eventMode = 'static'
+    this.visible = false
+
+    this.contentContainer = new Container()
+    this.maskGraphics = new Graphics()
+  }
+
+  /**
+   * バックログにエントリを追加する
+   */
+  addEntry(character: string | null, text: string): void {
+    // 空行（改ページ）は記録しない
+    if (text === '') return
+    this.entries.push({ character, text })
+  }
+
+  /**
+   * バックログを表示する
+   */
+  show(): void {
+    this.rebuild()
+    this.visible = true
+  }
+
+  /**
+   * バックログを非表示にする
+   */
+  hide(): void {
+    this.visible = false
+    this.removeChildren()
+  }
+
+  /**
+   * 表示/非表示をトグルする
+   */
+  toggle(): void {
+    if (this.visible) {
+      this.hide()
+    } else {
+      this.show()
+    }
+  }
+
+  /**
+   * マウスホイールでスクロールする
+   */
+  handleWheel(deltaY: number): void {
+    if (!this.visible) return
+    this.scrollOffset += deltaY * 0.5
+    this.clampScroll()
+    this.contentContainer.y = -this.scrollOffset + TEXT_PADDING_TOP
+  }
+
+  /**
+   * キーボードでスクロールする
+   */
+  handleKeyScroll(direction: 'up' | 'down'): void {
+    if (!this.visible) return
+    const step = LINE_HEIGHT * 3
+    this.scrollOffset += direction === 'down' ? step : -step
+    this.clampScroll()
+    this.contentContainer.y = -this.scrollOffset + TEXT_PADDING_TOP
+  }
+
+  private clampScroll(): void {
+    const viewableHeight = this.screenHeight - TEXT_PADDING_TOP - TEXT_PADDING_BOTTOM
+    const maxScroll = Math.max(0, this.totalContentHeight - viewableHeight)
+    this.scrollOffset = Math.max(0, Math.min(this.scrollOffset, maxScroll))
+  }
+
+  private rebuild(): void {
+    this.removeChildren()
+
+    // 半透明黒背景
+    const bg = new Graphics()
+    bg.rect(0, 0, this.screenWidth, this.screenHeight)
+    bg.fill({ color: 0x000000, alpha: OVERLAY_ALPHA })
+    bg.eventMode = 'static'
+    bg.on('pointerdown', (e) => e.stopPropagation())
+    this.addChild(bg)
+
+    // タイトル
+    const titleStyle = new TextStyle({
+      fontFamily: "'Noto Sans JP', sans-serif",
+      fontSize: 22,
+      fill: TITLE_COLOR,
+      fontWeight: 'bold',
+    })
+    const titleText = new PixiText({ text: 'BACKLOG', style: titleStyle })
+    titleText.x = this.screenWidth / 2
+    titleText.y = 16
+    titleText.anchor.set(0.5, 0)
+    this.addChild(titleText)
+
+    // マスク（タイトル下からスクリーン下端まで）
+    this.maskGraphics = new Graphics()
+    this.maskGraphics.rect(0, TEXT_PADDING_TOP, this.screenWidth, this.screenHeight - TEXT_PADDING_TOP - TEXT_PADDING_BOTTOM)
+    this.maskGraphics.fill(0xffffff)
+    this.addChild(this.maskGraphics)
+
+    // コンテンツコンテナ
+    this.contentContainer = new Container()
+    this.contentContainer.mask = this.maskGraphics
+    this.addChild(this.contentContainer)
+
+    const nameStyle = new TextStyle({
+      fontFamily: "'Noto Sans JP', sans-serif",
+      fontSize: 16,
+      fill: NAME_COLOR,
+      fontWeight: 'bold',
+    })
+    const textStyle = new TextStyle({
+      fontFamily: "'Noto Sans JP', sans-serif",
+      fontSize: 16,
+      fill: TEXT_COLOR,
+      wordWrap: true,
+      wordWrapWidth: this.screenWidth - TEXT_PADDING_X * 2,
+    })
+    const narrationStyle = new TextStyle({
+      fontFamily: "'Noto Sans JP', sans-serif",
+      fontSize: 16,
+      fill: NARRATION_COLOR,
+      fontStyle: 'italic',
+      wordWrap: true,
+      wordWrapWidth: this.screenWidth - TEXT_PADDING_X * 2,
+    })
+
+    let y = 0
+    for (const entry of this.entries) {
+      if (entry.character) {
+        const nameText = new PixiText({ text: entry.character, style: nameStyle })
+        nameText.x = TEXT_PADDING_X
+        nameText.y = y
+        this.contentContainer.addChild(nameText)
+        y += 22
+      }
+
+      const style = entry.character ? textStyle : narrationStyle
+      const lineText = new PixiText({ text: entry.text, style })
+      lineText.x = TEXT_PADDING_X
+      lineText.y = y
+      this.contentContainer.addChild(lineText)
+      y += lineText.height + 12
+    }
+
+    this.totalContentHeight = y
+
+    // 最新エントリが見えるようにスクロール位置を初期化
+    const viewableHeight = this.screenHeight - TEXT_PADDING_TOP - TEXT_PADDING_BOTTOM
+    if (this.totalContentHeight > viewableHeight) {
+      this.scrollOffset = this.totalContentHeight - viewableHeight
+    } else {
+      this.scrollOffset = 0
+    }
+
+    this.contentContainer.y = -this.scrollOffset + TEXT_PADDING_TOP
+
+    // 「閉じる」ヒント
+    const hintStyle = new TextStyle({
+      fontFamily: "'Noto Sans JP', sans-serif",
+      fontSize: 14,
+      fill: 0x888888,
+    })
+    const hintText = new PixiText({
+      text: 'ESC / B / クリックで閉じる',
+      style: hintStyle,
+    })
+    hintText.x = this.screenWidth / 2
+    hintText.y = this.screenHeight - 24
+    hintText.anchor.set(0.5, 0.5)
+    this.addChild(hintText)
+  }
+}

--- a/frontend/src/game/GameState.ts
+++ b/frontend/src/game/GameState.ts
@@ -50,4 +50,32 @@ export class GameState {
   clear(): void {
     this.flags.clear()
   }
+
+  /**
+   * フラグを Record として返す（シリアライズ用）
+   */
+  toJSON(): Record<string, FlagValue> {
+    const obj: Record<string, FlagValue> = {}
+    this.flags.forEach((value, key) => {
+      obj[key] = value
+    })
+    return obj
+  }
+
+  /**
+   * Record からフラグを復元する（デシリアライズ用）
+   */
+  fromJSON(data: Record<string, FlagValue>): void {
+    this.flags.clear()
+    for (const [key, value] of Object.entries(data)) {
+      this.flags.set(key, value)
+    }
+  }
+
+  /**
+   * 全フラグを取得する（外部参照用）
+   */
+  getFlags(): Map<string, FlagValue> {
+    return new Map(this.flags)
+  }
 }

--- a/frontend/src/game/GameState.ts
+++ b/frontend/src/game/GameState.ts
@@ -72,10 +72,4 @@ export class GameState {
     }
   }
 
-  /**
-   * 全フラグを取得する（外部参照用）
-   */
-  getFlags(): Map<string, FlagValue> {
-    return new Map(this.flags)
-  }
 }

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -166,7 +166,7 @@ export class NovelRenderer {
     window.addEventListener('keydown', this.handleKeyDown)
 
     // バックログスクロール
-    this.app.canvas.addEventListener('wheel', this.handleWheel)
+    this.app.canvas.addEventListener('wheel', this.handleWheel, { passive: false })
 
     this.initialized = true
   }
@@ -648,16 +648,27 @@ export class NovelRenderer {
     this.displayEventCount = this.events.filter((e) => getTextEvent(e) !== null).length
 
     // eventIndex まで演出イベントを再実行して状態を再構築
+    // Flag/Condition/Choice はスキップし、演出（Background/Blackout/BGM等）のみ再構築
+    // Condition の展開は通常の進行に任せる
+    let lastBgmEvent: Event | null = null
     for (let i = 0; i < data.eventIndex && i < this.events.length; i++) {
       const ev = this.events[i]
       if (!getTextEvent(ev)) {
-        this.processDirective(ev)
-        if (this.waitingForChoice) {
-          // Choice に遭遇した場合は、セーブ時点ではすでに選択済みのはず
-          this.waitingForChoice = false
-          this.choiceOverlay.hide()
+        if (typeof ev === 'object' && ev !== null) {
+          if ('Bgm' in ev) {
+            lastBgmEvent = ev
+          } else if ('Flag' in ev || 'Condition' in ev || 'Choice' in ev) {
+            // スキップ（フラグは fromJSON で復元済み、Condition/Choice は副作用防止）
+          } else {
+            this.processDirective(ev)
+          }
+        } else if (typeof ev === 'string') {
+          this.processDirective(ev)
         }
       }
+    }
+    if (lastBgmEvent) {
+      this.processDirective(lastBgmEvent)
     }
 
     this.eventIndex = data.eventIndex

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -16,6 +16,9 @@ import { DialogBox } from './DialogBox'
 import { AudioManager } from './AudioManager'
 import { GameState } from './GameState'
 import { ChoiceOverlay } from './ChoiceOverlay'
+import { SaveManager, SaveSlotData } from './SaveManager'
+import { SaveLoadOverlay } from './SaveLoadOverlay'
+import { BacklogOverlay } from './BacklogOverlay'
 import { Event, EventScene } from '../types'
 
 const GAME_WIDTH = 800
@@ -73,6 +76,21 @@ export class NovelRenderer {
   /** 展開済み Condition イベントのインデックス（重複展開防止） */
   private expandedConditions: Set<number> = new Set()
 
+  /** セーブマネージャー */
+  private saveManager: SaveManager = new SaveManager()
+
+  /** セーブ/ロードオーバーレイ */
+  private saveLoadOverlay!: SaveLoadOverlay
+
+  /** バックログオーバーレイ */
+  private backlogOverlay!: BacklogOverlay
+
+  /** 現在のシーンID */
+  private currentSceneId: string | null = null
+
+  /** 現在の背景パス */
+  private currentBackgroundPath: string | null = null
+
   constructor() {
     this.app = new Application()
     this.bgGraphics = new Graphics()
@@ -84,6 +102,8 @@ export class NovelRenderer {
     })
     this.audioManager = new AudioManager()
     this.choiceOverlay = new ChoiceOverlay(GAME_WIDTH, GAME_HEIGHT)
+    this.saveLoadOverlay = new SaveLoadOverlay(GAME_WIDTH, GAME_HEIGHT, this.saveManager)
+    this.backlogOverlay = new BacklogOverlay(GAME_WIDTH, GAME_HEIGHT)
   }
 
   /**
@@ -133,11 +153,20 @@ export class NovelRenderer {
     this.choiceOverlay.visible = false
     this.app.stage.addChild(this.choiceOverlay)
 
+    // セーブ/ロードオーバーレイ
+    this.app.stage.addChild(this.saveLoadOverlay)
+
+    // バックログオーバーレイ
+    this.app.stage.addChild(this.backlogOverlay)
+
     // クリック/タップで進行
     this.app.canvas.addEventListener('pointerdown', this.handleAdvance)
 
     // キーボードで進行
     window.addEventListener('keydown', this.handleKeyDown)
+
+    // バックログスクロール
+    this.app.canvas.addEventListener('wheel', this.handleWheel)
 
     this.initialized = true
   }
@@ -157,6 +186,7 @@ export class NovelRenderer {
     this.allScenes = scenes
     this.gameState.clear()
     if (scenes.length > 0) {
+      this.currentSceneId = scenes[0].id
       this.setEvents(scenes[0].events)
     }
   }
@@ -170,6 +200,7 @@ export class NovelRenderer {
       console.warn(`[name-name] シーンが見つからない: ${sceneId}`)
       return
     }
+    this.currentSceneId = sceneId
     this.resetAndStartEvents([...scene.events])
   }
 
@@ -210,9 +241,12 @@ export class NovelRenderer {
    */
   destroy(): void {
     this.app.canvas.removeEventListener('pointerdown', this.handleAdvance)
+    this.app.canvas.removeEventListener('wheel', this.handleWheel)
     window.removeEventListener('keydown', this.handleKeyDown)
     this.audioManager.destroy()
     this.choiceOverlay.hide()
+    this.saveLoadOverlay.hide()
+    this.backlogOverlay.hide()
     this.dialogBox.dispose()
     this.app.destroy(true, { children: true })
     this.initialized = false
@@ -222,11 +256,60 @@ export class NovelRenderer {
 
   private handleAdvance = (): void => {
     this.audioManager.ensureContext()
+    if (this.backlogOverlay.visible) {
+      this.backlogOverlay.hide()
+      return
+    }
+    if (this.saveLoadOverlay.visible) return
     this.advance()
+  }
+
+  private handleWheel = (e: WheelEvent): void => {
+    if (this.backlogOverlay.visible) {
+      e.preventDefault()
+      this.backlogOverlay.handleWheel(e.deltaY)
+    }
   }
 
   private handleKeyDown = (e: KeyboardEvent): void => {
     this.audioManager.ensureContext()
+
+    // Escape: 開いているオーバーレイを閉じる
+    if (e.key === 'Escape') {
+      if (this.backlogOverlay.visible) {
+        this.backlogOverlay.hide()
+        return
+      }
+      if (this.saveLoadOverlay.visible) {
+        this.saveLoadOverlay.hide()
+        return
+      }
+      return
+    }
+
+    // バックログ表示中のキー操作
+    if (this.backlogOverlay.visible) {
+      switch (e.key) {
+        case 'b':
+        case 'B':
+          this.backlogOverlay.hide()
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          this.backlogOverlay.handleKeyScroll('up')
+          break
+        case 'ArrowDown':
+          e.preventDefault()
+          this.backlogOverlay.handleKeyScroll('down')
+          break
+      }
+      return
+    }
+
+    // セーブ/ロードオーバーレイ表示中は入力を無視
+    if (this.saveLoadOverlay.visible) return
+
+    // オーバーレイが開いていない場合のキー操作
     switch (e.key) {
       case ' ':
       case 'Enter':
@@ -238,6 +321,24 @@ export class NovelRenderer {
         break
       case 'ArrowLeft':
         this.goBack()
+        break
+      case 's':
+      case 'S':
+        if (!this.waitingForChoice) {
+          this.openSaveMenu()
+        }
+        break
+      case 'l':
+      case 'L':
+        if (!this.waitingForChoice) {
+          this.openLoadMenu()
+        }
+        break
+      case 'b':
+      case 'B':
+        if (!this.waitingForChoice) {
+          this.backlogOverlay.toggle()
+        }
         break
     }
   }
@@ -253,6 +354,11 @@ export class NovelRenderer {
     const textEvt = getTextEvent(current)
 
     if (textEvt) {
+      // 現在表示中のテキストをバックログに記録
+      const currentLine = textEvt.text[this.textIndex] ?? ''
+      const character = textEvt.type === 'dialog' ? textEvt.character : null
+      this.backlogOverlay.addEntry(character, currentLine)
+
       this.textIndex++
       if (this.textIndex < textEvt.text.length) {
         // まだテキスト行が残っている
@@ -404,6 +510,7 @@ export class NovelRenderer {
    * 背景画像を設定する（アスペクト比維持でカバー）
    */
   private setBackground(path: string): void {
+    this.currentBackgroundPath = path
     this.bgContainer.removeChildren()
 
     if (!this.assetBaseUrl) return
@@ -447,6 +554,7 @@ export class NovelRenderer {
    * 背景画像をクリアする
    */
   private clearBackground(): void {
+    this.currentBackgroundPath = null
     this.bgContainer.removeChildren()
   }
 
@@ -477,6 +585,84 @@ export class NovelRenderer {
     if (lastBgmEvent) {
       this.processDirective(lastBgmEvent)
     }
+  }
+
+  /**
+   * セーブメニューを表示する
+   */
+  private openSaveMenu(): void {
+    this.saveLoadOverlay.showSave((slot: number) => {
+      const sceneName = this.currentSceneId
+        ? this.allScenes.find((s) => s.id === this.currentSceneId)?.title ?? null
+        : null
+
+      const data: SaveSlotData = {
+        slot,
+        sceneId: this.currentSceneId,
+        eventIndex: this.eventIndex,
+        textIndex: this.textIndex,
+        flags: this.gameState.toJSON(),
+        backgroundPath: this.currentBackgroundPath,
+        savedAt: new Date().toISOString(),
+        sceneName,
+      }
+      this.saveManager.save(slot, data)
+    })
+  }
+
+  /**
+   * ロードメニューを表示する
+   */
+  private openLoadMenu(): void {
+    this.saveLoadOverlay.showLoad((data: SaveSlotData) => {
+      this.loadFromSaveData(data)
+    })
+  }
+
+  /**
+   * セーブデータからゲーム状態を復元する
+   */
+  private loadFromSaveData(data: SaveSlotData): void {
+    // フラグを復元
+    this.gameState.fromJSON(data.flags)
+
+    if (!data.sceneId) return
+
+    // シーンを探す
+    const scene = this.allScenes.find((s) => s.id === data.sceneId)
+    if (!scene) {
+      console.warn(`[name-name] セーブデータのシーンが見つからない: ${data.sceneId}`)
+      return
+    }
+
+    this.currentSceneId = data.sceneId
+
+    // 選択肢状態をリセット
+    this.waitingForChoice = false
+    this.choiceOverlay.hide()
+    this.audioManager.stopBgm(0)
+    this.clearBackground()
+    this.blackoutOverlay.visible = false
+    this.events = [...scene.events]
+    this.expandedConditions.clear()
+    this.displayEventCount = this.events.filter((e) => getTextEvent(e) !== null).length
+
+    // eventIndex まで演出イベントを再実行して状態を再構築
+    for (let i = 0; i < data.eventIndex && i < this.events.length; i++) {
+      const ev = this.events[i]
+      if (!getTextEvent(ev)) {
+        this.processDirective(ev)
+        if (this.waitingForChoice) {
+          // Choice に遭遇した場合は、セーブ時点ではすでに選択済みのはず
+          this.waitingForChoice = false
+          this.choiceOverlay.hide()
+        }
+      }
+    }
+
+    this.eventIndex = data.eventIndex
+    this.textIndex = data.textIndex
+    this.render()
   }
 
   /**

--- a/frontend/src/game/SaveLoadOverlay.ts
+++ b/frontend/src/game/SaveLoadOverlay.ts
@@ -1,0 +1,294 @@
+/**
+ * セーブ/ロードメニューUI
+ *
+ * PixiJS Container で3スロットを縦に並べ、セーブ/ロードを行う。
+ * エクスポート/インポートボタンも表示する。
+ */
+
+import { Container, Graphics, Text as PixiText, TextStyle } from 'pixi.js'
+import { SaveManager, SaveSlotData } from './SaveManager'
+
+const SLOT_WIDTH = 520
+const SLOT_HEIGHT = 72
+const SLOT_GAP = 16
+const SLOT_RADIUS = 8
+const BUTTON_WIDTH = 200
+const BUTTON_HEIGHT = 44
+const BUTTON_GAP = 16
+
+const NORMAL_COLOR = 0x1a1a2e
+const HOVER_COLOR = 0x16213e
+const BORDER_COLOR = 0xa8dadc
+const HOVER_BORDER_COLOR = 0xf1faee
+const EMPTY_TEXT_COLOR = 0x666666
+const OVERLAY_ALPHA = 0.7
+
+export class SaveLoadOverlay extends Container {
+  private screenWidth: number
+  private screenHeight: number
+  private mode: 'save' | 'load' = 'save'
+  private saveManager: SaveManager
+  private onSave: ((slot: number) => void) | null = null
+  private onLoad: ((data: SaveSlotData) => void) | null = null
+
+  constructor(screenWidth: number, screenHeight: number, saveManager: SaveManager) {
+    super()
+    this.screenWidth = screenWidth
+    this.screenHeight = screenHeight
+    this.saveManager = saveManager
+    this.eventMode = 'static'
+    this.visible = false
+  }
+
+  /**
+   * セーブモードで表示する
+   */
+  showSave(onSave: (slot: number) => void): void {
+    this.mode = 'save'
+    this.onSave = onSave
+    this.onLoad = null
+    this.rebuild()
+    this.visible = true
+  }
+
+  /**
+   * ロードモードで表示する
+   */
+  showLoad(onLoad: (data: SaveSlotData) => void): void {
+    this.mode = 'load'
+    this.onLoad = onLoad
+    this.onSave = null
+    this.rebuild()
+    this.visible = true
+  }
+
+  /**
+   * メニューを閉じる
+   */
+  hide(): void {
+    this.visible = false
+    this.removeChildren()
+    this.onSave = null
+    this.onLoad = null
+  }
+
+  private rebuild(): void {
+    this.removeChildren()
+
+    // 半透明黒背景
+    const bg = new Graphics()
+    bg.rect(0, 0, this.screenWidth, this.screenHeight)
+    bg.fill({ color: 0x000000, alpha: OVERLAY_ALPHA })
+    bg.eventMode = 'static'
+    bg.on('pointerdown', (e) => e.stopPropagation())
+    this.addChild(bg)
+
+    // タイトル
+    const titleStyle = new TextStyle({
+      fontFamily: "'Noto Sans JP', sans-serif",
+      fontSize: 28,
+      fill: 0xf1faee,
+      fontWeight: 'bold',
+    })
+    const titleText = new PixiText({
+      text: this.mode === 'save' ? 'SAVE' : 'LOAD',
+      style: titleStyle,
+    })
+    titleText.x = this.screenWidth / 2
+    titleText.y = 40
+    titleText.anchor.set(0.5, 0)
+    this.addChild(titleText)
+
+    // スロット一覧
+    const slots = this.saveManager.listSlots()
+    const slotsStartY = 100
+
+    const slotTextStyle = new TextStyle({
+      fontFamily: "'Noto Sans JP', sans-serif",
+      fontSize: 18,
+      fill: 0xf1faee,
+    })
+    const emptyTextStyle = new TextStyle({
+      fontFamily: "'Noto Sans JP', sans-serif",
+      fontSize: 18,
+      fill: EMPTY_TEXT_COLOR,
+    })
+
+    for (let i = 0; i < 3; i++) {
+      const slotData = slots[i]
+      const slotContainer = new Container()
+      slotContainer.eventMode = 'static'
+      slotContainer.x = (this.screenWidth - SLOT_WIDTH) / 2
+      slotContainer.y = slotsStartY + i * (SLOT_HEIGHT + SLOT_GAP)
+
+      const isEmpty = slotData === null
+      const isClickable = this.mode === 'save' || !isEmpty
+
+      if (isClickable) {
+        slotContainer.cursor = 'pointer'
+      }
+
+      const slotBg = new Graphics()
+      this.drawSlot(slotBg, NORMAL_COLOR, BORDER_COLOR)
+      slotContainer.addChild(slotBg)
+
+      // スロット番号
+      const numberText = new PixiText({
+        text: `Slot ${i + 1}`,
+        style: slotTextStyle,
+      })
+      numberText.x = 16
+      numberText.y = 14
+      slotContainer.addChild(numberText)
+
+      if (isEmpty) {
+        const emptyLabel = new PixiText({
+          text: '--- 空きスロット ---',
+          style: emptyTextStyle,
+        })
+        emptyLabel.x = 16
+        emptyLabel.y = 42
+        slotContainer.addChild(emptyLabel)
+      } else {
+        const sceneName = slotData.sceneName ?? '不明なシーン'
+        const date = new Date(slotData.savedAt)
+        const dateStr = `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`
+
+        const infoText = new PixiText({
+          text: `${sceneName}    ${dateStr}`,
+          style: slotTextStyle,
+        })
+        infoText.x = 16
+        infoText.y = 42
+        slotContainer.addChild(infoText)
+      }
+
+      if (isClickable) {
+        slotContainer.on('pointerover', () => {
+          slotBg.clear()
+          this.drawSlot(slotBg, HOVER_COLOR, HOVER_BORDER_COLOR)
+        })
+        slotContainer.on('pointerout', () => {
+          slotBg.clear()
+          this.drawSlot(slotBg, NORMAL_COLOR, BORDER_COLOR)
+        })
+        slotContainer.on('pointerdown', (e) => {
+          e.stopPropagation()
+          if (this.mode === 'save') {
+            this.onSave?.(i)
+          } else if (slotData) {
+            this.onLoad?.(slotData)
+          }
+          this.hide()
+        })
+      }
+
+      this.addChild(slotContainer)
+    }
+
+    // エクスポート/インポートボタン
+    const buttonY = slotsStartY + 3 * (SLOT_HEIGHT + SLOT_GAP) + 16
+    const buttonTextStyle = new TextStyle({
+      fontFamily: "'Noto Sans JP', sans-serif",
+      fontSize: 16,
+      fill: 0xf1faee,
+      fontWeight: 'bold',
+    })
+
+    // エクスポートボタン
+    const exportBtn = this.createButton('エクスポート', buttonTextStyle, () => {
+      const json = this.saveManager.exportJSON()
+      const blob = new Blob([json], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'name-name-save.json'
+      a.click()
+      URL.revokeObjectURL(url)
+    })
+    exportBtn.x = this.screenWidth / 2 - BUTTON_WIDTH - BUTTON_GAP / 2
+    exportBtn.y = buttonY
+    this.addChild(exportBtn)
+
+    // インポートボタン
+    const importBtn = this.createButton('インポート', buttonTextStyle, () => {
+      const input = document.createElement('input')
+      input.type = 'file'
+      input.accept = '.json'
+      input.onchange = () => {
+        const file = input.files?.[0]
+        if (!file) return
+        const reader = new FileReader()
+        reader.onload = () => {
+          const text = reader.result as string
+          const success = this.saveManager.importJSON(text)
+          if (success) {
+            this.rebuild()
+          } else {
+            console.warn('[name-name] セーブデータのインポートに失敗')
+          }
+        }
+        reader.readAsText(file)
+      }
+      input.click()
+    })
+    importBtn.x = this.screenWidth / 2 + BUTTON_GAP / 2
+    importBtn.y = buttonY
+    this.addChild(importBtn)
+
+    // 閉じるボタン
+    const closeBtn = this.createButton('閉じる', buttonTextStyle, () => {
+      this.hide()
+    })
+    closeBtn.x = (this.screenWidth - BUTTON_WIDTH) / 2
+    closeBtn.y = buttonY + BUTTON_HEIGHT + BUTTON_GAP
+    this.addChild(closeBtn)
+  }
+
+  private createButton(
+    label: string,
+    textStyle: TextStyle,
+    onClick: () => void,
+  ): Container {
+    const container = new Container()
+    container.eventMode = 'static'
+    container.cursor = 'pointer'
+
+    const bg = new Graphics()
+    bg.roundRect(0, 0, BUTTON_WIDTH, BUTTON_HEIGHT, 6)
+    bg.fill(NORMAL_COLOR)
+    bg.stroke({ color: BORDER_COLOR, width: 2 })
+    container.addChild(bg)
+
+    const text = new PixiText({ text: label, style: textStyle })
+    text.x = BUTTON_WIDTH / 2
+    text.y = BUTTON_HEIGHT / 2
+    text.anchor.set(0.5, 0.5)
+    container.addChild(text)
+
+    container.on('pointerover', () => {
+      bg.clear()
+      bg.roundRect(0, 0, BUTTON_WIDTH, BUTTON_HEIGHT, 6)
+      bg.fill(HOVER_COLOR)
+      bg.stroke({ color: HOVER_BORDER_COLOR, width: 2 })
+    })
+    container.on('pointerout', () => {
+      bg.clear()
+      bg.roundRect(0, 0, BUTTON_WIDTH, BUTTON_HEIGHT, 6)
+      bg.fill(NORMAL_COLOR)
+      bg.stroke({ color: BORDER_COLOR, width: 2 })
+    })
+    container.on('pointerdown', (e) => {
+      e.stopPropagation()
+      onClick()
+    })
+
+    return container
+  }
+
+  private drawSlot(g: Graphics, fillColor: number, borderColor: number): void {
+    g.roundRect(0, 0, SLOT_WIDTH, SLOT_HEIGHT, SLOT_RADIUS)
+    g.fill(fillColor)
+    g.stroke({ color: borderColor, width: 2 })
+  }
+}

--- a/frontend/src/game/SaveManager.ts
+++ b/frontend/src/game/SaveManager.ts
@@ -1,0 +1,94 @@
+/**
+ * セーブデータの管理
+ *
+ * localStorage を使い、複数スロット（3つ）のセーブデータを管理する。
+ * JSON エクスポート/インポートによるブラウザ間の持ち運びにも対応。
+ */
+
+import { FlagValue } from '../types'
+
+const SLOT_COUNT = 3
+const STORAGE_PREFIX = 'name-name-save-'
+
+export interface SaveSlotData {
+  slot: number
+  sceneId: string | null
+  eventIndex: number
+  textIndex: number
+  flags: Record<string, FlagValue>
+  backgroundPath: string | null
+  savedAt: string // ISO 8601
+  sceneName: string | null
+}
+
+export class SaveManager {
+  /**
+   * 指定スロットにセーブデータを保存する
+   */
+  save(slot: number, data: SaveSlotData): void {
+    if (slot < 0 || slot >= SLOT_COUNT) return
+    const json = JSON.stringify(data)
+    localStorage.setItem(`${STORAGE_PREFIX}${slot}`, json)
+  }
+
+  /**
+   * 指定スロットからセーブデータを読み込む
+   */
+  load(slot: number): SaveSlotData | null {
+    if (slot < 0 || slot >= SLOT_COUNT) return null
+    const json = localStorage.getItem(`${STORAGE_PREFIX}${slot}`)
+    if (!json) return null
+    try {
+      return JSON.parse(json) as SaveSlotData
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * 全スロットの状態一覧を返す（空スロットは null）
+   */
+  listSlots(): (SaveSlotData | null)[] {
+    const result: (SaveSlotData | null)[] = []
+    for (let i = 0; i < SLOT_COUNT; i++) {
+      result.push(this.load(i))
+    }
+    return result
+  }
+
+  /**
+   * 指定スロットを削除する
+   */
+  deleteSlot(slot: number): void {
+    if (slot < 0 || slot >= SLOT_COUNT) return
+    localStorage.removeItem(`${STORAGE_PREFIX}${slot}`)
+  }
+
+  /**
+   * 全スロットを JSON 文字列でエクスポートする
+   */
+  exportJSON(): string {
+    const data: (SaveSlotData | null)[] = this.listSlots()
+    return JSON.stringify(data, null, 2)
+  }
+
+  /**
+   * JSON 文字列から全スロットを復元する
+   */
+  importJSON(json: string): boolean {
+    try {
+      const data = JSON.parse(json) as (SaveSlotData | null)[]
+      if (!Array.isArray(data)) return false
+      for (let i = 0; i < SLOT_COUNT; i++) {
+        if (i < data.length && data[i] !== null && data[i] !== undefined) {
+          this.save(i, data[i]!)
+        } else {
+          this.deleteSlot(i)
+        }
+      }
+      return true
+    } catch {
+      return false
+    }
+  }
+}

--- a/frontend/src/game/SaveManager.ts
+++ b/frontend/src/game/SaveManager.ts
@@ -77,13 +77,23 @@ export class SaveManager {
    */
   importJSON(json: string): boolean {
     try {
-      const data = JSON.parse(json) as (SaveSlotData | null)[]
+      const data = JSON.parse(json)
       if (!Array.isArray(data)) return false
+      // 各スロットの基本的な形状を検証
       for (let i = 0; i < SLOT_COUNT; i++) {
-        if (i < data.length && data[i] !== null && data[i] !== undefined) {
-          this.save(i, data[i]!)
-        } else {
+        const slot = i < data.length ? data[i] : null
+        if (slot === null || slot === undefined) {
           this.deleteSlot(i)
+        } else if (
+          typeof slot === 'object' &&
+          typeof slot.eventIndex === 'number' &&
+          typeof slot.textIndex === 'number' &&
+          typeof slot.savedAt === 'string' &&
+          typeof slot.flags === 'object'
+        ) {
+          this.save(i, slot as SaveSlotData)
+        } else {
+          return false
         }
       }
       return true


### PR DESCRIPTION
## 関連 Issue
closes #11

## 変更内容

### 新規ファイル
- `frontend/src/game/SaveManager.ts` — localStorage ベースの3スロットセーブ管理。JSON エクスポート/インポート対応
- `frontend/src/game/SaveLoadOverlay.ts` — PixiJS セーブ/ロードメニューUI（3スロット表示、エクスポート/インポートボタン）
- `frontend/src/game/BacklogOverlay.ts` — 過去テキストの全画面スクロール表示

### 変更ファイル
- `frontend/src/game/GameState.ts` — toJSON/fromJSON/getFlags 追加
- `frontend/src/game/NovelRenderer.ts` — セーブ/ロード/バックログ統合、キーボード操作(S/L/B/Escape)追加
- `CLAUDE.md` — 実装状況更新

### 操作方法
- `S` キー: セーブメニュー
- `L` キー: ロードメニュー
- `B` キー: バックログ表示/非表示
- `Escape`: オーバーレイを閉じる
- マウスホイール / 上下キー: バックログスクロール