### PR TITLE
fix: #33 backend Dockerfile を pyproject.toml + uv 対応に書き換え

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ target/
 .claude/settings.local.json
 .serena/
 .mcp.json
+*.tsbuildinfo

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,17 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+.venv
+venv
+env
+ENV
+.pytest_cache
+.mypy_cache
+*.egg-info
+.coverage
+htmlcov
+.DS_Store
+projects
+.git

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,22 +1,33 @@
+# syntax=docker/dockerfile:1.7
 FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install git for GitPython
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+# uv をインストール（公式バイナリ）
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
-# Copy requirements and install dependencies
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# GitPython が使う git 本体
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git \
+ && rm -rf /var/lib/apt/lists/*
 
-# Copy application code
-COPY . .
+# 依存定義だけ先にコピーして依存レイヤをキャッシュ
+COPY pyproject.toml uv.lock ./
 
-# Create projects directory
+# 仮想環境は /app/.venv（uv 既定）。本体コード同梱前に依存だけ同期
+RUN uv sync --frozen --no-dev --no-install-project
+
+# アプリコード
+COPY app ./app
+
+# プロジェクト自体もインストール
+RUN uv sync --frozen --no-dev
+
+# プロジェクトデータ格納先
 RUN mkdir -p projects
 
-# Expose port
-EXPOSE 8000
+# compose.yaml と統一
+EXPOSE 7373
 
-# Run the application
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# uv 管理の venv 経由で uvicorn を起動
+CMD ["uv", "run", "--no-dev", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "7373"]


### PR DESCRIPTION
## 関連 Issue
closes #33

## 変更内容
- `backend/Dockerfile`
  - `requirements.txt` + `pip install` を削除
  - `ghcr.io/astral-sh/uv:latest` から `uv` バイナリをコピーして `uv sync --frozen` で依存解決
  - 依存レイヤのキャッシュのため `pyproject.toml` + `uv.lock` だけ先にコピーして sync → `app/` をコピーして再 sync の 2段構成
  - `EXPOSE 7373`、CMD も `uv run uvicorn ... --port 7373` に統一（compose.yaml と一致）
- `backend/.dockerignore` を新規作成（venv, cache, projects, .git を除外）
- `*.tsbuildinfo` を `.gitignore` に追加（作業中に混入を発見）

## 動作確認
- ローカルの Docker デーモンが停止していたため `docker build` 実測は未実施。`uv sync` + `uvicorn` の起動コマンドは CLAUDE.md / README.md と一致しており、`uv.lock` は既にリポジトリにコミット済み
- compose.yaml の backend サービスと Dockerfile のポート/コマンドが一致することを確認

動作確認は CI もしくはユーザー側の `docker compose up` で最終チェックしてください。