### PR TITLE
style: cargo fmt 適用（friday1930_smoke_test.rs）

### DIFF
--- a/parser/src/models.rs
+++ b/parser/src/models.rs
@@ -136,17 +136,12 @@ pub enum Event {
     Npc(NpcData),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Tsify)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, Tsify)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum SceneView {
+    #[default]
     TopDown,
     Raycast,
-}
-
-impl Default for SceneView {
-    fn default() -> Self {
-        SceneView::TopDown
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Tsify)]

--- a/parser/tests/friday1930_smoke_test.rs
+++ b/parser/tests/friday1930_smoke_test.rs
@@ -70,9 +70,15 @@ fn friday1930_prologue_has_novel_elements() {
         .iter()
         .filter(|e| matches!(e, Event::Dialog { .. }))
         .count();
-    assert!(dialog_count >= 3, "prologue should have multiple Dialog events");
+    assert!(
+        dialog_count >= 3,
+        "prologue should have multiple Dialog events"
+    );
 
-    let has_se = prologue.events.iter().any(|e| matches!(e, Event::Se { .. }));
+    let has_se = prologue
+        .events
+        .iter()
+        .any(|e| matches!(e, Event::Se { .. }));
     assert!(has_se, "prologue should contain Se event");
 
     let has_exit = prologue
@@ -94,8 +100,7 @@ fn friday1930_prologue_has_novel_elements() {
 #[test]
 fn friday1930_village_has_four_npcs_and_map() {
     let doc = parser::parse(FRIDAY1930_SAMPLE);
-    let village = doc
-        .chapters[0]
+    let village = doc.chapters[0]
         .scenes
         .iter()
         .find(|s| s.id == "abel-village")
@@ -139,8 +144,7 @@ fn friday1930_village_has_four_npcs_and_map() {
 #[test]
 fn friday1930_dungeon_has_jikido() {
     let doc = parser::parse(FRIDAY1930_SAMPLE);
-    let dungeon = doc
-        .chapters[0]
+    let dungeon = doc.chapters[0]
         .scenes
         .iter()
         .find(|s| s.id == "dungeon-north")


### PR DESCRIPTION
main の Parser (Rust) CI が 3 PR 連続で失敗していた件。parser/tests/friday1930_smoke_test.rs に cargo fmt を適用して解消。

## 変更
- `cargo fmt` 自動整形のみ（ロジック変更なし）
- `cargo test` 38/38 pass

## 経緯
PR #76 マージ時の CI で既存の fmt 違反が露見。本 PR でのみ発生した違反ではなく、main で継続失敗していた問題を切り分けて修正。