### PR TITLE
fix: #54 RaycastRenderer 近距離NPC消失を解消

### DIFF
--- a/frontend/src/game/RaycastRenderer.ts
+++ b/frontend/src/game/RaycastRenderer.ts
@@ -543,15 +543,23 @@ export class RaycastRenderer {
     const invDet = 1.0 / (planeX * dirY - dirX * planeY)
     for (const entry of npcSprites) {
       const n = entry.npc
+      // プレイヤーと同タイルに立っている NPC は描画不要（衝突判定で発生しないが保険）
+      const nTileX = Math.floor(n.x)
+      const nTileY = Math.floor(n.y)
+      const pTileX = Math.floor(this.playerX)
+      const pTileY = Math.floor(this.playerY)
+      if (nTileX === pTileX && nTileY === pTileY) continue
       const rx = n.x - this.playerX
       const ry = n.y - this.playerY
       const transformX = invDet * (dirY * rx - dirX * ry)
       const transformY = invDet * (-planeY * rx + planeX * ry) // これが depth
 
-      if (transformY <= 0.05) continue // 後ろ or 至近
+      if (transformY <= 0.01) continue // 後ろ or ゼロ除算ガードのみ
 
       const spriteScreenX = Math.floor((w / 2) * (1 + transformX / transformY))
-      const spriteHeight = Math.abs(Math.floor(h / transformY))
+      // 極小 transformY でスプライトが青天井に肥大化するのを防ぐ。分母に下限を設ける
+      const clampedDepth = Math.max(transformY, 0.1)
+      const spriteHeight = Math.abs(Math.floor(h / clampedDepth))
       const spriteWidthPx = spriteHeight
       let drawStartY = Math.floor(-spriteHeight / 2 + h / 2)
       if (drawStartY < 0) drawStartY = 0

--- a/frontend/src/game/RaycastRenderer.ts
+++ b/frontend/src/game/RaycastRenderer.ts
@@ -57,6 +57,10 @@ export class RaycastRenderer {
   // フォグ上限 12 タイル: マップサイズ（通常 16x12 前後）に対して「遠くの壁は薄く霞む」ことを狙った値。
   // 大きくすると遠景まで鮮明に見えて没入感が減り、小さくすると視界が狭く感じる。
   private readonly fogMaxDist = 12
+  // NPC スプライトサイズ算出時の深度下限。極小 transformY でスプライト高が青天井に肥大化するのを防ぐ。
+  // 0.1 = 画面高の10倍まで許容 → drawStart/End の既存クランプで画面内に収まるサイズ。
+  // 幾何的な位置（spriteScreenX）や z-buffer 比較には適用しない（遮蔽整合性のため）。
+  private readonly npcSpriteMinDepth = 0.1
 
   private keys = new Set<string>()
   private lastTickMs = 0
@@ -541,24 +545,27 @@ export class RaycastRenderer {
 
     // 逆行列: [planeX dirX; planeY dirY]^-1
     const invDet = 1.0 / (planeX * dirY - dirX * planeY)
+    const playerTileX = Math.floor(this.playerX)
+    const playerTileY = Math.floor(this.playerY)
     for (const entry of npcSprites) {
       const n = entry.npc
-      // プレイヤーと同タイルに立っている NPC は描画不要（衝突判定で発生しないが保険）
-      const nTileX = Math.floor(n.x)
-      const nTileY = Math.floor(n.y)
-      const pTileX = Math.floor(this.playerX)
-      const pTileY = Math.floor(this.playerY)
-      if (nTileX === pTileX && nTileY === pTileY) continue
+      // プレイヤーと同タイルに立っている NPC は描画不要（衝突判定で発生しないが保険）。
+      // 壁めり込み等の異常状態でここに達した場合、後段の z-buffer 比較でも
+      // 近距離 NPC が誤って奥判定される可能性があるため、先頭で弾く。
+      const npcTileX = Math.floor(n.x)
+      const npcTileY = Math.floor(n.y)
+      if (npcTileX === playerTileX && npcTileY === playerTileY) continue
       const rx = n.x - this.playerX
       const ry = n.y - this.playerY
       const transformX = invDet * (dirY * rx - dirX * ry)
       const transformY = invDet * (-planeY * rx + planeX * ry) // これが depth
 
-      if (transformY <= 0.01) continue // 後ろ or ゼロ除算ガードのみ
+      if (transformY <= 0.01) continue // 背面カリング兼ゼロ除算ガード
 
       const spriteScreenX = Math.floor((w / 2) * (1 + transformX / transformY))
-      // 極小 transformY でスプライトが青天井に肥大化するのを防ぐ。分母に下限を設ける
-      const clampedDepth = Math.max(transformY, 0.1)
+      // 幾何的な位置（spriteScreenX）と遮蔽判定（後段の zBuffer 比較）には元の transformY を使い、
+      // サイズ算出のみ下限でクランプする（位置まで固定するとカメラ前に貼り付く）。
+      const clampedDepth = Math.max(transformY, this.npcSpriteMinDepth)
       const spriteHeight = Math.abs(Math.floor(h / clampedDepth))
       const spriteWidthPx = spriteHeight
       let drawStartY = Math.floor(-spriteHeight / 2 + h / 2)


### PR DESCRIPTION
## 関連 Issue
closes #54

## 変更内容

`frontend/src/game/RaycastRenderer.ts` の NPC 描画ループを修正。Issue の3案を複合採用。

### 修正1: transformY 閾値を下げる
`transformY <= 0.05 ? continue` → `transformY <= 0.01 ? continue`。
0.05 は視覚的カリングとして働き「近距離で一瞬消える」原因になっていた。ゼロ除算防止の純粋な epsilon として 0.01 に変更。

### 修正2: spriteHeight/Width の分母をクランプ
`h / transformY` → `h / Math.max(transformY, 0.1)`。
極小 transformY でサイズが青天井に肥大化するのを防ぐ。drawStartY/drawEndY は既存のクランプで画面内に収まるため、巨大サイズでの描画クラッシュや異常な計算量を排除。
`spriteScreenX` は視野角上の実位置なので**元の transformY を維持**（クランプすると画面中央に貼り付いてしまう）。

### 修正3: 同一タイル NPC のスキップ（防御的）
`Math.floor(n.x) === Math.floor(playerX) && Math.floor(n.y) === Math.floor(playerY)` なら continue。衝突判定で発生しないが安全網として追加。transformY 計算より前に配置し無駄計算を省く。

## 検証
- `npm run lint` エラーゼロ
- `npm run type-check` エラーゼロ
- `npm run test -- --run` 27/27 PASS
- 実機確認（通常プレイで NPC 消失なしの確認）は別途