### PR TITLE
style: #57 Prettier 一括適用 + pre-commit フック整備

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run lint
+
       - run: npm run type-check
 
       - run: npm test -- --run

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+cd frontend && npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+# staged ファイルは frontend/ 配下のみ対象。backend(.py) やリポルート直下(.md) は対象外。
 cd frontend && npx lint-staged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,13 @@ npm run dev
 # → http://localhost:5173
 ```
 
+**pre-commit フック**:
+
+- `npm install` で husky が自動インストールされる（`.husky/pre-commit` が有効化）
+- `git commit` 時に staged な `frontend/src/**/*.{ts,tsx,css,json,md}` が自動で ESLint + Prettier で整形される
+- 整形結果は自動再ステージされる（lint-staged が処理）
+- バイパスしたい場合は `git commit --no-verify`（ただし CI の `npm run lint` で落ちる）
+
 ### Docker Compose（推奨）
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ npm run dev
 **pre-commit フック**:
 
 - `npm install` で husky が自動インストールされる（`.husky/pre-commit` が有効化）
-- `git commit` 時に staged な `frontend/src/**/*.{ts,tsx,css,json,md}` が自動で ESLint + Prettier で整形される
+- `git commit` 時に staged な `frontend/**/*.{ts,tsx,css,json,md}` が自動で整形される（ts/tsx は ESLint + Prettier、css/json/md は Prettier のみ）
 - 整形結果は自動再ステージされる（lint-staged が処理）
 - バイパスしたい場合は `git commit --no-verify`（ただし CI の `npm run lint` で落ちる）
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
     "type-check": "tsc -b --noEmit",
-    "prepare": "husky"
+    "prepare": "cd .. && node frontend/node_modules/husky/bin.js || true"
   },
   "dependencies": {
     "framer-motion": "^12.23.24",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,7 +72,9 @@ function App() {
             <h2 className="text-xl font-bold mb-4">設定</h2>
             <div className="space-y-4">
               <div>
-                <label className={`block text-sm font-medium mb-1 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                <label
+                  className={`block text-sm font-medium mb-1 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}
+                >
                   API URL
                 </label>
                 <input

--- a/frontend/src/components/MapEditor.tsx
+++ b/frontend/src/components/MapEditor.tsx
@@ -47,7 +47,9 @@ function MapEditor({ mapData, onChange, isDark }: MapEditorProps) {
   return (
     <div className="h-full flex flex-col">
       {/* タイルパレット */}
-      <div className={`p-4 border-b ${isDark ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-white'}`}>
+      <div
+        className={`p-4 border-b ${isDark ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-white'}`}
+      >
         <div className="flex items-center gap-2">
           <span className={`text-sm font-medium ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
             タイル選択:

--- a/frontend/src/components/NPCEditor.tsx
+++ b/frontend/src/components/NPCEditor.tsx
@@ -20,7 +20,7 @@ function NPCEditor({ npcs, mapData, onChange, isDark }: NPCEditorProps) {
   })
 
   // IDから現在のNPCデータを引く（selectedNPCIdが古いデータを持ち続けるバグを防ぐ）
-  const selectedNPC = selectedNPCId ? (npcs.find(n => n.id === selectedNPCId) ?? null) : null
+  const selectedNPC = selectedNPCId ? (npcs.find((n) => n.id === selectedNPCId) ?? null) : null
 
   const handleAddNPC = () => {
     if (!newNPC.name || !newNPC.message) {
@@ -44,7 +44,7 @@ function NPCEditor({ npcs, mapData, onChange, isDark }: NPCEditorProps) {
 
   const handleDeleteNPC = (id: string) => {
     if (confirm('このNPCを削除しますか？')) {
-      onChange(npcs.filter(n => n.id !== id))
+      onChange(npcs.filter((n) => n.id !== id))
       if (selectedNPCId === id) {
         setSelectedNPCId(null)
       }
@@ -52,7 +52,7 @@ function NPCEditor({ npcs, mapData, onChange, isDark }: NPCEditorProps) {
   }
 
   const handleUpdateNPC = (id: string, updates: Partial<NPCData>) => {
-    onChange(npcs.map(n => (n.id === id ? { ...n, ...updates } : n)))
+    onChange(npcs.map((n) => (n.id === id ? { ...n, ...updates } : n)))
   }
 
   const handleMapClick = (x: number, y: number) => {
@@ -68,7 +68,9 @@ function NPCEditor({ npcs, mapData, onChange, isDark }: NPCEditorProps) {
         className={`w-80 border-r overflow-auto ${isDark ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-white'}`}
       >
         <div className={`p-4 border-b ${isDark ? 'border-gray-700' : 'border-gray-200'}`}>
-          <h3 className={`font-semibold mb-3 ${isDark ? 'text-white' : 'text-gray-900'}`}>NPCリスト</h3>
+          <h3 className={`font-semibold mb-3 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            NPCリスト
+          </h3>
           <button
             onClick={() => setShowAddForm(true)}
             className={`w-full py-2 px-4 rounded font-medium transition-colors ${
@@ -87,7 +89,7 @@ function NPCEditor({ npcs, mapData, onChange, isDark }: NPCEditorProps) {
               NPCがまだありません
             </p>
           ) : (
-            npcs.map(npc => (
+            npcs.map((npc) => (
               <div
                 key={npc.id}
                 onClick={() => setSelectedNPCId(npc.id)}
@@ -102,9 +104,11 @@ function NPCEditor({ npcs, mapData, onChange, isDark }: NPCEditorProps) {
                 } border`}
               >
                 <div className="flex items-center justify-between mb-1">
-                  <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>{npc.name}</span>
+                  <span className={`font-medium ${isDark ? 'text-white' : 'text-gray-900'}`}>
+                    {npc.name}
+                  </span>
                   <button
-                    onClick={e => {
+                    onClick={(e) => {
                       e.stopPropagation()
                       handleDeleteNPC(npc.id)
                     }}
@@ -134,7 +138,9 @@ function NPCEditor({ npcs, mapData, onChange, isDark }: NPCEditorProps) {
       <div className={`flex-1 overflow-auto p-4 ${isDark ? 'bg-gray-900' : 'bg-gray-50'}`}>
         {selectedNPC ? (
           <div className="mb-4">
-            <div className={`text-sm font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+            <div
+              className={`text-sm font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}
+            >
               「{selectedNPC.name}」の配置: マップをクリックして位置を変更
             </div>
           </div>
@@ -155,7 +161,7 @@ function NPCEditor({ npcs, mapData, onChange, isDark }: NPCEditorProps) {
           >
             {mapData.tiles.map((row, y) =>
               row.map((tile, x) => {
-                const npcHere = npcs.find(n => n.x === x && n.y === y)
+                const npcHere = npcs.find((n) => n.x === x && n.y === y)
                 const isSelected = selectedNPC && selectedNPC.x === x && selectedNPC.y === y
 
                 return (
@@ -167,7 +173,7 @@ function NPCEditor({ npcs, mapData, onChange, isDark }: NPCEditorProps) {
                     style={{
                       backgroundColor: npcHere
                         ? `#${npcHere.color.toString(16).padStart(6, '0')}`
-                        : TILE_COLORS[tile as TileType] ?? TILE_COLORS[TileType.GRASS],
+                        : (TILE_COLORS[tile as TileType] ?? TILE_COLORS[TileType.GRASS]),
                     }}
                     onClick={() => handleMapClick(x, y)}
                     title={npcHere ? `${npcHere.name} (${x}, ${y})` : `(${x}, ${y})`}
@@ -196,69 +202,87 @@ function NPCEditor({ npcs, mapData, onChange, isDark }: NPCEditorProps) {
             <h2 className="text-xl font-bold mb-4">NPC追加</h2>
             <div className="space-y-4">
               <div>
-                <label className={`block text-sm font-medium mb-1 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                <label
+                  className={`block text-sm font-medium mb-1 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}
+                >
                   名前
                 </label>
                 <input
                   type="text"
                   value={newNPC.name}
-                  onChange={e => setNewNPC({ ...newNPC, name: e.target.value })}
+                  onChange={(e) => setNewNPC({ ...newNPC, name: e.target.value })}
                   className={`w-full px-3 py-2 border rounded ${
-                    isDark ? 'bg-gray-700 border-gray-600 text-white' : 'bg-white border-gray-300 text-gray-900'
+                    isDark
+                      ? 'bg-gray-700 border-gray-600 text-white'
+                      : 'bg-white border-gray-300 text-gray-900'
                   }`}
                   placeholder="村人"
                 />
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className={`block text-sm font-medium mb-1 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                  <label
+                    className={`block text-sm font-medium mb-1 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}
+                  >
                     X座標
                   </label>
                   <input
                     type="number"
                     value={newNPC.x}
-                    onChange={e => setNewNPC({ ...newNPC, x: parseInt(e.target.value) ?? 0 })}
+                    onChange={(e) => setNewNPC({ ...newNPC, x: parseInt(e.target.value) ?? 0 })}
                     className={`w-full px-3 py-2 border rounded ${
-                      isDark ? 'bg-gray-700 border-gray-600 text-white' : 'bg-white border-gray-300 text-gray-900'
+                      isDark
+                        ? 'bg-gray-700 border-gray-600 text-white'
+                        : 'bg-white border-gray-300 text-gray-900'
                     }`}
                   />
                 </div>
                 <div>
-                  <label className={`block text-sm font-medium mb-1 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                  <label
+                    className={`block text-sm font-medium mb-1 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}
+                  >
                     Y座標
                   </label>
                   <input
                     type="number"
                     value={newNPC.y}
-                    onChange={e => setNewNPC({ ...newNPC, y: parseInt(e.target.value) ?? 0 })}
+                    onChange={(e) => setNewNPC({ ...newNPC, y: parseInt(e.target.value) ?? 0 })}
                     className={`w-full px-3 py-2 border rounded ${
-                      isDark ? 'bg-gray-700 border-gray-600 text-white' : 'bg-white border-gray-300 text-gray-900'
+                      isDark
+                        ? 'bg-gray-700 border-gray-600 text-white'
+                        : 'bg-white border-gray-300 text-gray-900'
                     }`}
                   />
                 </div>
               </div>
               <div>
-                <label className={`block text-sm font-medium mb-1 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                <label
+                  className={`block text-sm font-medium mb-1 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}
+                >
                   メッセージ
                 </label>
                 <textarea
                   value={newNPC.message}
-                  onChange={e => setNewNPC({ ...newNPC, message: e.target.value })}
+                  onChange={(e) => setNewNPC({ ...newNPC, message: e.target.value })}
                   className={`w-full px-3 py-2 border rounded ${
-                    isDark ? 'bg-gray-700 border-gray-600 text-white' : 'bg-white border-gray-300 text-gray-900'
+                    isDark
+                      ? 'bg-gray-700 border-gray-600 text-white'
+                      : 'bg-white border-gray-300 text-gray-900'
                   }`}
                   rows={3}
                   placeholder="こんにちは！"
                 />
               </div>
               <div>
-                <label className={`block text-sm font-medium mb-1 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                <label
+                  className={`block text-sm font-medium mb-1 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}
+                >
                   色 (16進数)
                 </label>
                 <input
                   type="text"
                   value={`#${newNPC.color?.toString(16).padStart(6, '0')}`}
-                  onChange={e => {
+                  onChange={(e) => {
                     const hex = e.target.value.replace('#', '')
                     const num = parseInt(hex, 16)
                     if (!isNaN(num)) {
@@ -266,7 +290,9 @@ function NPCEditor({ npcs, mapData, onChange, isDark }: NPCEditorProps) {
                     }
                   }}
                   className={`w-full px-3 py-2 border rounded ${
-                    isDark ? 'bg-gray-700 border-gray-600 text-white' : 'bg-white border-gray-300 text-gray-900'
+                    isDark
+                      ? 'bg-gray-700 border-gray-600 text-white'
+                      : 'bg-white border-gray-300 text-gray-900'
                   }`}
                   placeholder="#ff6b6b"
                 />
@@ -286,7 +312,9 @@ function NPCEditor({ npcs, mapData, onChange, isDark }: NPCEditorProps) {
               <button
                 onClick={handleAddNPC}
                 className={`px-4 py-2 rounded font-medium transition-colors ${
-                  isDark ? 'bg-blue-600 hover:bg-blue-700 text-white' : 'bg-blue-500 hover:bg-blue-600 text-white'
+                  isDark
+                    ? 'bg-blue-600 hover:bg-blue-700 text-white'
+                    : 'bg-blue-500 hover:bg-blue-600 text-white'
                 }`}
               >
                 追加

--- a/frontend/src/components/ProjectList.tsx
+++ b/frontend/src/components/ProjectList.tsx
@@ -36,7 +36,9 @@ function ProjectList({ apiBaseUrl, isDark, onSelectProject }: ProjectListProps) 
 
   if (loading) {
     return (
-      <div className={`flex items-center justify-center h-full ${isDark ? 'bg-gray-900 text-white' : 'bg-white text-gray-900'}`}>
+      <div
+        className={`flex items-center justify-center h-full ${isDark ? 'bg-gray-900 text-white' : 'bg-white text-gray-900'}`}
+      >
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
           <p>読み込み中...</p>
@@ -46,8 +48,12 @@ function ProjectList({ apiBaseUrl, isDark, onSelectProject }: ProjectListProps) 
   }
 
   return (
-    <div className={`flex flex-col items-center justify-center h-full p-8 ${isDark ? 'bg-gray-900' : 'bg-gray-50'}`}>
-      <div className={`w-full max-w-2xl ${isDark ? 'bg-gray-800' : 'bg-white'} rounded-lg shadow-xl p-8`}>
+    <div
+      className={`flex flex-col items-center justify-center h-full p-8 ${isDark ? 'bg-gray-900' : 'bg-gray-50'}`}
+    >
+      <div
+        className={`w-full max-w-2xl ${isDark ? 'bg-gray-800' : 'bg-white'} rounded-lg shadow-xl p-8`}
+      >
         <h2 className={`text-2xl font-bold mb-6 ${isDark ? 'text-white' : 'text-gray-900'}`}>
           プロジェクトを選択
         </h2>

--- a/frontend/src/components/SaveDiscardButtons.tsx
+++ b/frontend/src/components/SaveDiscardButtons.tsx
@@ -67,74 +67,85 @@ function SaveDiscardButtons({
 
       {/* アンドゥ/セーブボタン */}
       <div className="flex gap-2">
-      {/* アンドゥボタン */}
-      <button
-        className={`w-12 h-12 flex items-center justify-center transition-colors rounded-lg shadow-md border ${
-          hasUnsavedChanges && !isSaving
-            ? isDark
-              ? 'bg-gray-700 text-white border-gray-600 hover:bg-gray-600'
-              : 'bg-gray-400 text-white border-gray-300 hover:bg-gray-500'
-            : isDark
-              ? 'bg-gray-800 text-gray-500 border-gray-700 cursor-not-allowed'
-              : 'bg-gray-200 text-gray-400 border-gray-300 cursor-not-allowed'
-        }`}
-        onClick={onDiscard}
-        disabled={!hasUnsavedChanges || isSaving}
-        title={hasUnsavedChanges ? '変更を破棄' : '変更なし'}
-      >
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"
-          />
-        </svg>
-      </button>
-
-      {/* セーブボタン */}
-      <button
-        className={`w-12 h-12 flex items-center justify-center transition-colors rounded-lg shadow-md border ${
-          hasUnsavedChanges && !isSaving
-            ? isDark
-              ? 'bg-blue-600 text-white border-blue-500 hover:bg-blue-700'
-              : 'bg-blue-500 text-white border-blue-400 hover:bg-blue-600'
-            : isDark
-              ? 'bg-gray-800 text-gray-500 border-gray-700 cursor-not-allowed'
-              : 'bg-gray-200 text-gray-400 border-gray-300 cursor-not-allowed'
-        }`}
-        onClick={onSave}
-        disabled={!hasUnsavedChanges || isSaving}
-        title={hasUnsavedChanges ? 'Gitにコミット・プッシュ' : '保存済み'}
-      >
-        {isSaving ? (
-          <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-          </svg>
-        ) : (
+        {/* アンドゥボタン */}
+        <button
+          className={`w-12 h-12 flex items-center justify-center transition-colors rounded-lg shadow-md border ${
+            hasUnsavedChanges && !isSaving
+              ? isDark
+                ? 'bg-gray-700 text-white border-gray-600 hover:bg-gray-600'
+                : 'bg-gray-400 text-white border-gray-300 hover:bg-gray-500'
+              : isDark
+                ? 'bg-gray-800 text-gray-500 border-gray-700 cursor-not-allowed'
+                : 'bg-gray-200 text-gray-400 border-gray-300 cursor-not-allowed'
+          }`}
+          onClick={onDiscard}
+          disabled={!hasUnsavedChanges || isSaving}
+          title={hasUnsavedChanges ? '変更を破棄' : '変更なし'}
+        >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               strokeLinecap="round"
               strokeLinejoin="round"
               strokeWidth={2}
-              d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z"
-            />
-            <polyline
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              points="17 21 17 13 7 13 7 21"
-            />
-            <polyline
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              points="7 3 7 8 15 8"
+              d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6"
             />
           </svg>
-        )}
-      </button>
+        </button>
+
+        {/* セーブボタン */}
+        <button
+          className={`w-12 h-12 flex items-center justify-center transition-colors rounded-lg shadow-md border ${
+            hasUnsavedChanges && !isSaving
+              ? isDark
+                ? 'bg-blue-600 text-white border-blue-500 hover:bg-blue-700'
+                : 'bg-blue-500 text-white border-blue-400 hover:bg-blue-600'
+              : isDark
+                ? 'bg-gray-800 text-gray-500 border-gray-700 cursor-not-allowed'
+                : 'bg-gray-200 text-gray-400 border-gray-300 cursor-not-allowed'
+          }`}
+          onClick={onSave}
+          disabled={!hasUnsavedChanges || isSaving}
+          title={hasUnsavedChanges ? 'Gitにコミット・プッシュ' : '保存済み'}
+        >
+          {isSaving ? (
+            <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              ></circle>
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              ></path>
+            </svg>
+          ) : (
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z"
+              />
+              <polyline
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                points="17 21 17 13 7 13 7 21"
+              />
+              <polyline
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                points="7 3 7 8 15 8"
+              />
+            </svg>
+          )}
+        </button>
       </div>
     </div>
   )

--- a/frontend/src/game/AudioManager.ts
+++ b/frontend/src/game/AudioManager.ts
@@ -14,7 +14,11 @@ export class AudioManager {
   private currentBgmUrl: string | null = null
   private audioCache: Map<string, AudioBuffer> = new Map()
   private bgmRequestId = 0
-  private fadingNodes: { source: AudioBufferSourceNode; gain: GainNode; timer: ReturnType<typeof setTimeout> }[] = []
+  private fadingNodes: {
+    source: AudioBufferSourceNode
+    gain: GainNode
+    timer: ReturnType<typeof setTimeout>
+  }[] = []
 
   /**
    * AudioContext を生成/再開する。

--- a/frontend/src/game/BacklogOverlay.ts
+++ b/frontend/src/game/BacklogOverlay.ts
@@ -131,7 +131,12 @@ export class BacklogOverlay extends Container {
 
     // マスク（タイトル下からスクリーン下端まで）
     this.maskGraphics = new Graphics()
-    this.maskGraphics.rect(0, TEXT_PADDING_TOP, this.screenWidth, this.screenHeight - TEXT_PADDING_TOP - TEXT_PADDING_BOTTOM)
+    this.maskGraphics.rect(
+      0,
+      TEXT_PADDING_TOP,
+      this.screenWidth,
+      this.screenHeight - TEXT_PADDING_TOP - TEXT_PADDING_BOTTOM
+    )
     this.maskGraphics.fill(0xffffff)
     this.addChild(this.maskGraphics)
 

--- a/frontend/src/game/ChoiceOverlay.ts
+++ b/frontend/src/game/ChoiceOverlay.ts
@@ -23,7 +23,7 @@ export class ChoiceOverlay extends Container {
 
   constructor(
     private screenWidth: number,
-    private screenHeight: number,
+    private screenHeight: number
   ) {
     super()
     this.eventMode = 'static'

--- a/frontend/src/game/SaveLoadOverlay.ts
+++ b/frontend/src/game/SaveLoadOverlay.ts
@@ -245,11 +245,7 @@ export class SaveLoadOverlay extends Container {
     this.addChild(closeBtn)
   }
 
-  private createButton(
-    label: string,
-    textStyle: TextStyle,
-    onClick: () => void,
-  ): Container {
+  private createButton(label: string, textStyle: TextStyle, onClick: () => void): Container {
     const container = new Container()
     container.eventMode = 'static'
     container.cursor = 'pointer'

--- a/frontend/src/game/resolveEvents.test.ts
+++ b/frontend/src/game/resolveEvents.test.ts
@@ -21,10 +21,7 @@ describe('resolveEvents', () => {
       { Narration: { text: ['後'] } },
     ]
     const result = resolveEvents(events, gs)
-    expect(result).toEqual([
-      { Narration: { text: ['前'] } },
-      { Narration: { text: ['後'] } },
-    ])
+    expect(result).toEqual([{ Narration: { text: ['前'] } }, { Narration: { text: ['後'] } }])
   })
 
   it('Condition が真なら内部 events を展開する', () => {
@@ -59,10 +56,7 @@ describe('resolveEvents', () => {
       },
     ]
     const result = resolveEvents(events, gs)
-    expect(result).toEqual([
-      { Narration: { text: ['外側'] } },
-      { Narration: { text: ['内側'] } },
-    ])
+    expect(result).toEqual([{ Narration: { text: ['外側'] } }, { Narration: { text: ['内側'] } }])
   })
 
   it('ネストした Condition の内側が偽なら内側だけスキップする', () => {
@@ -104,9 +98,7 @@ describe('resolveEvents', () => {
     const gs = new GameState()
     gs.setFlag('a', { Bool: true })
     const inner: Event[] = [{ Narration: { text: ['展開'] } }]
-    const events: Event[] = [
-      { Condition: { flag: 'a', events: inner } },
-    ]
+    const events: Event[] = [{ Condition: { flag: 'a', events: inner } }]
     const eventsCopy = JSON.parse(JSON.stringify(events))
     resolveEvents(events, gs)
     expect(events).toEqual(eventsCopy)

--- a/frontend/src/game/rpgProjectFromDoc.test.ts
+++ b/frontend/src/game/rpgProjectFromDoc.test.ts
@@ -548,9 +548,7 @@ describe('applyRpgProjectToDoc', () => {
       expect(villageFirst.RpgMap.tiles[0]).toEqual([1, 1, 1, 1])
     }
     // Ch1 村の NPC が差し替わっている
-    const villageNpc = villageEvents.find(
-      (e) => typeof e !== 'string' && 'Npc' in e
-    )
+    const villageNpc = villageEvents.find((e) => typeof e !== 'string' && 'Npc' in e)
     expect(villageNpc).toBeDefined()
     if (villageNpc && typeof villageNpc !== 'string' && 'Npc' in villageNpc) {
       expect(villageNpc.Npc.id).toBe('new-villager')
@@ -572,9 +570,7 @@ describe('applyRpgProjectToDoc', () => {
         [2, 2, 2],
       ])
     }
-    const dungeonNpc = dungeonEvents.find(
-      (e) => typeof e !== 'string' && 'Npc' in e
-    )
+    const dungeonNpc = dungeonEvents.find((e) => typeof e !== 'string' && 'Npc' in e)
     expect(dungeonNpc).toBeDefined()
     if (dungeonNpc && typeof dungeonNpc !== 'string' && 'Npc' in dungeonNpc) {
       expect(dungeonNpc.Npc.id).toBe('boss')

--- a/frontend/src/screens/AssetsScreen.tsx
+++ b/frontend/src/screens/AssetsScreen.tsx
@@ -190,10 +190,13 @@ function AssetsScreen({
         const formData = new FormData()
         formData.append('file', file)
 
-        const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}`, {
-          method: 'POST',
-          body: formData,
-        })
+        const response = await fetch(
+          `${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}`,
+          {
+            method: 'POST',
+            body: formData,
+          }
+        )
 
         if (!response.ok) {
           throw new Error(`Failed to upload ${file.name}: ${response.status}`)
@@ -219,9 +222,12 @@ function AssetsScreen({
     if (!deletingAsset) return
 
     try {
-      const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}/${deletingAsset.name}`, {
-        method: 'DELETE',
-      })
+      const response = await fetch(
+        `${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}/${deletingAsset.name}`,
+        {
+          method: 'DELETE',
+        }
+      )
 
       if (!response.ok) {
         throw new Error(`Failed to delete ${deletingAsset.name}: ${response.status}`)
@@ -306,10 +312,14 @@ function AssetsScreen({
 
   return (
     <div className={`flex flex-col h-screen ${isDark ? 'dark bg-gray-900' : 'bg-white'}`}>
-      <header className={`border-b ${isDark ? 'border-gray-700 bg-gray-900' : 'border-blue-200 bg-blue-50'}`}>
+      <header
+        className={`border-b ${isDark ? 'border-gray-700 bg-gray-900' : 'border-blue-200 bg-blue-50'}`}
+      >
         <div className="px-6 py-2 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <h1 className={`text-lg font-semibold flex items-center gap-2 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            <h1
+              className={`text-lg font-semibold flex items-center gap-2 ${isDark ? 'text-white' : 'text-gray-900'}`}
+            >
               <span>Name × Name</span>
               <span className={isDark ? 'text-gray-500' : 'text-gray-400'}>-</span>
               <button
@@ -364,14 +374,21 @@ function AssetsScreen({
                   strokeWidth={2}
                   d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
                 />
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                />
               </svg>
             </button>
           </div>
         </div>
 
         {/* タブ */}
-        <div className={`flex items-center border-t ${isDark ? 'border-gray-700' : 'border-gray-200'}`}>
+        <div
+          className={`flex items-center border-t ${isDark ? 'border-gray-700' : 'border-gray-200'}`}
+        >
           <div className="flex flex-1">
             {(['images', 'sounds', 'movies', 'ideas'] as AssetType[]).map((type) => (
               <button
@@ -399,7 +416,12 @@ function AssetsScreen({
             title="閉じる"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
             </svg>
           </button>
         </div>
@@ -407,7 +429,9 @@ function AssetsScreen({
 
       <main className="flex-1 overflow-hidden flex">
         {/* アセット一覧 */}
-        <div className={`w-96 border-r ${isDark ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-gray-50'} flex flex-col`}>
+        <div
+          className={`w-96 border-r ${isDark ? 'border-gray-700 bg-gray-800' : 'border-gray-200 bg-gray-50'} flex flex-col`}
+        >
           {/* 検索・フィルター領域 */}
           <div className={`p-4 border-b ${isDark ? 'border-gray-700' : 'border-gray-200'}`}>
             <div className="relative">
@@ -493,7 +517,9 @@ function AssetsScreen({
                       )}
 
                       <div className="flex-1 min-w-0">
-                        <div className={`text-sm font-medium truncate ${isDark ? 'text-gray-200' : 'text-gray-900'}`}>
+                        <div
+                          className={`text-sm font-medium truncate ${isDark ? 'text-gray-200' : 'text-gray-900'}`}
+                        >
                           {asset.name}
                         </div>
                         <div className={`text-xs ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
@@ -527,7 +553,12 @@ function AssetsScreen({
                         }`}
                         title="削除"
                       >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
                           <path
                             strokeLinecap="round"
                             strokeLinejoin="round"
@@ -583,7 +614,9 @@ function AssetsScreen({
         <div className="flex-1 overflow-y-auto">
           {selectedAsset ? (
             <div className="p-8">
-              <h2 className={`text-xl font-semibold mb-4 ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              <h2
+                className={`text-xl font-semibold mb-4 ${isDark ? 'text-white' : 'text-gray-900'}`}
+              >
                 {selectedAsset.name}
               </h2>
 
@@ -631,7 +664,11 @@ function AssetsScreen({
 
               {/* タグ管理 */}
               <div className={`mt-6 p-4 rounded-lg ${isDark ? 'bg-gray-800' : 'bg-gray-50'}`}>
-                <h3 className={`text-sm font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>タグ</h3>
+                <h3
+                  className={`text-sm font-medium mb-2 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}
+                >
+                  タグ
+                </h3>
                 <div className="flex flex-wrap gap-1 mb-2">
                   {selectedAsset.tags.map((tag) => (
                     <span
@@ -686,7 +723,12 @@ function AssetsScreen({
             <div className="flex items-center justify-center h-full">
               <div className={`text-center ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
                 {selectedType === 'images' && (
-                  <svg className="w-16 h-16 mx-auto mb-4 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg
+                    className="w-16 h-16 mx-auto mb-4 opacity-50"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"
@@ -696,7 +738,12 @@ function AssetsScreen({
                   </svg>
                 )}
                 {selectedType === 'sounds' && (
-                  <svg className="w-16 h-16 mx-auto mb-4 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg
+                    className="w-16 h-16 mx-auto mb-4 opacity-50"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"
@@ -706,7 +753,12 @@ function AssetsScreen({
                   </svg>
                 )}
                 {selectedType === 'movies' && (
-                  <svg className="w-16 h-16 mx-auto mb-4 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg
+                    className="w-16 h-16 mx-auto mb-4 opacity-50"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"
@@ -716,7 +768,12 @@ function AssetsScreen({
                   </svg>
                 )}
                 {selectedType === 'ideas' && (
-                  <svg className="w-16 h-16 mx-auto mb-4 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg
+                    className="w-16 h-16 mx-auto mb-4 opacity-50"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"

--- a/frontend/src/screens/EditorScreen.tsx
+++ b/frontend/src/screens/EditorScreen.tsx
@@ -79,12 +79,10 @@ function EditorScreen({
   // 未設定または doc に存在しない場合は最初の RPG シーンにフォールバックする。
   const rpgProject: RPGProject | null = useMemo(() => {
     if (!doc) return null
-    const explicitFound =
-      rpgSceneId !== null ? findRpgSceneIndex(doc, rpgSceneId) : null
+    const explicitFound = rpgSceneId !== null ? findRpgSceneIndex(doc, rpgSceneId) : null
     const found = explicitFound ?? findRpgSceneIndex(doc)
     if (!found) return null
-    const sceneIdForThisDoc =
-      doc.chapters[found.chapterIndex]?.scenes[found.sceneIndex]?.id ?? null
+    const sceneIdForThisDoc = doc.chapters[found.chapterIndex]?.scenes[found.sceneIndex]?.id ?? null
     return rpgProjectFromDoc(doc, sceneIdForThisDoc ?? undefined, projectName)
   }, [doc, projectName, rpgSceneId])
 
@@ -564,7 +562,9 @@ function EditorScreen({
 
             <div className="flex-1 overflow-hidden">
               {rpgProject === null ? (
-                <div className={`h-full flex flex-col items-center justify-center gap-4 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}>
+                <div
+                  className={`h-full flex flex-col items-center justify-center gap-4 ${isDark ? 'text-gray-300' : 'text-gray-700'}`}
+                >
                   <p className="text-sm">このプロジェクトにはまだRPGシーンがありません。</p>
                   <button
                     onClick={addEmptyRpgScene}

--- a/frontend/src/screens/ProjectListScreen.tsx
+++ b/frontend/src/screens/ProjectListScreen.tsx
@@ -79,11 +79,7 @@ function ProjectListScreen({
       </header>
 
       <main className="flex-1 overflow-hidden">
-        <ProjectList
-          apiBaseUrl={apiBaseUrl}
-          isDark={isDark}
-          onSelectProject={onSelectProject}
-        />
+        <ProjectList apiBaseUrl={apiBaseUrl} isDark={isDark} onSelectProject={onSelectProject} />
       </main>
     </div>
   )


### PR DESCRIPTION
## 関連 Issue
closes #57

## 変更内容

### コミット1: Prettier 一括適用（14ファイル）
`npx prettier --write "src/**/*.{ts,tsx,css}"` を実行。main 由来の既存 Prettier エラー 127 件を一掃。機能的な変更はなし。

### コミット2: husky + lint-staged の pre-commit フック整備
- `.husky/pre-commit` 新規作成（`cd frontend && npx lint-staged`）
- `frontend/package.json` の `prepare` スクリプトを monorepo 構造に対応
  - `.git` はリポジトリルート、`package.json` は `frontend/` という変則構造のため、`cd .. && frontend/node_modules/husky/bin.js` を呼ぶ
- `frontend/.lintstagedrc.json` は既存のものをそのまま利用（ts/tsx→eslint+prettier、css/json/md→prettier）

## 検証
- `npm run lint` エラー0
- `npm run type-check` エラー0
- `npm run test -- --run` 27/27 PASS
- pre-commit 実地検証: ダミーコミット時に prettier が発火することを確認済（agent 報告）

## 注意
差分の大半は Prettier によるフォーマット変更です。レビュー観点は pre-commit フック部分に集中することを推奨。