### PR TITLE
feat: 立ち絵表示 + 表情変更 + 退場 (#18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,7 +373,7 @@ uv sync
 - ⬜ タグ機能（アセット分類）
 - ⬜ フロントエンドでのWASMパーサー統合
 - ⬜ RPGプレイヤーのPixiJS移行（現在はPhaser）
-- ⬜ 立ち絵表示・退場（未Issue化）
+- ✅ 立ち絵表示 + 表情変更 + 退場（#18）— CharacterLayer / 左右中央配置 / ExpressionChange / Exit
 - ✅ 選択肢・分岐 + フラグ・条件分岐（#10）— GameState / ChoiceOverlay / シーンジャンプ
 - ✅ セーブ/ロード + バックログ（#11）— SaveManager / SaveLoadOverlay / BacklogOverlay / localStorage 3スロット / JSON エクスポート・インポート
 

--- a/frontend/src/game/CharacterLayer.ts
+++ b/frontend/src/game/CharacterLayer.ts
@@ -1,0 +1,118 @@
+/**
+ * 立ち絵表示レイヤー
+ *
+ * PixiJS Container 上でキャラクター立ち絵の表示・表情変更・退場を管理する。
+ */
+
+import { Container, Sprite } from 'pixi.js'
+
+const GAME_WIDTH = 800
+const GAME_HEIGHT = 600
+
+/** キャラクターの画面上の配置位置 */
+const POSITION_X: Record<string, number> = {
+  left: 150,
+  center: 400,
+  right: 650,
+}
+
+/** 足元 Y 座標（ダイアログボックス上端あたり） */
+const CHARACTER_Y = 380
+
+interface CharacterState {
+  sprite: Sprite
+  position: string
+  expression: string
+}
+
+export class CharacterLayer extends Container {
+  private characters: Map<string, CharacterState> = new Map()
+
+  /**
+   * キャラクター立ち絵を表示する。既に表示中なら position / expression を更新する。
+   */
+  show(character: string, expression: string, position: string, assetBaseUrl: string): void {
+    const existing = this.characters.get(character)
+
+    if (existing) {
+      // 表情が同じで位置も同じなら何もしない
+      if (existing.expression === expression && existing.position === position) return
+
+      // 位置変更
+      if (existing.position !== position) {
+        const x = POSITION_X[position] ?? POSITION_X['center']
+        existing.sprite.x = x
+        existing.position = position
+      }
+
+      // 表情変更
+      if (existing.expression !== expression) {
+        this.loadTexture(existing.sprite, expression, assetBaseUrl)
+        existing.expression = expression
+      }
+      return
+    }
+
+    // 新規表示
+    const x = POSITION_X[position] ?? POSITION_X['center']
+    const sprite = new Sprite()
+    sprite.anchor.set(0.5, 1)
+    sprite.x = x
+    sprite.y = CHARACTER_Y
+    this.addChild(sprite)
+
+    this.characters.set(character, { sprite, position, expression })
+    this.loadTexture(sprite, expression, assetBaseUrl)
+  }
+
+  /**
+   * 表情のみを差し替える（位置はそのまま）
+   */
+  changeExpression(character: string, expression: string, assetBaseUrl: string): void {
+    const state = this.characters.get(character)
+    if (!state) return
+    if (state.expression === expression) return
+    state.expression = expression
+    this.loadTexture(state.sprite, expression, assetBaseUrl)
+  }
+
+  /**
+   * キャラクターを退場させる
+   */
+  remove(character: string): void {
+    const state = this.characters.get(character)
+    if (!state) return
+    this.removeChild(state.sprite)
+    state.sprite.destroy()
+    this.characters.delete(character)
+  }
+
+  /**
+   * 全キャラクターを削除する
+   */
+  clear(): void {
+    for (const [, state] of this.characters) {
+      this.removeChild(state.sprite)
+      state.sprite.destroy()
+    }
+    this.characters.clear()
+  }
+
+  /**
+   * テクスチャをロードして Sprite に適用する
+   */
+  private loadTexture(sprite: Sprite, expression: string, assetBaseUrl: string): void {
+    if (!assetBaseUrl) return
+
+    const cleanExpression = expression.replace(/^\//, '')
+    const url = `${assetBaseUrl}/images/${cleanExpression}.png`
+
+    const newSprite = Sprite.from(url)
+    newSprite.texture.source.on('loaded', () => {
+      sprite.texture = newSprite.texture
+    })
+    newSprite.texture.source.on('error', () => {
+      console.warn(`[name-name] 立ち絵の読み込みに失敗: ${url}`)
+    })
+  }
+}

--- a/frontend/src/game/CharacterLayer.ts
+++ b/frontend/src/game/CharacterLayer.ts
@@ -4,10 +4,7 @@
  * PixiJS Container 上でキャラクター立ち絵の表示・表情変更・退場を管理する。
  */
 
-import { Container, Sprite } from 'pixi.js'
-
-const GAME_WIDTH = 800
-const GAME_HEIGHT = 600
+import { Container, Sprite, Texture } from 'pixi.js'
 
 /** キャラクターの画面上の配置位置 */
 const POSITION_X: Record<string, number> = {
@@ -107,11 +104,11 @@ export class CharacterLayer extends Container {
     const cleanExpression = expression.replace(/^\//, '')
     const url = `${assetBaseUrl}/images/${cleanExpression}.png`
 
-    const newSprite = Sprite.from(url)
-    newSprite.texture.source.on('loaded', () => {
-      sprite.texture = newSprite.texture
+    const texture = Texture.from(url)
+    texture.source.on('loaded', () => {
+      sprite.texture = texture
     })
-    newSprite.texture.source.on('error', () => {
+    texture.source.on('error', () => {
       console.warn(`[name-name] 立ち絵の読み込みに失敗: ${url}`)
     })
   }

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -692,39 +692,18 @@ export class NovelRenderer {
     this.waitingForChoice = false
     this.choiceOverlay.hide()
     this.audioManager.stopBgm(0)
-    this.clearBackground()
-    this.characterLayer.clear()
-    this.blackoutOverlay.visible = false
     this.events = [...scene.events]
     this.expandedConditions.clear()
     this.displayEventCount = this.events.filter((e) => getTextEvent(e) !== null).length
 
     // eventIndex まで演出イベントを再実行して状態を再構築
-    // Flag/Condition/Choice はスキップし、演出（Background/Blackout/BGM/立ち絵等）のみ再構築
-    // Condition の展開は通常の進行に任せる
-    let lastBgmEvent: Event | null = null
-    for (let i = 0; i < data.eventIndex && i < this.events.length; i++) {
-      const ev = this.events[i]
-      const textEvt = getTextEvent(ev)
-      if (textEvt) {
-        // Dialog の立ち絵情報をリプレイする
-        this.showCharacterFromDialog(ev)
-        continue
-      }
-      if (typeof ev === 'object' && ev !== null) {
-        if ('Bgm' in ev) {
-          lastBgmEvent = ev
-        } else if ('Flag' in ev || 'Condition' in ev || 'Choice' in ev) {
-          // スキップ（フラグは fromJSON で復元済み、Condition/Choice は副作用防止）
-        } else {
-          this.processDirective(ev)
-        }
-      } else if (typeof ev === 'string') {
-        this.processDirective(ev)
-      }
-    }
-    if (lastBgmEvent) {
-      this.processDirective(lastBgmEvent)
+    const targetIndex = Math.min(data.eventIndex - 1, this.events.length - 1)
+    if (targetIndex >= 0) {
+      this.replayDirectivesUpTo(targetIndex)
+    } else {
+      this.clearBackground()
+      this.characterLayer.clear()
+      this.blackoutOverlay.visible = false
     }
 
     this.eventIndex = data.eventIndex

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -12,6 +12,7 @@
  */
 
 import { Application, Container, Graphics, Sprite, Text as PixiText, TextStyle } from 'pixi.js'
+import { CharacterLayer } from './CharacterLayer'
 import { DialogBox } from './DialogBox'
 import { AudioManager } from './AudioManager'
 import { GameState } from './GameState'
@@ -28,12 +29,18 @@ const GAME_HEIGHT = 600
 function getTextEvent(
   event: Event
 ):
-  | { type: 'dialog'; character: string | null; text: string[] }
+  | { type: 'dialog'; character: string | null; expression: string | null; position: string | null; text: string[] }
   | { type: 'narration'; text: string[] }
   | null {
   if (typeof event === 'object' && event !== null) {
     if ('Dialog' in event) {
-      return { type: 'dialog', character: event.Dialog.character, text: event.Dialog.text }
+      return {
+        type: 'dialog',
+        character: event.Dialog.character,
+        expression: event.Dialog.expression,
+        position: event.Dialog.position,
+        text: event.Dialog.text,
+      }
     }
     if ('Narration' in event) {
       return { type: 'narration', text: event.Narration.text }
@@ -47,6 +54,7 @@ export class NovelRenderer {
   private dialogBox: DialogBox
   private bgGraphics: Graphics
   private bgContainer: Container
+  private characterLayer: CharacterLayer
   private blackoutOverlay: Graphics
   private counterText: PixiText | null = null
   private displayEventCount = 0
@@ -95,6 +103,7 @@ export class NovelRenderer {
     this.app = new Application()
     this.bgGraphics = new Graphics()
     this.bgContainer = new Container()
+    this.characterLayer = new CharacterLayer()
     this.blackoutOverlay = new Graphics()
     this.dialogBox = new DialogBox({
       screenWidth: GAME_WIDTH,
@@ -126,6 +135,9 @@ export class NovelRenderer {
 
     // 背景画像コンテナ
     this.app.stage.addChild(this.bgContainer)
+
+    // 立ち絵レイヤー
+    this.app.stage.addChild(this.characterLayer)
 
     // 暗転レイヤー
     this.blackoutOverlay.rect(0, 0, GAME_WIDTH, GAME_HEIGHT)
@@ -212,6 +224,7 @@ export class NovelRenderer {
     this.choiceOverlay.hide()
     this.audioManager.stopBgm(0)
     this.clearBackground()
+    this.characterLayer.clear()
     this.blackoutOverlay.visible = false
     this.events = events
     this.eventIndex = 0
@@ -219,6 +232,10 @@ export class NovelRenderer {
     this.expandedConditions.clear()
     this.displayEventCount = this.events.filter((e) => getTextEvent(e) !== null).length
     this.processUntilNextTextEvent()
+    // 最初のテキストイベントに立ち絵情報があれば表示
+    if (this.eventIndex < this.events.length) {
+      this.showCharacterFromDialog(this.events[this.eventIndex])
+    }
     this.render()
   }
 
@@ -244,6 +261,7 @@ export class NovelRenderer {
     this.app.canvas.removeEventListener('wheel', this.handleWheel)
     window.removeEventListener('keydown', this.handleKeyDown)
     this.audioManager.destroy()
+    this.characterLayer.clear()
     this.choiceOverlay.hide()
     this.saveLoadOverlay.hide()
     this.backlogOverlay.hide()
@@ -381,6 +399,10 @@ export class NovelRenderer {
     }
 
     this.processUntilNextTextEvent()
+    // テキストイベントに立ち絵情報があれば表示
+    if (this.eventIndex < this.events.length) {
+      this.showCharacterFromDialog(this.events[this.eventIndex])
+    }
     this.render()
   }
 
@@ -503,7 +525,29 @@ export class NovelRenderer {
       })
       return
     }
-    // Exit, Wait, ExpressionChange 等は別Issue — スキップ
+    if ('ExpressionChange' in event) {
+      this.characterLayer.changeExpression(
+        event.ExpressionChange.character,
+        event.ExpressionChange.expression,
+        this.assetBaseUrl
+      )
+      return
+    }
+    if ('Exit' in event) {
+      this.characterLayer.remove(event.Exit.character)
+      return
+    }
+    // Wait 等は別Issue — スキップ
+  }
+
+  /**
+   * Dialog イベントに立ち絵情報（expression + position）があれば表示する
+   */
+  private showCharacterFromDialog(event: Event): void {
+    const textEvt = getTextEvent(event)
+    if (!textEvt || textEvt.type !== 'dialog') return
+    if (!textEvt.expression || !textEvt.position || !textEvt.character) return
+    this.characterLayer.show(textEvt.character, textEvt.expression, textEvt.position, this.assetBaseUrl)
   }
 
   /**
@@ -563,6 +607,7 @@ export class NovelRenderer {
    */
   private replayDirectivesUpTo(targetIndex: number): void {
     this.clearBackground()
+    this.characterLayer.clear()
     this.blackoutOverlay.visible = false
     this.audioManager.stopBgm(0)
 
@@ -570,7 +615,13 @@ export class NovelRenderer {
     let lastBgmEvent: Event | null = null
     for (let i = 0; i <= targetIndex; i++) {
       const ev = this.events[i]
-      if (!getTextEvent(ev) && typeof ev === 'object' && ev !== null) {
+      // Dialog の立ち絵情報もリプレイする
+      const textEvt = getTextEvent(ev)
+      if (textEvt) {
+        this.showCharacterFromDialog(ev)
+        continue
+      }
+      if (typeof ev === 'object' && ev !== null) {
         if ('Bgm' in ev) {
           lastBgmEvent = ev
         } else if ('Flag' in ev || 'Condition' in ev || 'Choice' in ev) {
@@ -642,29 +693,34 @@ export class NovelRenderer {
     this.choiceOverlay.hide()
     this.audioManager.stopBgm(0)
     this.clearBackground()
+    this.characterLayer.clear()
     this.blackoutOverlay.visible = false
     this.events = [...scene.events]
     this.expandedConditions.clear()
     this.displayEventCount = this.events.filter((e) => getTextEvent(e) !== null).length
 
     // eventIndex まで演出イベントを再実行して状態を再構築
-    // Flag/Condition/Choice はスキップし、演出（Background/Blackout/BGM等）のみ再構築
+    // Flag/Condition/Choice はスキップし、演出（Background/Blackout/BGM/立ち絵等）のみ再構築
     // Condition の展開は通常の進行に任せる
     let lastBgmEvent: Event | null = null
     for (let i = 0; i < data.eventIndex && i < this.events.length; i++) {
       const ev = this.events[i]
-      if (!getTextEvent(ev)) {
-        if (typeof ev === 'object' && ev !== null) {
-          if ('Bgm' in ev) {
-            lastBgmEvent = ev
-          } else if ('Flag' in ev || 'Condition' in ev || 'Choice' in ev) {
-            // スキップ（フラグは fromJSON で復元済み、Condition/Choice は副作用防止）
-          } else {
-            this.processDirective(ev)
-          }
-        } else if (typeof ev === 'string') {
+      const textEvt = getTextEvent(ev)
+      if (textEvt) {
+        // Dialog の立ち絵情報をリプレイする
+        this.showCharacterFromDialog(ev)
+        continue
+      }
+      if (typeof ev === 'object' && ev !== null) {
+        if ('Bgm' in ev) {
+          lastBgmEvent = ev
+        } else if ('Flag' in ev || 'Condition' in ev || 'Choice' in ev) {
+          // スキップ（フラグは fromJSON で復元済み、Condition/Choice は副作用防止）
+        } else {
           this.processDirective(ev)
         }
+      } else if (typeof ev === 'string') {
+        this.processDirective(ev)
       }
     }
     if (lastBgmEvent) {


### PR DESCRIPTION
## 関連 Issue
closes #18

## 変更内容

### 新規ファイル
- `frontend/src/game/CharacterLayer.ts` — PixiJS Container で立ち絵の表示・管理。左/右/中央配置、表情差し替え、退場

### 変更ファイル
- `frontend/src/game/NovelRenderer.ts` — CharacterLayer 統合。Dialog の立ち絵表示、ExpressionChange/Exit 処理、replayDirectivesUpTo/loadFromSaveData での立ち絵リプレイ
- `CLAUDE.md` — 実装状況更新

### 実装詳細
- Dialog に expression+position+character が揃っている場合のみ立ち絵を表示
- ExpressionChange でテクスチャ差し替え、Exit で Sprite 削除
- 戻る操作/セーブロード時に立ち絵状態を正しく再構築
- Z順序: bgContainer → characterLayer → blackoutOverlay