### PR TITLE
feat: アセット検索+タグ機能 (#21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,8 @@ curl -X POST http://localhost:8001/api/projects/{name}/switch-branch \
 my-game/
 ├── .git/
 ├── .gitignore          # .name-name.jsonを除外
-├── .name-name.json     # ローカル設定（ブランチ情報）
+├── .name-name.json     # ローカル設定（ブランチ情報、gitignore対象）
+├── .name-name-tags.json # アセットタグ情報（Git管理対象）
 ├── chapters/
 │   └── all.md          # 章データ（Markdown形式）
 └── assets/
@@ -266,10 +267,15 @@ LD_PRELOAD= git push origin main
 - `PUT /api/projects/{name}/chapters` - 保存
 
 ### アセット管理
-- `GET /api/projects/{name}/assets/{type}` - 一覧（type: images/sounds/movies/ideas）
+- `GET /api/projects/{name}/assets/{type}` - 一覧（type: images/sounds/movies/ideas）。`?q=`で名前検索、`?tag=`でタグフィルタ
 - `POST /api/projects/{name}/assets/{type}` - アップロード
 - `GET /api/projects/{name}/assets/{type}/{filename}` - ダウンロード
 - `DELETE /api/projects/{name}/assets/{type}/{filename}` - 削除
+- `PUT /api/projects/{name}/assets/{type}/{filename}/tags` - タグ設定
+- `DELETE /api/projects/{name}/assets/{type}/{filename}/tags/{tag}` - タグ削除
+
+### タグ管理
+- `GET /api/projects/{name}/tags` - プロジェクト内の全ユニークタグ一覧
 
 ### コミット・同期
 - `GET /api/projects/{name}/status` - 未コミットの変更確認
@@ -339,7 +345,8 @@ uv sync
 - ✅ キャンバスエディタ（ドラッグ&ドロップ）
 - ✅ アセット管理画面
   - タブ切り替え（4種類のアセット）
-  - 検索機能（UI実装済み）
+  - 検索機能（バックエンド連携済み、名前部分一致）
+  - タグ機能（付与・削除・フィルタリング、`.name-name-tags.json` に保存）
   - サムネイル表示（画像）
   - プレビュー機能（画像・音声・動画）
   - ドラッグ&ドロップアップロード
@@ -373,8 +380,6 @@ uv sync
 - ✅ AudioBuffer キャッシュ・ユーザーインタラクション制約対応
 
 ### 未実装
-- ⬜ アセット検索機能（バックエンド連携）
-- ⬜ タグ機能（アセット分類）
 - ⬜ フロントエンドでのWASMパーサー統合
 - ⬜ RPGプレイヤーのPixiJS移行（現在はPhaser）
 - ✅ 立ち絵表示 + 表情変更 + 退場（#18）— CharacterLayer / 左右中央配置 / ExpressionChange / Exit

--- a/backend/ASSETS.md
+++ b/backend/ASSETS.md
@@ -28,10 +28,12 @@ projects/{project_name}/
 
 ### アセット一覧取得
 ```
-GET /api/projects/{project_name}/assets/{asset_type}
+GET /api/projects/{project_name}/assets/{asset_type}?q={query}&tag={tag}
 ```
 - `asset_type`: `images`, `sounds`, `movies`, `ideas`
-- レスポンス: アセットの名前、サイズ、URLのリスト
+- `q`（オプション）: ファイル名の部分一致検索（大文字小文字無視）
+- `tag`（オプション）: 指定タグを持つアセットのみ返す
+- レスポンス: アセットの名前、サイズ、URL、タグのリスト
 
 ### アセットアップロード
 ```
@@ -56,6 +58,42 @@ GET /api/projects/{project_name}/assets/{asset_type}/{filename}
 DELETE /api/projects/{project_name}/assets/{asset_type}/{filename}
 ```
 - ファイルを削除し、自動的にGitコミット・プッシュ
+- 紐づくタグ情報も自動削除
+
+### タグ設定
+```
+PUT /api/projects/{project_name}/assets/{asset_type}/{filename}/tags
+Content-Type: application/json
+
+{"tags": ["キャラ", "主人公"]}
+```
+- アセットのタグを上書き設定
+- 空配列を渡すとタグをクリア
+
+### タグ個別削除
+```
+DELETE /api/projects/{project_name}/assets/{asset_type}/{filename}/tags/{tag}
+```
+- アセットから指定タグのみ削除
+
+### タグ一覧取得
+```
+GET /api/projects/{project_name}/tags
+```
+- プロジェクト内の全ユニークタグ名を返す
+
+## タグの保存先
+
+タグ情報はプロジェクトルートの `.name-name-tags.json` に保存されます。
+
+```json
+{
+  "images/hero.png": ["キャラ", "主人公"],
+  "sounds/bgm01.ogg": ["BGM", "戦闘"]
+}
+```
+
+キーは `{asset_type}/{filename}` 形式。このファイルはGit管理対象（コミットボタンで他の変更と一緒にコミットされます）。
 
 ## PixiJSとの統合
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -105,13 +105,23 @@ POST   /api/projects/{name}/commit           # コミット・プッシュ
 ### アセット管理
 
 ```
-GET    /api/projects/{name}/assets/{type}           # アセット一覧
-POST   /api/projects/{name}/assets/{type}           # アセットアップロード
-GET    /api/projects/{name}/assets/{type}/{file}    # アセット取得
-DELETE /api/projects/{name}/assets/{type}/{file}    # アセット削除
+GET    /api/projects/{name}/assets/{type}               # アセット一覧（?q= 名前検索, ?tag= タグフィルタ）
+POST   /api/projects/{name}/assets/{type}               # アセットアップロード
+GET    /api/projects/{name}/assets/{type}/{file}        # アセット取得
+DELETE /api/projects/{name}/assets/{type}/{file}        # アセット削除
+PUT    /api/projects/{name}/assets/{type}/{file}/tags   # タグ設定
+DELETE /api/projects/{name}/assets/{type}/{file}/tags/{tag}  # タグ削除
+```
+
+### タグ管理
+
+```
+GET    /api/projects/{name}/tags                        # 全ユニークタグ一覧
 ```
 
 `{type}`: `images`, `sounds`, `movies`, `ideas`
+
+タグ情報はプロジェクト内の `.name-name-tags.json` に保存されます（Git管理対象）。
 
 ## CORS設定
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -130,7 +130,8 @@ def validate_tags(tags: list) -> list[str]:
 
 def validate_asset_type(asset_type: str):
     """アセットタイプのバリデーション"""
-    validate_asset_type(asset_type)
+    if asset_type not in ["images", "sounds", "movies", "ideas"]:
+        raise HTTPException(status_code=400, detail="asset_type must be images, sounds, movies, or ideas")
 
 
 @app.get("/")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -90,11 +90,18 @@ def get_tags_file_path(project_name: str) -> Path:
     return PROJECTS_DIR / project_name / ".name-name-tags.json"
 
 
+MAX_TAG_LENGTH = 50
+
+
 def load_tags(project_name: str) -> dict:
     """タグ情報を読み込み"""
     path = get_tags_file_path(project_name)
     if path.exists():
-        return json.loads(path.read_text(encoding="utf-8"))
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            logger.warning(f"Invalid JSON in tags file: {path}")
+            return {}
     return {}
 
 
@@ -102,6 +109,28 @@ def save_tags(project_name: str, tags: dict):
     """タグ情報を保存"""
     path = get_tags_file_path(project_name)
     path.write_text(json.dumps(tags, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def validate_tags(tags: list) -> list[str]:
+    """タグリストのバリデーション。不正な値があれば例外を投げる"""
+    if not isinstance(tags, list):
+        raise HTTPException(status_code=400, detail="tags must be an array")
+    validated = []
+    for tag in tags:
+        if not isinstance(tag, str):
+            raise HTTPException(status_code=400, detail="each tag must be a string")
+        tag = tag.strip()
+        if not tag:
+            continue
+        if len(tag) > MAX_TAG_LENGTH:
+            raise HTTPException(status_code=400, detail=f"tag must be {MAX_TAG_LENGTH} characters or less")
+        validated.append(tag)
+    return validated
+
+
+def validate_asset_type(asset_type: str):
+    """アセットタイプのバリデーション"""
+    validate_asset_type(asset_type)
 
 
 @app.get("/")
@@ -364,8 +393,7 @@ async def list_assets(
     q: ファイル名の部分一致検索（大文字小文字無視）
     tag: 指定タグを持つアセットのみ返す
     """
-    if asset_type not in ["images", "sounds", "movies", "ideas"]:
-        raise HTTPException(status_code=400, detail="asset_type must be images, sounds, movies, or ideas")
+    validate_asset_type(asset_type)
 
     project_path = get_project_path(project_name)
     if not project_path.exists():
@@ -415,8 +443,7 @@ async def upload_asset(
 
     asset_type: images, sounds, movies, ideas
     """
-    if asset_type not in ["images", "sounds", "movies", "ideas"]:
-        raise HTTPException(status_code=400, detail="asset_type must be images, sounds, movies, or ideas")
+    validate_asset_type(asset_type)
 
     project_path = get_project_path(project_name)
     if not project_path.exists():
@@ -449,8 +476,7 @@ async def get_asset(project_name: str, asset_type: str, filename: str):
 
     asset_type: images, sounds, movies, ideas
     """
-    if asset_type not in ["images", "sounds", "movies", "ideas"]:
-        raise HTTPException(status_code=400, detail="asset_type must be images, sounds, movies, or ideas")
+    validate_asset_type(asset_type)
 
     assets_dir = get_assets_dir(project_name, asset_type)
     file_path = assets_dir / filename
@@ -472,8 +498,7 @@ async def delete_asset(
 
     asset_type: images, sounds, movies, ideas
     """
-    if asset_type not in ["images", "sounds", "movies", "ideas"]:
-        raise HTTPException(status_code=400, detail="asset_type must be images, sounds, movies, or ideas")
+    validate_asset_type(asset_type)
 
     project_path = get_project_path(project_name)
     if not project_path.exists():
@@ -525,8 +550,7 @@ async def list_tags(project_name: str):
 @app.put("/api/projects/{project_name}/assets/{asset_type}/{filename}/tags")
 async def set_asset_tags(project_name: str, asset_type: str, filename: str, body: dict):
     """アセットのタグを設定（上書き）"""
-    if asset_type not in ["images", "sounds", "movies", "ideas"]:
-        raise HTTPException(status_code=400, detail="asset_type must be images, sounds, movies, or ideas")
+    validate_asset_type(asset_type)
 
     # アセットの存在確認
     assets_dir = get_assets_dir(project_name, asset_type)
@@ -534,7 +558,7 @@ async def set_asset_tags(project_name: str, asset_type: str, filename: str, body
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="Asset not found")
 
-    tags = body.get("tags", [])
+    tags = validate_tags(body.get("tags", []))
 
     all_tags = load_tags(project_name)
     tag_key = f"{asset_type}/{filename}"
@@ -552,8 +576,16 @@ async def set_asset_tags(project_name: str, asset_type: str, filename: str, body
 @app.delete("/api/projects/{project_name}/assets/{asset_type}/{filename}/tags/{tag}")
 async def delete_asset_tag(project_name: str, asset_type: str, filename: str, tag: str):
     """アセットから個別タグを削除"""
-    if asset_type not in ["images", "sounds", "movies", "ideas"]:
-        raise HTTPException(status_code=400, detail="asset_type must be images, sounds, movies, or ideas")
+    validate_asset_type(asset_type)
+
+    project_path = get_project_path(project_name)
+    if not project_path.exists():
+        raise HTTPException(status_code=404, detail=f"Project '{project_name}' not found")
+
+    assets_dir = get_assets_dir(project_name, asset_type)
+    file_path = assets_dir / filename
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="Asset not found")
 
     all_tags = load_tags(project_name)
     tag_key = f"{asset_type}/{filename}"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -85,6 +85,25 @@ def get_project_path(project_name: str) -> Path:
     return PROJECTS_DIR / project_name
 
 
+def get_tags_file_path(project_name: str) -> Path:
+    """タグ情報ファイルのパスを取得"""
+    return PROJECTS_DIR / project_name / ".name-name-tags.json"
+
+
+def load_tags(project_name: str) -> dict:
+    """タグ情報を読み込み"""
+    path = get_tags_file_path(project_name)
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return {}
+
+
+def save_tags(project_name: str, tags: dict):
+    """タグ情報を保存"""
+    path = get_tags_file_path(project_name)
+    path.write_text(json.dumps(tags, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
 @app.get("/")
 async def root():
     """ヘルスチェック"""
@@ -333,10 +352,17 @@ async def switch_branch(project_name: str, body: dict):
 
 
 @app.get("/api/projects/{project_name}/assets/{asset_type}")
-async def list_assets(project_name: str, asset_type: str):
+async def list_assets(
+    project_name: str,
+    asset_type: str,
+    q: Optional[str] = None,
+    tag: Optional[str] = None,
+):
     """指定タイプのアセット一覧を取得
 
     asset_type: images, sounds, movies, ideas
+    q: ファイル名の部分一致検索（大文字小文字無視）
+    tag: 指定タグを持つアセットのみ返す
     """
     if asset_type not in ["images", "sounds", "movies", "ideas"]:
         raise HTTPException(status_code=400, detail="asset_type must be images, sounds, movies, or ideas")
@@ -350,13 +376,29 @@ async def list_assets(project_name: str, asset_type: str):
     if not assets_dir.exists():
         return {"assets": []}
 
+    # タグ情報を読み込み
+    all_tags = load_tags(project_name)
+
     assets = []
     for file_path in assets_dir.iterdir():
         if file_path.is_file() and file_path.name != ".gitkeep":
+            # 検索フィルタ
+            if q and q.lower() not in file_path.name.lower():
+                continue
+
+            # タグキー
+            tag_key = f"{asset_type}/{file_path.name}"
+            asset_tags = all_tags.get(tag_key, [])
+
+            # タグフィルタ
+            if tag and tag not in asset_tags:
+                continue
+
             assets.append({
                 "name": file_path.name,
                 "size": file_path.stat().st_size,
                 "url": f"/api/projects/{project_name}/assets/{asset_type}/{file_path.name}",
+                "tags": asset_tags,
             })
 
     return {"assets": assets}
@@ -447,6 +489,13 @@ async def delete_asset(
         # ファイルを削除（コミットはしない）
         file_path.unlink()
 
+        # タグ情報からも削除
+        all_tags = load_tags(project_name)
+        tag_key = f"{asset_type}/{filename}"
+        if tag_key in all_tags:
+            del all_tags[tag_key]
+            save_tags(project_name, all_tags)
+
         return {
             "success": True,
             "filename": filename,
@@ -455,6 +504,73 @@ async def delete_asset(
     except Exception as e:
         logger.error(f"Delete asset failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+# === タグ管理エンドポイント ===
+
+
+@app.get("/api/projects/{project_name}/tags")
+async def list_tags(project_name: str):
+    """プロジェクト内の全ユニークタグ一覧を取得"""
+    project_path = get_project_path(project_name)
+    if not project_path.exists():
+        raise HTTPException(status_code=404, detail=f"Project '{project_name}' not found")
+
+    all_tags = load_tags(project_name)
+    unique_tags = sorted(set(tag for tags in all_tags.values() for tag in tags))
+
+    return {"tags": unique_tags}
+
+
+@app.put("/api/projects/{project_name}/assets/{asset_type}/{filename}/tags")
+async def set_asset_tags(project_name: str, asset_type: str, filename: str, body: dict):
+    """アセットのタグを設定（上書き）"""
+    if asset_type not in ["images", "sounds", "movies", "ideas"]:
+        raise HTTPException(status_code=400, detail="asset_type must be images, sounds, movies, or ideas")
+
+    # アセットの存在確認
+    assets_dir = get_assets_dir(project_name, asset_type)
+    file_path = assets_dir / filename
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    tags = body.get("tags", [])
+
+    all_tags = load_tags(project_name)
+    tag_key = f"{asset_type}/{filename}"
+
+    if tags:
+        all_tags[tag_key] = tags
+    elif tag_key in all_tags:
+        del all_tags[tag_key]
+
+    save_tags(project_name, all_tags)
+
+    return {"success": True, "tags": tags}
+
+
+@app.delete("/api/projects/{project_name}/assets/{asset_type}/{filename}/tags/{tag}")
+async def delete_asset_tag(project_name: str, asset_type: str, filename: str, tag: str):
+    """アセットから個別タグを削除"""
+    if asset_type not in ["images", "sounds", "movies", "ideas"]:
+        raise HTTPException(status_code=400, detail="asset_type must be images, sounds, movies, or ideas")
+
+    all_tags = load_tags(project_name)
+    tag_key = f"{asset_type}/{filename}"
+    asset_tags = all_tags.get(tag_key, [])
+
+    if tag not in asset_tags:
+        raise HTTPException(status_code=404, detail=f"Tag '{tag}' not found on this asset")
+
+    asset_tags.remove(tag)
+    if asset_tags:
+        all_tags[tag_key] = asset_tags
+    elif tag_key in all_tags:
+        del all_tags[tag_key]
+
+    save_tags(project_name, all_tags)
+
+    return {"success": True, "tags": asset_tags}
 
 
 if __name__ == "__main__":

--- a/frontend/src/screens/AssetsScreen.tsx
+++ b/frontend/src/screens/AssetsScreen.tsx
@@ -7,6 +7,7 @@ interface Asset {
   name: string
   size: number
   url: string
+  tags: string[]
 }
 
 interface AssetsScreenProps {
@@ -35,6 +36,10 @@ function AssetsScreen({
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedTag, setSelectedTag] = useState<string | null>(null)
+  const [allTags, setAllTags] = useState<string[]>([])
+  const [newTagInput, setNewTagInput] = useState('')
 
   // 初回ロード時と5秒ごとにgit statusをチェック
   useEffect(() => {
@@ -102,17 +107,53 @@ function AssetsScreen({
     }
   }
 
-  // タブ切り替え時に選択をクリア
+  // タブ切り替え時に選択とフィルターをクリア
   useEffect(() => {
     setSelectedAsset(null)
+    setSearchQuery('')
+    setSelectedTag(null)
   }, [selectedType])
+
+  // 全タグ一覧を取得
+  useEffect(() => {
+    const loadTags = async () => {
+      try {
+        const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/tags`)
+        if (response.ok) {
+          const data = await response.json()
+          setAllTags(data.tags)
+        }
+      } catch (error) {
+        console.error('Failed to load tags:', error)
+      }
+    }
+    loadTags()
+  }, [apiBaseUrl, projectName])
+
+  // タグ一覧を再取得するヘルパー
+  const refreshTags = async () => {
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/tags`)
+      if (response.ok) {
+        const data = await response.json()
+        setAllTags(data.tags)
+      }
+    } catch (error) {
+      console.error('Failed to refresh tags:', error)
+    }
+  }
 
   // アセット一覧を取得
   useEffect(() => {
     const loadAssets = async () => {
       setLoading(true)
       try {
-        const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}`)
+        const params = new URLSearchParams()
+        if (searchQuery) params.set('q', searchQuery)
+        if (selectedTag) params.set('tag', selectedTag)
+        const queryString = params.toString()
+        const url = `${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}${queryString ? '?' + queryString : ''}`
+        const response = await fetch(url)
         if (!response.ok) {
           throw new Error(`Failed to load assets: ${response.status}`)
         }
@@ -125,7 +166,7 @@ function AssetsScreen({
       }
     }
     loadAssets()
-  }, [apiBaseUrl, projectName, selectedType])
+  }, [apiBaseUrl, projectName, selectedType, searchQuery, selectedTag])
 
   // ファイルアップロード
   const handleFileUpload = async (files: FileList | null) => {
@@ -185,6 +226,54 @@ function AssetsScreen({
     } catch (error) {
       console.error('Failed to delete file:', error)
       setDeletingAsset(null)
+    }
+  }
+
+  // タグを追加
+  const handleAddTag = async (asset: Asset, tagName: string) => {
+    const trimmed = tagName.trim()
+    if (!trimmed || asset.tags.includes(trimmed)) return
+
+    const newTags = [...asset.tags, trimmed]
+    try {
+      const response = await fetch(
+        `${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}/${asset.name}/tags`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tags: newTags }),
+        }
+      )
+      if (response.ok) {
+        setAssets(assets.map((a) => (a.name === asset.name ? { ...a, tags: newTags } : a)))
+        if (selectedAsset?.name === asset.name) {
+          setSelectedAsset({ ...asset, tags: newTags })
+        }
+        setNewTagInput('')
+        refreshTags()
+      }
+    } catch (error) {
+      console.error('Failed to add tag:', error)
+    }
+  }
+
+  // タグを削除
+  const handleRemoveTag = async (asset: Asset, tagName: string) => {
+    try {
+      const response = await fetch(
+        `${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}/${asset.name}/tags/${encodeURIComponent(tagName)}`,
+        { method: 'DELETE' }
+      )
+      if (response.ok) {
+        const newTags = asset.tags.filter((t) => t !== tagName)
+        setAssets(assets.map((a) => (a.name === asset.name ? { ...a, tags: newTags } : a)))
+        if (selectedAsset?.name === asset.name) {
+          setSelectedAsset({ ...asset, tags: newTags })
+        }
+        refreshTags()
+      }
+    } catch (error) {
+      console.error('Failed to remove tag:', error)
     }
   }
 
@@ -329,6 +418,8 @@ function AssetsScreen({
               <input
                 type="text"
                 placeholder="検索..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
                 className={`w-full pl-10 pr-3 py-2 rounded border ${
                   isDark
                     ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400'
@@ -336,6 +427,26 @@ function AssetsScreen({
                 }`}
               />
             </div>
+            {/* タグフィルター */}
+            {allTags.length > 0 && (
+              <div className="flex flex-wrap gap-1 mt-2">
+                {allTags.map((tag) => (
+                  <button
+                    key={tag}
+                    onClick={() => setSelectedTag(selectedTag === tag ? null : tag)}
+                    className={`px-2 py-0.5 text-xs rounded-full transition-colors ${
+                      selectedTag === tag
+                        ? 'bg-blue-500 text-white'
+                        : isDark
+                          ? 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+                          : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                    }`}
+                  >
+                    {tag}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
 
           {/* アセット一覧（スクロール可能） */}
@@ -377,6 +488,20 @@ function AssetsScreen({
                         <div className={`text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
                           {formatFileSize(asset.size)}
                         </div>
+                        {asset.tags.length > 0 && (
+                          <div className="flex flex-wrap gap-1 mt-1">
+                            {asset.tags.map((tag) => (
+                              <span
+                                key={tag}
+                                className={`px-1.5 py-0 text-[10px] rounded-full ${
+                                  isDark ? 'bg-gray-600 text-gray-300' : 'bg-gray-200 text-gray-600'
+                                }`}
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        )}
                       </div>
 
                       <button
@@ -492,6 +617,59 @@ function AssetsScreen({
                   />
                 </div>
               )}
+
+              {/* タグ管理 */}
+              <div className={`mt-6 p-4 rounded-lg ${isDark ? 'bg-gray-800' : 'bg-gray-50'}`}>
+                <h3 className={`text-sm font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>タグ</h3>
+                <div className="flex flex-wrap gap-1 mb-2">
+                  {selectedAsset.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-full ${
+                        isDark ? 'bg-gray-700 text-gray-300' : 'bg-gray-200 text-gray-700'
+                      }`}
+                    >
+                      {tag}
+                      <button
+                        onClick={() => handleRemoveTag(selectedAsset, tag)}
+                        className={`hover:text-red-400 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}
+                      >
+                        ×
+                      </button>
+                    </span>
+                  ))}
+                </div>
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    placeholder="タグを追加..."
+                    value={newTagInput}
+                    onChange={(e) => setNewTagInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && newTagInput.trim()) {
+                        handleAddTag(selectedAsset, newTagInput)
+                      }
+                    }}
+                    className={`flex-1 px-3 py-1.5 text-sm rounded border ${
+                      isDark
+                        ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400'
+                        : 'bg-white border-gray-300 text-gray-900 placeholder-gray-500'
+                    }`}
+                  />
+                  <button
+                    onClick={() => {
+                      if (newTagInput.trim()) handleAddTag(selectedAsset, newTagInput)
+                    }}
+                    className={`px-3 py-1.5 text-sm rounded transition-colors ${
+                      isDark
+                        ? 'bg-blue-600 hover:bg-blue-700 text-white'
+                        : 'bg-blue-500 hover:bg-blue-600 text-white'
+                    }`}
+                  >
+                    追加
+                  </button>
+                </div>
+              </div>
             </div>
           ) : (
             <div className="flex items-center justify-center h-full">

--- a/frontend/src/screens/AssetsScreen.tsx
+++ b/frontend/src/screens/AssetsScreen.tsx
@@ -50,6 +50,13 @@ function AssetsScreen({
     debounceRef.current = setTimeout(() => setDebouncedQuery(value), 300)
   }, [])
 
+  // アンマウント時にデバウンスタイマーをクリア
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [])
+
   // 初回ロード時と5秒ごとにgit statusをチェック
   useEffect(() => {
     const checkStatus = async () => {
@@ -220,12 +227,13 @@ function AssetsScreen({
         throw new Error(`Failed to delete ${deletingAsset.name}: ${response.status}`)
       }
 
-      // 削除成功後、一覧を再取得
+      // 削除成功後、一覧とタグを再取得
       setAssets(assets.filter((a) => a.name !== deletingAsset.name))
       if (selectedAsset?.name === deletingAsset.name) {
         setSelectedAsset(null)
       }
       setDeletingAsset(null)
+      fetchTags()
     } catch (error) {
       console.error('Failed to delete file:', error)
       setDeletingAsset(null)

--- a/frontend/src/screens/AssetsScreen.tsx
+++ b/frontend/src/screens/AssetsScreen.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import SaveDiscardButtons from '../components/SaveDiscardButtons'
 
 type AssetType = 'images' | 'sounds' | 'movies' | 'ideas'
@@ -36,10 +36,19 @@ function AssetsScreen({
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
-  const [searchQuery, setSearchQuery] = useState('')
+  const [searchInput, setSearchInput] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
   const [selectedTag, setSelectedTag] = useState<string | null>(null)
   const [allTags, setAllTags] = useState<string[]>([])
   const [newTagInput, setNewTagInput] = useState('')
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // 検索入力のデバウンス (300ms)
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchInput(value)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => setDebouncedQuery(value), 300)
+  }, [])
 
   // 初回ロード時と5秒ごとにgit statusをチェック
   useEffect(() => {
@@ -93,12 +102,8 @@ function AssetsScreen({
       if (!response.ok) {
         throw new Error(`Failed to discard: ${response.status}`)
       }
-      // アセット一覧を再読み込み
-      const assetsResponse = await fetch(`${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}`)
-      if (assetsResponse.ok) {
-        const data = await assetsResponse.json()
-        setAssets(data.assets)
-      }
+      // アセット一覧を再読み込み（フィルタ維持）
+      await fetchAssets()
       setHasUnsavedChanges(false)
     } catch (error) {
       console.error('Failed to discard changes:', error)
@@ -110,28 +115,19 @@ function AssetsScreen({
   // タブ切り替え時に選択とフィルターをクリア
   useEffect(() => {
     setSelectedAsset(null)
-    setSearchQuery('')
+    setSearchInput('')
+    setDebouncedQuery('')
     setSelectedTag(null)
+    setNewTagInput('')
   }, [selectedType])
 
-  // 全タグ一覧を取得
+  // アセット選択変更時にタグ入力をクリア
   useEffect(() => {
-    const loadTags = async () => {
-      try {
-        const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/tags`)
-        if (response.ok) {
-          const data = await response.json()
-          setAllTags(data.tags)
-        }
-      } catch (error) {
-        console.error('Failed to load tags:', error)
-      }
-    }
-    loadTags()
-  }, [apiBaseUrl, projectName])
+    setNewTagInput('')
+  }, [selectedAsset?.name])
 
-  // タグ一覧を再取得するヘルパー
-  const refreshTags = async () => {
+  // タグ一覧を取得・再取得
+  const fetchTags = useCallback(async () => {
     try {
       const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/tags`)
       if (response.ok) {
@@ -139,34 +135,43 @@ function AssetsScreen({
         setAllTags(data.tags)
       }
     } catch (error) {
-      console.error('Failed to refresh tags:', error)
+      console.error('Failed to load tags:', error)
     }
-  }
+  }, [apiBaseUrl, projectName])
+
+  useEffect(() => {
+    fetchTags()
+  }, [fetchTags])
+
+  // アセット一覧URLを構築するヘルパー
+  const buildAssetsUrl = useCallback(() => {
+    const params = new URLSearchParams()
+    if (debouncedQuery) params.set('q', debouncedQuery)
+    if (selectedTag) params.set('tag', selectedTag)
+    const queryString = params.toString()
+    return `${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}${queryString ? '?' + queryString : ''}`
+  }, [apiBaseUrl, projectName, selectedType, debouncedQuery, selectedTag])
 
   // アセット一覧を取得
-  useEffect(() => {
-    const loadAssets = async () => {
-      setLoading(true)
-      try {
-        const params = new URLSearchParams()
-        if (searchQuery) params.set('q', searchQuery)
-        if (selectedTag) params.set('tag', selectedTag)
-        const queryString = params.toString()
-        const url = `${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}${queryString ? '?' + queryString : ''}`
-        const response = await fetch(url)
-        if (!response.ok) {
-          throw new Error(`Failed to load assets: ${response.status}`)
-        }
-        const data = await response.json()
-        setAssets(data.assets)
-      } catch (error) {
-        console.error('Failed to load assets:', error)
-      } finally {
-        setLoading(false)
+  const fetchAssets = useCallback(async () => {
+    setLoading(true)
+    try {
+      const response = await fetch(buildAssetsUrl())
+      if (!response.ok) {
+        throw new Error(`Failed to load assets: ${response.status}`)
       }
+      const data = await response.json()
+      setAssets(data.assets)
+    } catch (error) {
+      console.error('Failed to load assets:', error)
+    } finally {
+      setLoading(false)
     }
-    loadAssets()
-  }, [apiBaseUrl, projectName, selectedType, searchQuery, selectedTag])
+  }, [buildAssetsUrl])
+
+  useEffect(() => {
+    fetchAssets()
+  }, [fetchAssets])
 
   // ファイルアップロード
   const handleFileUpload = async (files: FileList | null) => {
@@ -188,10 +193,8 @@ function AssetsScreen({
         }
       }
 
-      // アップロード成功後、一覧を再取得
-      const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}`)
-      const data = await response.json()
-      setAssets(data.assets)
+      // アップロード成功後、一覧を再取得（フィルタ維持）
+      await fetchAssets()
     } catch (error) {
       console.error('Failed to upload files:', error)
     } finally {
@@ -250,7 +253,7 @@ function AssetsScreen({
           setSelectedAsset({ ...asset, tags: newTags })
         }
         setNewTagInput('')
-        refreshTags()
+        fetchTags()
       }
     } catch (error) {
       console.error('Failed to add tag:', error)
@@ -270,7 +273,7 @@ function AssetsScreen({
         if (selectedAsset?.name === asset.name) {
           setSelectedAsset({ ...asset, tags: newTags })
         }
-        refreshTags()
+        fetchTags()
       }
     } catch (error) {
       console.error('Failed to remove tag:', error)
@@ -418,8 +421,8 @@ function AssetsScreen({
               <input
                 type="text"
                 placeholder="検索..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                value={searchInput}
+                onChange={(e) => handleSearchChange(e.target.value)}
                 className={`w-full pl-10 pr-3 py-2 rounded border ${
                   isDark
                     ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400'


### PR DESCRIPTION
## 関連 Issue
closes #21

## 変更内容

### バックエンド
- `GET /api/projects/{name}/assets/{type}` に `?q=` 名前検索・`?tag=` タグフィルタを追加
- アセット一覧レスポンスに `tags` フィールドを追加
- タグAPI新設: `GET /tags`（全タグ一覧）、`PUT .../tags`（タグ設定）、`DELETE .../tags/{tag}`（タグ削除）
- タグ情報は `.name-name-tags.json` に保存（Git管理対象）
- アセット削除時にタグ情報も自動クリーンアップ

### フロントエンド
- 検索入力をバックエンドAPIに接続（名前部分一致、大文字小文字無視）
- タグフィルターチップ（検索欄の下、クリックで適用/解除）
- アセット一覧にタグチップ表示
- プレビューパネルにタグ管理セクション（追加・削除）

### ドキュメント
- CLAUDE.md: API一覧・実装状況・プロジェクト構造を更新
- backend/README.md: タグAPIエンドポイントを追記
- backend/ASSETS.md: 検索パラメータ・タグAPIの仕様を追記