### PR TITLE
refactor: スナップショット方式による状態管理・シークバーUI・API公開

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,7 +363,11 @@ uv sync
 - ✅ Event型モデルでの描画（旧ScriptRowから移行完了）
 - ✅ 背景画像表示（アスペクト比維持カバー）+ 暗転/暗転解除 + 場面転換
 - ✅ 演出イベントの即時実行（Background/Blackout/SceneTransition）
-- ✅ 戻る操作時の演出状態リプレイ
+- ✅ スナップショット方式の状態管理（NovelGameState + 履歴スタック）
+- ✅ 宣言的復元（applyState）— 巻き戻し・シーク・ロードで先頭リプレイ不要
+- ✅ Condition 不変展開（resolveEvents — events 配列の splice 廃止）
+- ✅ シークバーUI（プログレスバー + クリックジャンプ）
+- ✅ advance/goBack/getSnapshot/seekTo の public API
 - ✅ BGM ループ再生・フェードアウト停止・切り替え（Web Audio API）
 - ✅ SE ワンショット再生・複数同時再生（Web Audio API）
 - ✅ AudioBuffer キャッシュ・ユーザーインタラクション制約対応
@@ -376,6 +380,7 @@ uv sync
 - ✅ 立ち絵表示 + 表情変更 + 退場（#18）— CharacterLayer / 左右中央配置 / ExpressionChange / Exit
 - ✅ 選択肢・分岐 + フラグ・条件分岐（#10）— GameState / ChoiceOverlay / シーンジャンプ
 - ✅ セーブ/ロード + バックログ（#11）— SaveManager / SaveLoadOverlay / BacklogOverlay / localStorage 3スロット / JSON エクスポート・インポート
+- ✅ スナップショット方式リファクタリング（#26）— NovelGameState / resolveEvents / SeekBar / applyState 宣言的復元 / SaveSlotData 拡張
 
 ## 参考ドキュメント
 

--- a/frontend/src/game/CharacterLayer.ts
+++ b/frontend/src/game/CharacterLayer.ts
@@ -85,6 +85,17 @@ export class CharacterLayer extends Container {
   }
 
   /**
+   * 現在表示中のキャラクター情報を返す（スナップショット用）
+   */
+  getCharacterStates(): Array<{ name: string; expression: string; position: string }> {
+    const result: Array<{ name: string; expression: string; position: string }> = []
+    for (const [name, state] of this.characters) {
+      result.push({ name, expression: state.expression, position: state.position })
+    }
+    return result
+  }
+
+  /**
    * 全キャラクターを削除する
    */
   clear(): void {

--- a/frontend/src/game/GameState.ts
+++ b/frontend/src/game/GameState.ts
@@ -5,7 +5,48 @@
  * NovelRenderer.setEvents() でリセットされない。
  */
 
-import { FlagValue } from '../types'
+import { Event, FlagValue } from '../types'
+
+/**
+ * ノベルゲームの全状態を表すスナップショット
+ *
+ * advance/goBack/seekTo/save/load の際にこのインターフェースで状態を取り回す。
+ */
+export interface NovelGameState {
+  sceneId: string | null
+  eventIndex: number
+  textIndex: number
+  flags: Record<string, FlagValue>
+  backgroundPath: string | null
+  isBlackout: boolean
+  characters: Array<{ name: string; expression: string; position: string }>
+  currentBgmPath: string | null
+}
+
+/**
+ * Condition イベントをフラグに基づいて展開し、フラットなイベント配列を返す。
+ *
+ * - Condition が真 → 内部 events を再帰的に展開して挿入（Condition 自体は除去）
+ * - Condition が偽 → スキップ
+ * - Flag / その他のイベントはそのまま残す
+ *
+ * 元の events 配列は変更しない（不変）。
+ */
+export function resolveEvents(events: readonly Event[], gameState: GameState): Event[] {
+  const result: Event[] = []
+  for (const event of events) {
+    if (typeof event === 'object' && event !== null && 'Condition' in event) {
+      if (gameState.checkFlag(event.Condition.flag)) {
+        // 条件が真 → 内部 events を再帰的に展開
+        result.push(...resolveEvents(event.Condition.events, gameState))
+      }
+      // 偽ならスキップ
+    } else {
+      result.push(event)
+    }
+  }
+  return result
+}
 
 export class GameState {
   private flags: Map<string, FlagValue> = new Map()
@@ -71,5 +112,4 @@ export class GameState {
       this.flags.set(key, value)
     }
   }
-
 }

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -15,21 +15,26 @@ import { Application, Container, Graphics, Sprite, Text as PixiText, TextStyle }
 import { CharacterLayer } from './CharacterLayer'
 import { DialogBox } from './DialogBox'
 import { AudioManager } from './AudioManager'
-import { GameState } from './GameState'
+import { GameState, NovelGameState, resolveEvents } from './GameState'
 import { ChoiceOverlay } from './ChoiceOverlay'
 import { SaveManager, SaveSlotData } from './SaveManager'
 import { SaveLoadOverlay } from './SaveLoadOverlay'
 import { BacklogOverlay } from './BacklogOverlay'
+import { SeekBar } from './SeekBar'
 import { Event, EventScene } from '../types'
 
 const GAME_WIDTH = 800
 const GAME_HEIGHT = 600
 
 /** Dialog / Narration から text を取り出すヘルパー */
-function getTextEvent(
-  event: Event
-):
-  | { type: 'dialog'; character: string | null; expression: string | null; position: string | null; text: string[] }
+function getTextEvent(event: Event):
+  | {
+      type: 'dialog'
+      character: string | null
+      expression: string | null
+      position: string | null
+      text: string[]
+    }
   | { type: 'narration'; text: string[] }
   | null {
   if (typeof event === 'object' && event !== null) {
@@ -59,9 +64,13 @@ export class NovelRenderer {
   private counterText: PixiText | null = null
   private displayEventCount = 0
 
-  private events: Event[] = []
+  /** Condition 展開済みのフラットなイベント配列（元の events は保持しない） */
+  private resolvedEvents: Event[] = []
   private eventIndex = 0
   private textIndex = 0
+
+  /** スナップショット履歴スタック（テキストイベント到達ごとに push） */
+  private history: NovelGameState[] = []
 
   private initialized = false
   private onEndCallback: (() => void) | null = null
@@ -87,9 +96,6 @@ export class NovelRenderer {
   /** 全シーン情報（シーンジャンプ用） */
   private allScenes: EventScene[] = []
 
-  /** 展開済み Condition イベントのインデックス（重複展開防止） */
-  private expandedConditions: Set<number> = new Set()
-
   /** セーブマネージャー */
   private saveManager: SaveManager = new SaveManager()
 
@@ -99,11 +105,17 @@ export class NovelRenderer {
   /** バックログオーバーレイ */
   private backlogOverlay!: BacklogOverlay
 
+  /** シークバー */
+  private seekBar: SeekBar
+
   /** 現在のシーンID */
   private currentSceneId: string | null = null
 
   /** 現在の背景パス */
   private currentBackgroundPath: string | null = null
+
+  /** 現在の BGM パス（スナップショット用） */
+  private currentBgmPath: string | null = null
 
   constructor() {
     this.app = new Application()
@@ -119,6 +131,7 @@ export class NovelRenderer {
     this.choiceOverlay = new ChoiceOverlay(GAME_WIDTH, GAME_HEIGHT)
     this.saveLoadOverlay = new SaveLoadOverlay(GAME_WIDTH, GAME_HEIGHT, this.saveManager)
     this.backlogOverlay = new BacklogOverlay(GAME_WIDTH, GAME_HEIGHT)
+    this.seekBar = new SeekBar()
   }
 
   /**
@@ -153,6 +166,10 @@ export class NovelRenderer {
 
     // ダイアログボックス
     this.app.stage.addChild(this.dialogBox)
+
+    // シークバー（ダイアログボックスの下）
+    this.seekBar.setOnSeek((index) => this.seekTo(index))
+    this.app.stage.addChild(this.seekBar)
 
     // シーンカウンター
     const counterStyle = new TextStyle({
@@ -237,16 +254,24 @@ export class NovelRenderer {
     this.clearBackground()
     this.characterLayer.clear()
     this.blackoutOverlay.visible = false
-    this.events = events
+    this.currentBgmPath = null
+
+    // Condition をフラグに基づいて展開（元の events は変更しない）
+    this.resolvedEvents = resolveEvents(events, this.gameState)
     this.eventIndex = 0
     this.textIndex = 0
-    this.expandedConditions.clear()
-    this.displayEventCount = this.events.filter((e) => getTextEvent(e) !== null).length
+    this.history = []
+    this.displayEventCount = this.resolvedEvents.filter((e) => getTextEvent(e) !== null).length
     this.processUntilNextTextEvent()
+
     // 最初のテキストイベントに立ち絵情報があれば表示
-    if (this.eventIndex < this.events.length) {
-      this.showCharacterFromDialog(this.events[this.eventIndex])
+    if (this.eventIndex < this.resolvedEvents.length) {
+      this.showCharacterFromDialog(this.resolvedEvents[this.eventIndex])
     }
+
+    // 最初のテキストイベントのスナップショットを記録
+    this.pushSnapshot()
+
     this.render()
   }
 
@@ -285,7 +310,158 @@ export class NovelRenderer {
     this.initialized = false
   }
 
+  /**
+   * 現在のゲーム状態のスナップショットを返す
+   */
+  getSnapshot(): NovelGameState {
+    return {
+      sceneId: this.currentSceneId,
+      eventIndex: this.eventIndex,
+      textIndex: this.textIndex,
+      flags: this.gameState.toJSON(),
+      backgroundPath: this.currentBackgroundPath,
+      isBlackout: this.blackoutOverlay.visible,
+      characters: this.characterLayer.getCharacterStates(),
+      currentBgmPath: this.currentBgmPath,
+    }
+  }
+
+  /**
+   * 次のテキスト / 次のイベントへ進む
+   */
+  advance(): void {
+    if (this.resolvedEvents.length === 0) return
+    if (this.waitingForChoice || this.waitingForWait) return
+
+    const current = this.resolvedEvents[this.eventIndex]
+    const textEvt = getTextEvent(current)
+
+    if (textEvt) {
+      // 現在表示中のテキストをバックログに記録
+      const currentLine = textEvt.text[this.textIndex] ?? ''
+      const character = textEvt.type === 'dialog' ? textEvt.character : null
+      this.backlogOverlay.addEntry(character, currentLine)
+
+      this.textIndex++
+      if (this.textIndex < textEvt.text.length) {
+        // まだテキスト行が残っている
+        this.render()
+        return
+      }
+    }
+
+    // 次のイベントへ
+    this.eventIndex++
+    this.textIndex = 0
+
+    if (this.eventIndex >= this.resolvedEvents.length) {
+      // 全イベント完了
+      this.dialogBox.setDialog(null, '')
+      this.dialogBox.setIndicatorVisible(false)
+      this.updateCounter()
+      this.onEndCallback?.()
+      return
+    }
+
+    this.processUntilNextTextEvent()
+    // テキストイベントに立ち絵情報があれば表示
+    if (this.eventIndex < this.resolvedEvents.length) {
+      this.showCharacterFromDialog(this.resolvedEvents[this.eventIndex])
+    }
+
+    // スナップショットを記録
+    this.pushSnapshot()
+
+    this.render()
+  }
+
+  /**
+   * 1つ前の表示イベントに戻る（スナップショットベースの宣言的復元）
+   */
+  goBack(): void {
+    if (this.resolvedEvents.length === 0) return
+    if (this.waitingForChoice || this.waitingForWait) return
+
+    const current = this.resolvedEvents[this.eventIndex]
+    const textEvt = getTextEvent(current)
+
+    if (textEvt && this.textIndex > 0) {
+      this.textIndex--
+      this.render()
+      return
+    }
+
+    // 前のスナップショットへ（現在の分を pop して、その前に戻る）
+    if (this.history.length > 1) {
+      this.history.pop()
+      const prevState = this.history[this.history.length - 1]
+      this.applyState(prevState)
+      this.render()
+    }
+  }
+
+  /**
+   * 履歴の任意位置にジャンプする（シークバーから呼ばれる）
+   */
+  seekTo(historyIndex: number): void {
+    if (historyIndex < 0 || historyIndex >= this.history.length) return
+    if (this.waitingForChoice || this.waitingForWait) return
+
+    // 履歴を指定位置まで切り詰める
+    this.history = this.history.slice(0, historyIndex + 1)
+    const targetState = this.history[historyIndex]
+    this.applyState(targetState)
+    this.render()
+  }
+
   // --- private ---
+
+  /**
+   * スナップショットを履歴に push する
+   */
+  private pushSnapshot(): void {
+    if (
+      this.eventIndex < this.resolvedEvents.length &&
+      getTextEvent(this.resolvedEvents[this.eventIndex])
+    ) {
+      this.history.push(this.getSnapshot())
+    }
+  }
+
+  /**
+   * スナップショットから状態を宣言的に復元する
+   */
+  private applyState(state: NovelGameState): void {
+    // インデックス復元
+    this.eventIndex = state.eventIndex
+    this.textIndex = state.textIndex
+
+    // 背景復元
+    if (state.backgroundPath) {
+      this.setBackground(state.backgroundPath)
+    } else {
+      this.clearBackground()
+    }
+
+    // 暗転復元
+    this.blackoutOverlay.visible = state.isBlackout
+
+    // 立ち絵復元
+    this.characterLayer.clear()
+    for (const ch of state.characters) {
+      this.characterLayer.show(ch.name, ch.expression, ch.position, this.assetBaseUrl)
+    }
+
+    // BGM復元
+    if (state.currentBgmPath) {
+      const soundUrl = `${this.assetBaseUrl}/sounds/${state.currentBgmPath.replace(/^\//, '')}`
+      this.audioManager.playBgm(soundUrl)
+      this.currentBgmPath = state.currentBgmPath
+    } else {
+      this.audioManager.stopBgm(0)
+      this.currentBgmPath = null
+    }
+  }
 
   private handleAdvance = (): void => {
     this.audioManager.ensureContext()
@@ -377,106 +553,12 @@ export class NovelRenderer {
   }
 
   /**
-   * 次のテキスト / 次のイベントへ進む
-   */
-  private advance(): void {
-    if (this.events.length === 0) return
-    if (this.waitingForChoice || this.waitingForWait) return
-
-    const current = this.events[this.eventIndex]
-    const textEvt = getTextEvent(current)
-
-    if (textEvt) {
-      // 現在表示中のテキストをバックログに記録
-      const currentLine = textEvt.text[this.textIndex] ?? ''
-      const character = textEvt.type === 'dialog' ? textEvt.character : null
-      this.backlogOverlay.addEntry(character, currentLine)
-
-      this.textIndex++
-      if (this.textIndex < textEvt.text.length) {
-        // まだテキスト行が残っている
-        this.render()
-        return
-      }
-    }
-
-    // 次のイベントへ
-    this.eventIndex++
-    this.textIndex = 0
-
-    if (this.eventIndex >= this.events.length) {
-      // 全イベント完了
-      this.dialogBox.setDialog(null, '')
-      this.dialogBox.setIndicatorVisible(false)
-      this.updateCounter()
-      this.onEndCallback?.()
-      return
-    }
-
-    this.processUntilNextTextEvent()
-    // テキストイベントに立ち絵情報があれば表示
-    if (this.eventIndex < this.events.length) {
-      this.showCharacterFromDialog(this.events[this.eventIndex])
-    }
-    this.render()
-  }
-
-  /**
-   * 1つ前の表示イベントに戻る
-   */
-  private goBack(): void {
-    if (this.events.length === 0) return
-    if (this.waitingForChoice || this.waitingForWait) return
-
-    const current = this.events[this.eventIndex]
-    const textEvt = getTextEvent(current)
-
-    if (textEvt && this.textIndex > 0) {
-      this.textIndex--
-      this.render()
-      return
-    }
-
-    // 前のイベントへ
-    if (this.eventIndex > 0) {
-      const oldEventIndex = this.eventIndex
-      const oldTextIndex = this.textIndex
-
-      this.eventIndex--
-      this.textIndex = 0
-
-      // 前の表示イベントを探す
-      while (this.eventIndex > 0 && !getTextEvent(this.events[this.eventIndex])) {
-        this.eventIndex--
-      }
-
-      if (!getTextEvent(this.events[this.eventIndex])) {
-        // テキストイベントが見つからなかった — 何もしない
-        this.eventIndex = oldEventIndex
-        this.textIndex = oldTextIndex
-        return
-      }
-
-      const prevEvt = getTextEvent(this.events[this.eventIndex])
-      if (prevEvt) {
-        // 最後のテキスト行を表示
-        this.textIndex = prevEvt.text.length - 1
-      }
-
-      // 演出状態を先頭から再構築
-      this.replayDirectivesUpTo(this.eventIndex)
-
-      this.render()
-    }
-  }
-
-  /**
    * 非テキストイベントを実行しながら次のテキストイベントまで進む
    */
   private processUntilNextTextEvent(): void {
-    while (this.eventIndex < this.events.length) {
-      if (getTextEvent(this.events[this.eventIndex])) break
-      this.processDirective(this.events[this.eventIndex])
+    while (this.eventIndex < this.resolvedEvents.length) {
+      if (getTextEvent(this.resolvedEvents[this.eventIndex])) break
+      this.processDirective(this.resolvedEvents[this.eventIndex])
       // Choice / Wait は進行を止める
       if (this.waitingForChoice || this.waitingForWait) break
       this.eventIndex++
@@ -485,6 +567,8 @@ export class NovelRenderer {
 
   /**
    * 演出イベント（Background, Blackout, SceneTransition）を実行する
+   *
+   * Condition は resolvedEvents では既に展開済みなので、ここでは処理しない。
    */
   private processDirective(event: Event): void {
     if (typeof event === 'string') {
@@ -506,8 +590,10 @@ export class NovelRenderer {
       if (event.Bgm.action === 'Play' && event.Bgm.path) {
         const soundUrl = `${this.assetBaseUrl}/sounds/${event.Bgm.path.replace(/^\//, '')}`
         this.audioManager.playBgm(soundUrl)
+        this.currentBgmPath = event.Bgm.path
       } else {
         this.audioManager.stopBgm()
+        this.currentBgmPath = null
       }
       return
     }
@@ -518,17 +604,10 @@ export class NovelRenderer {
     }
     if ('Flag' in event) {
       this.gameState.setFlag(event.Flag.name, event.Flag.value)
-      return
-    }
-    if ('Condition' in event) {
-      if (!this.expandedConditions.has(this.eventIndex) && this.gameState.checkFlag(event.Condition.flag)) {
-        // 条件が真 → 内部 events を現在位置に挿入（flatten）、重複展開を防止
-        this.expandedConditions.add(this.eventIndex)
-        const innerEvents = event.Condition.events
-        this.events.splice(this.eventIndex + 1, 0, ...innerEvents)
-        // displayEventCount を再計算
-        this.displayEventCount = this.events.filter((e) => getTextEvent(e) !== null).length
-      }
+      // フラグ変更により Condition の評価結果が変わる可能性があるが、
+      // resolvedEvents は setEvents/jumpToScene 時に計算済み。
+      // Flag が resolvedEvents 内に残っているので、ここで再展開は不要。
+      // もし動的に再展開が必要な場合は、ここに再計算ロジックを入れる。
       return
     }
     if ('Choice' in event) {
@@ -561,9 +640,10 @@ export class NovelRenderer {
         this.waitingForWait = false
         this.eventIndex++
         this.processUntilNextTextEvent()
-        if (this.eventIndex < this.events.length) {
-          this.showCharacterFromDialog(this.events[this.eventIndex])
+        if (this.eventIndex < this.resolvedEvents.length) {
+          this.showCharacterFromDialog(this.resolvedEvents[this.eventIndex])
         }
+        this.pushSnapshot()
         this.render()
       }, event.Wait.ms)
       return
@@ -577,7 +657,12 @@ export class NovelRenderer {
     const textEvt = getTextEvent(event)
     if (!textEvt || textEvt.type !== 'dialog') return
     if (!textEvt.expression || !textEvt.position || !textEvt.character) return
-    this.characterLayer.show(textEvt.character, textEvt.expression, textEvt.position, this.assetBaseUrl)
+    this.characterLayer.show(
+      textEvt.character,
+      textEvt.expression,
+      textEvt.position,
+      this.assetBaseUrl
+    )
   }
 
   /**
@@ -633,57 +718,25 @@ export class NovelRenderer {
   }
 
   /**
-   * 先頭から targetIndex まで演出イベントを再実行して状態を再構築する
-   */
-  private replayDirectivesUpTo(targetIndex: number): void {
-    this.clearBackground()
-    this.characterLayer.clear()
-    this.blackoutOverlay.visible = false
-    this.audioManager.stopBgm(0)
-
-    // 最後の BGM イベントを見つけて再生する（SE/Flag/Condition/Choice はリプレイしない）
-    let lastBgmEvent: Event | null = null
-    for (let i = 0; i <= targetIndex; i++) {
-      const ev = this.events[i]
-      // Dialog の立ち絵情報もリプレイする
-      const textEvt = getTextEvent(ev)
-      if (textEvt) {
-        this.showCharacterFromDialog(ev)
-        continue
-      }
-      if (typeof ev === 'object' && ev !== null) {
-        if ('Bgm' in ev) {
-          lastBgmEvent = ev
-        } else if ('Flag' in ev || 'Condition' in ev || 'Choice' in ev || 'Wait' in ev) {
-          // リプレイ時にはスキップ（副作用の重複を防ぐ）
-        } else {
-          this.processDirective(ev)
-        }
-      } else if (typeof ev === 'string') {
-        this.processDirective(ev)
-      }
-    }
-    if (lastBgmEvent) {
-      this.processDirective(lastBgmEvent)
-    }
-  }
-
-  /**
    * セーブメニューを表示する
    */
   private openSaveMenu(): void {
     this.saveLoadOverlay.showSave((slot: number) => {
       const sceneName = this.currentSceneId
-        ? this.allScenes.find((s) => s.id === this.currentSceneId)?.title ?? null
+        ? (this.allScenes.find((s) => s.id === this.currentSceneId)?.title ?? null)
         : null
 
+      const snapshot = this.getSnapshot()
       const data: SaveSlotData = {
         slot,
-        sceneId: this.currentSceneId,
-        eventIndex: this.eventIndex,
-        textIndex: this.textIndex,
-        flags: this.gameState.toJSON(),
-        backgroundPath: this.currentBackgroundPath,
+        sceneId: snapshot.sceneId,
+        eventIndex: snapshot.eventIndex,
+        textIndex: snapshot.textIndex,
+        flags: snapshot.flags,
+        backgroundPath: snapshot.backgroundPath,
+        isBlackout: snapshot.isBlackout,
+        characters: snapshot.characters,
+        currentBgmPath: snapshot.currentBgmPath,
         savedAt: new Date().toISOString(),
         sceneName,
       }
@@ -701,7 +754,7 @@ export class NovelRenderer {
   }
 
   /**
-   * セーブデータからゲーム状態を復元する
+   * セーブデータからゲーム状態を復元する（applyState ベースの宣言的復元）
    */
   private loadFromSaveData(data: SaveSlotData): void {
     // フラグを復元
@@ -720,24 +773,33 @@ export class NovelRenderer {
 
     // 選択肢状態をリセット
     this.waitingForChoice = false
-    this.choiceOverlay.hide()
-    this.audioManager.stopBgm(0)
-    this.events = [...scene.events]
-    this.expandedConditions.clear()
-    this.displayEventCount = this.events.filter((e) => getTextEvent(e) !== null).length
-
-    // eventIndex まで演出イベントを再実行して状態を再構築
-    const targetIndex = Math.min(data.eventIndex - 1, this.events.length - 1)
-    if (targetIndex >= 0) {
-      this.replayDirectivesUpTo(targetIndex)
-    } else {
-      this.clearBackground()
-      this.characterLayer.clear()
-      this.blackoutOverlay.visible = false
+    this.waitingForWait = false
+    if (this.waitTimer) {
+      clearTimeout(this.waitTimer)
+      this.waitTimer = null
     }
+    this.choiceOverlay.hide()
 
-    this.eventIndex = data.eventIndex
-    this.textIndex = data.textIndex
+    // Condition をフラグに基づいて展開
+    this.resolvedEvents = resolveEvents([...scene.events], this.gameState)
+    this.displayEventCount = this.resolvedEvents.filter((e) => getTextEvent(e) !== null).length
+
+    // NovelGameState を構築して applyState で宣言的に復元
+    const state: NovelGameState = {
+      sceneId: data.sceneId,
+      eventIndex: data.eventIndex,
+      textIndex: data.textIndex,
+      flags: data.flags,
+      backgroundPath: data.backgroundPath,
+      isBlackout: data.isBlackout ?? false,
+      characters: data.characters ?? [],
+      currentBgmPath: data.currentBgmPath ?? null,
+    }
+    this.applyState(state)
+
+    // 履歴をリセット（ロード後は現在位置のみ）
+    this.history = [this.getSnapshot()]
+
     this.render()
   }
 
@@ -746,9 +808,9 @@ export class NovelRenderer {
    */
   private render(): void {
     if (!this.initialized) return
-    if (this.eventIndex >= this.events.length) return
+    if (this.eventIndex >= this.resolvedEvents.length) return
 
-    const current = this.events[this.eventIndex]
+    const current = this.resolvedEvents[this.eventIndex]
     const textEvt = getTextEvent(current)
 
     if (!textEvt) {
@@ -764,10 +826,11 @@ export class NovelRenderer {
 
     // 最後のテキスト行かつ最後のイベントならインジケーター非表示
     const isLastText = this.textIndex >= textEvt.text.length - 1
-    const isLastEvent = this.eventIndex >= this.events.length - 1
+    const isLastEvent = this.eventIndex >= this.resolvedEvents.length - 1
     this.dialogBox.setIndicatorVisible(!(isLastText && isLastEvent))
 
     this.updateCounter()
+    this.updateSeekBar()
   }
 
   private updateCounter(): void {
@@ -775,12 +838,25 @@ export class NovelRenderer {
     const total = this.displayEventCount
     // 表示イベントの中での現在位置を計算
     let displayIndex = 0
-    for (let i = 0; i < this.eventIndex && i < this.events.length; i++) {
-      if (getTextEvent(this.events[i])) displayIndex++
+    for (let i = 0; i < this.eventIndex && i < this.resolvedEvents.length; i++) {
+      if (getTextEvent(this.resolvedEvents[i])) displayIndex++
     }
-    if (this.eventIndex < this.events.length && getTextEvent(this.events[this.eventIndex])) {
+    if (
+      this.eventIndex < this.resolvedEvents.length &&
+      getTextEvent(this.resolvedEvents[this.eventIndex])
+    ) {
       displayIndex++
     }
     this.counterText.text = `${displayIndex} / ${total}`
+  }
+
+  /**
+   * シークバーの表示を更新する
+   */
+  private updateSeekBar(): void {
+    // history.length - 1 が現在のインデックス（0-based）
+    const current = Math.max(0, this.history.length - 1)
+    const total = this.history.length
+    this.seekBar.update(current, total)
   }
 }

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -472,7 +472,6 @@ export class NovelRenderer {
    * Flag イベント処理後に呼ばれ、後続の Condition が新しいフラグ値で評価される。
    */
   private reResolveEvents(): void {
-    const oldResolved = this.resolvedEvents
     const oldIndex = this.eventIndex
     this.resolvedEvents = resolveEvents(this.rawEvents, this.gameState)
     this.displayEventCount = this.resolvedEvents.filter((e) => getTextEvent(e) !== null).length

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -22,9 +22,7 @@ import { SaveLoadOverlay } from './SaveLoadOverlay'
 import { BacklogOverlay } from './BacklogOverlay'
 import { SeekBar } from './SeekBar'
 import { Event, EventScene } from '../types'
-
-const GAME_WIDTH = 800
-const GAME_HEIGHT = 600
+import { GAME_WIDTH, GAME_HEIGHT } from './constants'
 
 /** Dialog / Narration から text を取り出すヘルパー */
 function getTextEvent(event: Event):
@@ -64,7 +62,9 @@ export class NovelRenderer {
   private counterText: PixiText | null = null
   private displayEventCount = 0
 
-  /** Condition 展開済みのフラットなイベント配列（元の events は保持しない） */
+  /** Condition 展開前の元イベント配列（Flag 変更時の再展開に使用） */
+  private rawEvents: Event[] = []
+  /** Condition 展開済みのフラットなイベント配列 */
   private resolvedEvents: Event[] = []
   private eventIndex = 0
   private textIndex = 0
@@ -256,7 +256,8 @@ export class NovelRenderer {
     this.blackoutOverlay.visible = false
     this.currentBgmPath = null
 
-    // Condition をフラグに基づいて展開（元の events は変更しない）
+    // 元イベントを保持し、Condition をフラグに基づいて展開
+    this.rawEvents = events
     this.resolvedEvents = resolveEvents(events, this.gameState)
     this.eventIndex = 0
     this.textIndex = 0
@@ -407,7 +408,7 @@ export class NovelRenderer {
     if (historyIndex < 0 || historyIndex >= this.history.length) return
     if (this.waitingForChoice || this.waitingForWait) return
 
-    // 履歴を指定位置まで切り詰める
+    // 履歴を指定位置まで切り詰める（アンドゥスタック方式: 戻った地点から再進行すると新しい履歴が積まれる）
     this.history = this.history.slice(0, historyIndex + 1)
     const targetState = this.history[historyIndex]
     this.applyState(targetState)
@@ -432,6 +433,9 @@ export class NovelRenderer {
    * スナップショットから状態を宣言的に復元する
    */
   private applyState(state: NovelGameState): void {
+    // フラグ復元
+    this.gameState.fromJSON(state.flags)
+
     // インデックス復元
     this.eventIndex = state.eventIndex
     this.textIndex = state.textIndex
@@ -461,6 +465,24 @@ export class NovelRenderer {
       this.audioManager.stopBgm(0)
       this.currentBgmPath = null
     }
+  }
+
+  /**
+   * rawEvents を現在のフラグ状態で再展開し、eventIndex を維持する。
+   * Flag イベント処理後に呼ばれ、後続の Condition が新しいフラグ値で評価される。
+   */
+  private reResolveEvents(): void {
+    const oldResolved = this.resolvedEvents
+    const oldIndex = this.eventIndex
+    this.resolvedEvents = resolveEvents(this.rawEvents, this.gameState)
+    this.displayEventCount = this.resolvedEvents.filter((e) => getTextEvent(e) !== null).length
+
+    // 再展開で配列長が変わった場合、eventIndex を安全な範囲に収める
+    if (oldIndex >= this.resolvedEvents.length) {
+      this.eventIndex = Math.max(0, this.resolvedEvents.length - 1)
+    }
+    // 再展開前と同じイベントを指しているか確認（Flag イベント自体は展開で位置が変わらない）
+    // Flag は Condition の外にあるため、Flag の位置は再展開で変動しない
   }
 
   private handleAdvance = (): void => {
@@ -604,10 +626,9 @@ export class NovelRenderer {
     }
     if ('Flag' in event) {
       this.gameState.setFlag(event.Flag.name, event.Flag.value)
-      // フラグ変更により Condition の評価結果が変わる可能性があるが、
-      // resolvedEvents は setEvents/jumpToScene 時に計算済み。
-      // Flag が resolvedEvents 内に残っているので、ここで再展開は不要。
-      // もし動的に再展開が必要な場合は、ここに再計算ロジックを入れる。
+      // フラグ変更により後続の Condition の評価結果が変わる可能性がある。
+      // 現在のシーンの元イベントを再取得して resolvedEvents を再計算する。
+      this.reResolveEvents()
       return
     }
     if ('Choice' in event) {
@@ -780,8 +801,9 @@ export class NovelRenderer {
     }
     this.choiceOverlay.hide()
 
-    // Condition をフラグに基づいて展開
-    this.resolvedEvents = resolveEvents([...scene.events], this.gameState)
+    // 元イベントを保持し、Condition をフラグに基づいて展開
+    this.rawEvents = [...scene.events]
+    this.resolvedEvents = resolveEvents(this.rawEvents, this.gameState)
     this.displayEventCount = this.resolvedEvents.filter((e) => getTextEvent(e) !== null).length
 
     // NovelGameState を構築して applyState で宣言的に復元

--- a/frontend/src/game/SaveManager.ts
+++ b/frontend/src/game/SaveManager.ts
@@ -17,6 +17,12 @@ export interface SaveSlotData {
   textIndex: number
   flags: Record<string, FlagValue>
   backgroundPath: string | null
+  /** 暗転状態 */
+  isBlackout: boolean
+  /** 表示中のキャラクター情報 */
+  characters: Array<{ name: string; expression: string; position: string }>
+  /** 再生中の BGM パス */
+  currentBgmPath: string | null
   savedAt: string // ISO 8601
   sceneName: string | null
 }

--- a/frontend/src/game/SaveManager.ts
+++ b/frontend/src/game/SaveManager.ts
@@ -95,7 +95,9 @@ export class SaveManager {
           typeof slot.eventIndex === 'number' &&
           typeof slot.textIndex === 'number' &&
           typeof slot.savedAt === 'string' &&
-          typeof slot.flags === 'object'
+          typeof slot.flags === 'object' &&
+          typeof slot.isBlackout === 'boolean' &&
+          Array.isArray(slot.characters)
         ) {
           this.save(i, slot as SaveSlotData)
         } else {

--- a/frontend/src/game/SeekBar.ts
+++ b/frontend/src/game/SeekBar.ts
@@ -6,10 +6,8 @@
  * 動画プレイヤー的な見た目のスクラブバー。
  */
 
-import { Container, Graphics } from 'pixi.js'
-
-const GAME_WIDTH = 800
-const GAME_HEIGHT = 600
+import { Container, FederatedPointerEvent, Graphics } from 'pixi.js'
+import { GAME_WIDTH, GAME_HEIGHT } from './constants'
 
 /** バー全体の高さ（px） */
 const BAR_HEIGHT = 6
@@ -31,7 +29,7 @@ export class SeekBar extends Container {
   private barBg: Graphics
   private barFill: Graphics
   private thumb: Graphics
-  private hitArea_: Graphics
+  private clickRegion: Graphics
 
   private barWidth: number
   private barX: number
@@ -49,13 +47,13 @@ export class SeekBar extends Container {
     this.barWidth = GAME_WIDTH - BAR_MARGIN_X * 2
 
     // 透明ヒットエリア（クリック検出を広めに取る）
-    this.hitArea_ = new Graphics()
-    this.hitArea_.rect(this.barX, BAR_Y - 8, this.barWidth, BAR_HEIGHT + 16)
-    this.hitArea_.fill({ color: 0x000000, alpha: 0 })
-    this.hitArea_.eventMode = 'static'
-    this.hitArea_.cursor = 'pointer'
-    this.hitArea_.on('pointerdown', this.handleClick)
-    this.addChild(this.hitArea_)
+    this.clickRegion = new Graphics()
+    this.clickRegion.rect(this.barX, BAR_Y - 8, this.barWidth, BAR_HEIGHT + 16)
+    this.clickRegion.fill({ color: 0x000000, alpha: 0 })
+    this.clickRegion.eventMode = 'static'
+    this.clickRegion.cursor = 'pointer'
+    this.clickRegion.on('pointerdown', this.handleClick)
+    this.addChild(this.clickRegion)
 
     // 背景バー
     this.barBg = new Graphics()
@@ -99,7 +97,8 @@ export class SeekBar extends Container {
   }
 
   private updateVisual(): void {
-    const ratio = this._total > 0 ? Math.max(0, Math.min(1, this._current / this._total)) : 0
+    const maxIndex = this._total - 1
+    const ratio = maxIndex > 0 ? Math.max(0, Math.min(1, this._current / maxIndex)) : 0
     const fillWidth = Math.max(BAR_RADIUS * 2, this.barWidth * ratio)
 
     this.barFill.clear()
@@ -111,10 +110,10 @@ export class SeekBar extends Container {
     this.thumb.visible = this._total > 0
   }
 
-  private handleClick = (e: { globalX?: number; global?: { x: number } }): void => {
+  private handleClick = (e: FederatedPointerEvent): void => {
     if (this._total <= 0) return
 
-    const globalX = e.globalX ?? e.global?.x ?? 0
+    const globalX = e.globalX
     const localX = globalX - this.barX
     const ratio = Math.max(0, Math.min(1, localX / this.barWidth))
     const index = Math.round(ratio * (this._total - 1))

--- a/frontend/src/game/SeekBar.ts
+++ b/frontend/src/game/SeekBar.ts
@@ -1,0 +1,124 @@
+/**
+ * シークバー UI
+ *
+ * ダイアログボックスの下に薄いプログレスバーを表示し、
+ * クリックで任意のスナップショット位置にジャンプできる。
+ * 動画プレイヤー的な見た目のスクラブバー。
+ */
+
+import { Container, Graphics } from 'pixi.js'
+
+const GAME_WIDTH = 800
+const GAME_HEIGHT = 600
+
+/** バー全体の高さ（px） */
+const BAR_HEIGHT = 6
+/** バー左右マージン */
+const BAR_MARGIN_X = 20
+/** バーの Y 位置（画面最下端からのオフセット） */
+const BAR_Y = GAME_HEIGHT - 12
+
+/** バー背景色（暗いグレー） */
+const BAR_BG_COLOR = 0x333333
+/** バー進捗色（水色系、DialogBox のインジケーター色に合わせる） */
+const BAR_FILL_COLOR = 0xa8dadc
+/** バーの丸み */
+const BAR_RADIUS = 3
+/** つまみの半径 */
+const THUMB_RADIUS = 7
+
+export class SeekBar extends Container {
+  private barBg: Graphics
+  private barFill: Graphics
+  private thumb: Graphics
+  private hitArea_: Graphics
+
+  private barWidth: number
+  private barX: number
+
+  private _total = 0
+  private _current = 0
+
+  /** クリックで呼ばれるコールバック (historyIndex: number) => void */
+  private onSeek: ((historyIndex: number) => void) | null = null
+
+  constructor() {
+    super()
+
+    this.barX = BAR_MARGIN_X
+    this.barWidth = GAME_WIDTH - BAR_MARGIN_X * 2
+
+    // 透明ヒットエリア（クリック検出を広めに取る）
+    this.hitArea_ = new Graphics()
+    this.hitArea_.rect(this.barX, BAR_Y - 8, this.barWidth, BAR_HEIGHT + 16)
+    this.hitArea_.fill({ color: 0x000000, alpha: 0 })
+    this.hitArea_.eventMode = 'static'
+    this.hitArea_.cursor = 'pointer'
+    this.hitArea_.on('pointerdown', this.handleClick)
+    this.addChild(this.hitArea_)
+
+    // 背景バー
+    this.barBg = new Graphics()
+    this.drawBar(this.barBg, BAR_BG_COLOR, this.barWidth, 0.6)
+    this.addChild(this.barBg)
+
+    // 進捗バー
+    this.barFill = new Graphics()
+    this.addChild(this.barFill)
+
+    // つまみ
+    this.thumb = new Graphics()
+    this.thumb.circle(0, 0, THUMB_RADIUS)
+    this.thumb.fill({ color: BAR_FILL_COLOR, alpha: 0.9 })
+    this.thumb.y = BAR_Y + BAR_HEIGHT / 2
+    this.addChild(this.thumb)
+
+    this.updateVisual()
+  }
+
+  /**
+   * シークコールバックを設定する
+   */
+  setOnSeek(callback: (historyIndex: number) => void): void {
+    this.onSeek = callback
+  }
+
+  /**
+   * 現在位置と合計を更新する
+   */
+  update(current: number, total: number): void {
+    this._current = current
+    this._total = total
+    this.updateVisual()
+  }
+
+  private drawBar(g: Graphics, color: number, width: number, alpha: number): void {
+    g.clear()
+    g.roundRect(this.barX, BAR_Y, width, BAR_HEIGHT, BAR_RADIUS)
+    g.fill({ color, alpha })
+  }
+
+  private updateVisual(): void {
+    const ratio = this._total > 0 ? Math.max(0, Math.min(1, this._current / this._total)) : 0
+    const fillWidth = Math.max(BAR_RADIUS * 2, this.barWidth * ratio)
+
+    this.barFill.clear()
+    this.barFill.roundRect(this.barX, BAR_Y, fillWidth, BAR_HEIGHT, BAR_RADIUS)
+    this.barFill.fill({ color: BAR_FILL_COLOR, alpha: 0.8 })
+
+    // つまみ位置
+    this.thumb.x = this.barX + this.barWidth * ratio
+    this.thumb.visible = this._total > 0
+  }
+
+  private handleClick = (e: { globalX?: number; global?: { x: number } }): void => {
+    if (this._total <= 0) return
+
+    const globalX = e.globalX ?? e.global?.x ?? 0
+    const localX = globalX - this.barX
+    const ratio = Math.max(0, Math.min(1, localX / this.barWidth))
+    const index = Math.round(ratio * (this._total - 1))
+
+    this.onSeek?.(index)
+  }
+}

--- a/frontend/src/game/constants.ts
+++ b/frontend/src/game/constants.ts
@@ -1,0 +1,3 @@
+/** ゲーム画面の基本サイズ */
+export const GAME_WIDTH = 800
+export const GAME_HEIGHT = 600

--- a/frontend/src/game/resolveEvents.test.ts
+++ b/frontend/src/game/resolveEvents.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { GameState, resolveEvents } from './GameState'
+import { Event } from '../types'
+
+describe('resolveEvents', () => {
+  it('Condition のないイベント配列はそのまま返す', () => {
+    const gs = new GameState()
+    const events: Event[] = [
+      { Narration: { text: ['こんにちは'] } },
+      { Background: { path: 'bg.png' } },
+    ]
+    const result = resolveEvents(events, gs)
+    expect(result).toEqual(events)
+  })
+
+  it('Condition が偽ならスキップする', () => {
+    const gs = new GameState()
+    const events: Event[] = [
+      { Narration: { text: ['前'] } },
+      { Condition: { flag: 'visited', events: [{ Narration: { text: ['条件内'] } }] } },
+      { Narration: { text: ['後'] } },
+    ]
+    const result = resolveEvents(events, gs)
+    expect(result).toEqual([
+      { Narration: { text: ['前'] } },
+      { Narration: { text: ['後'] } },
+    ])
+  })
+
+  it('Condition が真なら内部 events を展開する', () => {
+    const gs = new GameState()
+    gs.setFlag('visited', { Bool: true })
+    const events: Event[] = [
+      { Narration: { text: ['前'] } },
+      { Condition: { flag: 'visited', events: [{ Narration: { text: ['条件内'] } }] } },
+      { Narration: { text: ['後'] } },
+    ]
+    const result = resolveEvents(events, gs)
+    expect(result).toEqual([
+      { Narration: { text: ['前'] } },
+      { Narration: { text: ['条件内'] } },
+      { Narration: { text: ['後'] } },
+    ])
+  })
+
+  it('ネストした Condition を再帰的に展開する', () => {
+    const gs = new GameState()
+    gs.setFlag('a', { Bool: true })
+    gs.setFlag('b', { Bool: true })
+    const events: Event[] = [
+      {
+        Condition: {
+          flag: 'a',
+          events: [
+            { Narration: { text: ['外側'] } },
+            { Condition: { flag: 'b', events: [{ Narration: { text: ['内側'] } }] } },
+          ],
+        },
+      },
+    ]
+    const result = resolveEvents(events, gs)
+    expect(result).toEqual([
+      { Narration: { text: ['外側'] } },
+      { Narration: { text: ['内側'] } },
+    ])
+  })
+
+  it('ネストした Condition の内側が偽なら内側だけスキップする', () => {
+    const gs = new GameState()
+    gs.setFlag('a', { Bool: true })
+    // b は未設定（偽）
+    const events: Event[] = [
+      {
+        Condition: {
+          flag: 'a',
+          events: [
+            { Narration: { text: ['外側'] } },
+            { Condition: { flag: 'b', events: [{ Narration: { text: ['内側'] } }] } },
+          ],
+        },
+      },
+    ]
+    const result = resolveEvents(events, gs)
+    expect(result).toEqual([{ Narration: { text: ['外側'] } }])
+  })
+
+  it('空のイベント配列は空配列を返す', () => {
+    const gs = new GameState()
+    expect(resolveEvents([], gs)).toEqual([])
+  })
+
+  it('Condition 内部が空でも問題ない', () => {
+    const gs = new GameState()
+    gs.setFlag('x', { Bool: true })
+    const events: Event[] = [
+      { Condition: { flag: 'x', events: [] } },
+      { Narration: { text: ['後'] } },
+    ]
+    const result = resolveEvents(events, gs)
+    expect(result).toEqual([{ Narration: { text: ['後'] } }])
+  })
+
+  it('元の events 配列を変更しない', () => {
+    const gs = new GameState()
+    gs.setFlag('a', { Bool: true })
+    const inner: Event[] = [{ Narration: { text: ['展開'] } }]
+    const events: Event[] = [
+      { Condition: { flag: 'a', events: inner } },
+    ]
+    const eventsCopy = JSON.parse(JSON.stringify(events))
+    resolveEvents(events, gs)
+    expect(events).toEqual(eventsCopy)
+  })
+
+  it('Flag イベントはそのまま残る', () => {
+    const gs = new GameState()
+    const events: Event[] = [
+      { Flag: { name: 'test', value: { Bool: true } } },
+      { Narration: { text: ['テスト'] } },
+    ]
+    const result = resolveEvents(events, gs)
+    expect(result).toEqual(events)
+  })
+})


### PR DESCRIPTION
## 関連 Issue
closes #26

## 変更内容

### 1. NovelGameState インターフェース抽出
- `GameState.ts` に `NovelGameState` インターフェースを追加
- View非依存の状態型（sceneId, eventIndex, textIndex, flags, backgroundPath, isBlackout, characters, currentBgmPath）

### 2. スナップショットスタック
- テキストイベント到達ごとに `history: NovelGameState[]` に push
- advance → push、goBack → pop して宣言的復元

### 3. 宣言的復元 `applyState()`
- スナップショットから背景・暗転・キャラクター・BGMを直接セット
- `replayDirectivesUpTo()` を廃止

### 4. Condition の splice 廃止
- `resolveEvents()` 関数で Condition をフラグに基づいてフラット展開（元の events 配列は不変）
- `expandedConditions` Set を削除

### 5. advance/goBack/getSnapshot/seekTo を public 化
- 外部からのテスト・操作が可能に

### 6. SaveSlotData を NovelGameState ベースに拡張
- `isBlackout`, `characters`, `currentBgmPath` フィールド追加
- セーブ = `getSnapshot()` の結果 + メタ情報
- ロード = `applyState()` で即座復元

### 7. シークバーUI
- `SeekBar.ts` 新規作成（PixiJS Container）
- ダイアログボックスの下にプログレスバー表示
- クリックで任意位置にジャンプ