### PR TITLE
fix: #31 discard 時に .name-name-tags.json がリセットされない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ target/
 .claude/settings.local.json
 .serena/
 .mcp.json
+*.tsbuildinfo

--- a/backend/ASSETS.md
+++ b/backend/ASSETS.md
@@ -95,6 +95,10 @@ GET /api/projects/{project_name}/tags
 
 キーは `{asset_type}/{filename}` 形式。このファイルはGit管理対象（コミットボタンで他の変更と一緒にコミットされます）。
 
+### 破棄操作との関係
+
+`POST /api/projects/{name}/discard` は `git reset --hard HEAD` + `git clean -fd` を実行するため、`.name-name-tags.json` の未コミット変更も HEAD 時点の内容に戻ります（コミット前のタグ追加・削除・編集はすべて取り消されます）。
+
 ## PixiJSとの統合
 
 ### エディタモード

--- a/backend/app/git_service.py
+++ b/backend/app/git_service.py
@@ -134,20 +134,21 @@ class GitService:
         return self.repo.is_dirty() or len(self.repo.untracked_files) > 0
 
     def discard_changes(self) -> bool:
-        """未コミットの変更を破棄（git checkout . + 未追跡ファイル削除）"""
+        """未コミットの変更を破棄（git reset --hard HEAD + git clean -fd）
+
+        `.name-name-tags.json` のようなコミット済みトラッキング対象ファイルも
+        HEAD 時点の内容に確実に戻すため、`git checkout .` ではなく
+        `git reset --hard HEAD` を使う（インデックスと作業ツリーの両方をリセット）。
+        """
         try:
             if not self.repo:
                 return False
 
-            # 変更されたファイルを元に戻す
-            self.repo.git.checkout('.')
+            # トラッキング対象ファイルを HEAD にリセット（インデックス + 作業ツリー）
+            self.repo.git.reset('--hard', 'HEAD')
 
-            # 未追跡ファイルを削除
-            for file in self.repo.untracked_files:
-                file_path = self.repo_path / file
-                if file_path.exists():
-                    file_path.unlink()
-                    logger.info(f"Deleted untracked file: {file}")
+            # 未追跡ファイル・ディレクトリを削除（.gitignore 対象は残す）
+            self.repo.git.clean('-fd')
 
             logger.info("All changes discarded")
             return True


### PR DESCRIPTION
## 関連 Issue
closes #31

## 原因
`discard_changes()` は `git checkout .` を使っていたが、これはインデックスに残った変更を元に戻さないケースがある。`.name-name-tags.json` のような Git 管理対象ファイルの未コミット編集が残ることがあった。

## 修正
`git reset --hard HEAD` + `git clean -fd` に置き換え:
- トラッキング対象ファイルの変更は確実に HEAD に戻る（インデックス+作業ツリー両方リセット）
- 未追跡ファイル・ディレクトリは `git clean -fd` で削除（.gitignore 対象は残す）

## ドキュメント
`backend/ASSETS.md` に discard と `.name-name-tags.json` の関係を追記。

## 動作確認
- 未コミットのタグ追加 → discard → タグが HEAD に戻ることを確認
- 新規作成（未追跡）の tags ファイル → discard → 削除されることを確認