### PR TITLE
docs: #105 ホスティングアーキテクチャ ADR 転記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,16 +2,18 @@
 
 このファイルは、Claude Codeがこのプロジェクトを理解し、効率的に開発を進めるための情報をまとめたものです。
 
+> **⚠️ ホスティング戦略は 2026-05-08 に転換しました。** 旧計画（FastAPI バックエンド + Docker + GCP デプロイ）は破棄。新方針は「**CF Pages（静的フロント）+ CF Worker（octokit）+ GitHub API（Agasteer 方式）**」です。**正本**: `repos/private/notes/.agasteer/notes/dev/name-name.md` の「ホスティング戦略（2026-05-08 確定）」セクション。`backend/` (FastAPI/GitPython/compose.yaml) は移行完了次第削除されます。本ファイル下記のローカル Docker 手順は**移行期間中の暫定**です。
+
 ## プロジェクト概要
 
 **Name×Name**: ゲームスクリプト言語 + GUIエディタ + ランタイム
 
 - ノベルゲームもRPGも同じ .md ファイルで記述（Markdownスーパーセット）
-- エディタモード: キャンバス上でドラッグ&ドロップで編集（ノベル/RPG共通）
-- ノベルプレイモード: PixiJSでゲーム実行（Phaserから移行済み）
-- RPGプレイモード: PixiJSでゲーム実行（Phaserから移行済み）
-- Git管理: 原稿とアセットをGitで自動バージョン管理
-- ブランチ戦略: develop（開発用）/ main（本番用）
+- **ハード = name-name**、**ソフト = 各ゲームリポ（ogurasia, skirts-colour, friday-1930 等）**
+- エディタとプレイヤーは**同じ React アプリ**で、認証で機能分岐（未ログイン=プレイヤーのみ／kako-jun ログイン=編集UI＋デバッグ追加）
+- ノベル / RPG どちらも PixiJS でゲーム実行（Phaserから移行済み）
+- 永続化: GitHub の各ゲームリポをそのままソース・オブ・トゥルースとし、Worker から GitHub REST API で読み書き
+- ブランチ戦略: develop（編集用）/ main（公開用、`/play/*` から見える）
 
 ## プロジェクト構造（モノレポ）
 
@@ -59,10 +61,10 @@ name-name/
 - パスはOS依存しない形で扱う
 
 ### 3. ブランチ戦略
-- **develop**: 開発・編集用（デフォルト）
-- **main**: 本番公開用
-- ローカル環境はdevelopブランチ
-- 本番環境（GCP）はmainブランチを参照
+- **develop**: 編集用（kako-jun が `/edit/<game>` から触るブランチ）
+- **main**: 公開用（一般ユーザーが `/play/<game>` で見るブランチ）
+- 一般ユーザーには未完成原稿が見えないよう、`/play/*` は `main` を参照する
+- 旧計画（GCP 本番環境が main を参照）は破棄済み
 
 ## 開発環境のセットアップ
 

--- a/README.md
+++ b/README.md
@@ -197,17 +197,19 @@ my-game/                # ゲームプロジェクト（別リポジトリ）
 
 ### インフラ
 - Docker Compose
-- Google Cloud Platform (GCP)
+- Cloudflare Pages（フロント） + Cloudflare Workers（API） + GitHub REST API（永続化）
+- ※ 旧計画の GCP デプロイは破棄。詳細は [docs/adr/0001-hosting-architecture.md](./docs/adr/0001-hosting-architecture.md)
 
 ## ドキュメント
 
+- [docs/adr/0001-hosting-architecture.md](./docs/adr/0001-hosting-architecture.md) - **ホスティングアーキテクチャ ADR（2026-05-08 確定）**
 - [docs/spec/markdown-v0.1.md](./docs/spec/markdown-v0.1.md) - Markdown v0.1 構文仕様
 - [docs/architecture.md](./docs/architecture.md) - アーキテクチャ設計書
 - [docs/guide/controls.md](./docs/guide/controls.md) - 操作ガイド
 - [CLAUDE.md](./CLAUDE.md) - 開発ガイド（Claude Code用）
-- [backend/README.md](./backend/README.md) - バックエンドAPI仕様
+- [backend/README.md](./backend/README.md) - バックエンドAPI仕様（旧 FastAPI、移行期間中の暫定）
 - [backend/ASSETS.md](./backend/ASSETS.md) - アセット管理詳細
-- [backend/BRANCHES.md](./backend/BRANCHES.md) - ブランチ戦略
+- [backend/BRANCHES.md](./backend/BRANCHES.md) - ブランチ戦略（2026-05-08 改訂）
 
 ## ライセンス
 

--- a/backend/BRANCHES.md
+++ b/backend/BRANCHES.md
@@ -1,194 +1,83 @@
 # ブランチ戦略
 
-Name×Nameは、Gitブランチを使って開発環境と本番環境を分離します。
+> **⚠️ 2026-05-08 改訂**
+> 旧版は「ローカル Docker 開発 + GCP 本番」前提でしたが、**ホスティング戦略は CF Pages + CF Worker + GitHub API（Agasteer 方式）に転換**しました。本ファイルもそれに合わせて書き直しています。
+> 正本（永続的な意思決定記録）: `repos/private/notes/.agasteer/notes/dev/name-name.md` の「ホスティング戦略（2026-05-08 確定）」セクション。
+> 旧版で説明されていた「FastAPI に POST してブランチ切替」「`backend/projects/` に clone」「GCP 本番環境」はすべて廃止予定です。
 
 ## ブランチの役割
 
-### `develop` ブランチ（デフォルト）
-- **用途**: 原稿の編集・テスト
-- **環境**: ローカル開発環境（localhost）
+各ゲームリポ（`kako-jun/ogurasia`, `kako-jun/skirts-colour`, `kako-jun/friday-1930` 等）は2本のブランチを持ちます。
+
+### `develop` ブランチ（編集用）
+
+- **誰が触るか**: kako-jun のみ（`name-name.llll-ll.com/edit/<game>` 経由）
+- **どこから触るか**: ブラウザのエディタ → CF Worker → GitHub Contents API → `develop` への commit
 - **特徴**:
   - 自由に編集・保存できる
-  - 本番環境には影響しない
-  - 新しい章やシーンを試作できる
+  - 一般ユーザーから見えない（`/play/*` は main しか参照しない）
+  - 未完成原稿・試作中シーンを置く場所
 
-### `main` ブランチ
-- **用途**: 本番公開用の確定した原稿
-- **環境**: GCP本番環境
+### `main` ブランチ（公開用）
+
+- **誰が見るか**: 一般ユーザー（`name-name.llll-ll.com/play/<game>`）
+- **どう反映するか**: kako-jun が GitHub UI で `develop` → `main` の PR をマージ
 - **特徴**:
-  - ユーザーに見せる完成版
-  - `develop`から十分テストした内容をマージ
-  - 慎重に管理
+  - 確定した原稿のみがマージされる
+  - マージ＝即公開（Worker のキャッシュをパージしてから次のリクエストで反映）
 
 ## ワークフロー
 
-### 1. 通常の開発作業
+### 1. 通常の編集作業
 
 ```
-開発者 → localhost (develop) → GitHub (develop)
+kako-jun (ブラウザ)
+    ↓ /edit/<game> でログイン
+name-name.llll-ll.com (CF Pages, 静的フロント)
+    ↓ fetch
+name-name-api.workers.dev (CF Worker)
+    ↓ GitHub REST API (octokit)
+github.com/kako-jun/<game>  (develop ブランチに commit)
 ```
 
-1. ローカルで`develop`ブランチを使用（デフォルト）
-2. 原稿を編集・保存
-3. 自動的に`develop`ブランチにcommit & push
+1. `/edit/<game>` を開く（CF Access or GitHub OAuth で kako-jun を認証）
+2. Worker が `GET /repos/kako-jun/<game>/contents/...?ref=develop` で内容取得
+3. ブラウザ上で編集
+4. 保存ボタン → Worker が `PUT /repos/.../contents/...` で SHA 付きコミット（`develop` に対して）
 
-### 2. 本番環境への反映
+### 2. 本番反映
 
 ```
-GitHub (develop) → Pull Request → GitHub (main) → GCP (main)
+develop → Pull Request → main → 一般ユーザーから見える
 ```
 
-1. GitHubで`develop`→`main`のPull Requestを作成
-2. 内容を確認してマージ
-3. 本番環境（GCP）が`main`ブランチから自動デプロイ
+1. GitHub 上で `develop` → `main` の PR を作成
+2. kako-jun が確認してマージ
+3. Worker のキャッシュをパージ（保存時 or マージ時に webhook で）
+4. 次の `/play/<game>` リクエストから新しい main が見える
 
-### 3. 本番内容の確認（オプション）
+### 3. 別デバイスでの楽観ロック
 
-開発環境で本番ブランチを確認したい場合：
+Contents API は `sha` 必須。別デバイスで先に編集された場合は 409 が返るので、エディタ側に「最新を取り直す」ボタンを実装して事故を防ぐ。
 
-```bash
-POST /api/projects/{project_name}/switch-branch
-{
-  "branch": "main"
-}
-```
+## 認証
 
-確認後、開発ブランチに戻す：
+- **編集 (`/edit/*`)**: CF Access or GitHub OAuth で kako-jun のみ通過
+- **再生 (`/play/*`)**: ログイン不要
+- **GitHub PAT**: Worker の Secret（`wrangler secret put GITHUB_TOKEN`）に格納。**ブラウザに一切渡さない**
 
-```bash
-POST /api/projects/{project_name}/switch-branch
-{
-  "branch": "develop"
-}
-```
+## 廃止された旧計画（参考）
 
-## API エンドポイント
+以下は旧版の記述で、**現在は使われていません**。順次削除されます。
 
-### プロジェクト作成時にブランチ指定
-
-```bash
-# 新規プロジェクト
-POST /api/projects/init
-{
-  "name": "my-game",
-  "branch": "develop"  # 省略可（デフォルトはdevelop）
-}
-
-# 既存リポジトリをクローン
-POST /api/projects/clone
-{
-  "name": "my-game",
-  "repo_url": "https://github.com/user/my-game.git",
-  "branch": "develop"  # 省略可（デフォルトはdevelop）
-}
-```
-
-### ブランチ切り替え
-
-```bash
-POST /api/projects/{project_name}/switch-branch
-{
-  "branch": "main"
-}
-```
-
-### プロジェクト一覧（ブランチ情報含む）
-
-```bash
-GET /api/projects
-
-# レスポンス
-{
-  "projects": [
-    {
-      "name": "my-game",
-      "path": "/path/to/projects/my-game",
-      "branch": "develop"
-    }
-  ]
-}
-```
-
-## 設定ファイル
-
-各プロジェクトのルートに`.name-name.json`が作成されます：
-
-```json
-{
-  "branch": "develop"
-}
-```
-
-このファイルは**ローカル設定**なので、Gitで管理されません。
-各環境（開発・本番）で異なるブランチを使用できます。
-
-## 環境別の設定例
-
-### ローカル開発環境
-```json
-{
-  "branch": "develop"
-}
-```
-- 編集中の原稿で作業
-- 本番に影響なし
-
-### GCP本番環境
-```json
-{
-  "branch": "main"
-}
-```
-- 確定した原稿をユーザーに配信
-- `main`ブランチのみを参照
-
-## ベストプラクティス
-
-1. **日常的な編集は`develop`で**
-   - 新しい章やシーンは必ず`develop`で作成
-   - 誤字修正も`develop`で行う
-
-2. **こまめにコミット**
-   - 保存のたびに自動コミット
-   - 変更履歴が残るので安心
-
-3. **本番反映は慎重に**
-   - `develop`で十分テストしてから`main`にマージ
-   - Pull Requestでレビューを行う
-
-4. **緊急修正の場合**
-   - 本番で誤字を発見 → `main`ブランチで直接修正も可能
-   - 修正後、`main`→`develop`にもマージして同期
-
-## トラブルシューティング
-
-### 間違えて本番ブランチで編集してしまった
-
-```bash
-# 1. developに切り替え
-POST /api/projects/{project_name}/switch-branch
-{"branch": "develop"}
-
-# 2. mainブランチの変更をdevelopにマージ（GitHubで）
-# または、変更を取り消す
-```
-
-### ブランチの状態がおかしい
-
-```bash
-# プロジェクトを同期
-POST /api/projects/{project_name}/sync
-```
-
-### 設定ファイルを手動で確認
-
-```bash
-cat projects/my-game/.name-name.json
-```
+- `POST /api/projects/{name}/switch-branch` (FastAPI バックエンド) → 廃止
+- `backend/projects/{name}/.git/` にローカルクローン → 廃止（GitHub をそのまま使う）
+- `.name-name.json` の `branch` フィールド → 廃止（ブランチはURL/UIで指定）
+- GCP 本番環境が main を自動デプロイ → 廃止（CF Pages + Worker に置換）
 
 ## まとめ
 
-- **`develop`**: 編集用（デフォルト）
-- **`main`**: 本番公開用
-- 開発環境と本番環境は完全に分離
-- ブランチ切り替えで柔軟に対応可能
+- **`develop`**: 編集用（kako-jun が `/edit/<game>` から触る）
+- **`main`**: 公開用（一般ユーザーが `/play/<game>` で見る）
+- 編集 = Worker → GitHub Contents API で `develop` に commit
+- 公開 = GitHub UI で develop→main マージ → Worker キャッシュパージ

--- a/docs/adr/0001-hosting-architecture.md
+++ b/docs/adr/0001-hosting-architecture.md
@@ -1,0 +1,116 @@
+# ADR 0001: ホスティングアーキテクチャ
+
+- 起票日: 2026-05-08
+- ステータス: Accepted
+- 関連 Issue: #105
+
+## Context（背景）
+
+name-name は当初、以下の構成でローカル開発と本番運用を行う計画だった:
+
+- **ローカル開発**: Docker Compose で FastAPI バックエンド (`http://localhost:7373`) と Vite フロント (`http://localhost:5173`) を立ち上げる
+- **永続化**: バックエンドが GitPython で `backend/projects/<game>/.git/` を直接操作。各ゲームリポはローカルディスクにクローンされる
+- **本番**: GCP に name-name 一式（FastAPI + Vite + 各ゲームリポ）をデプロイし、main ブランチを参照
+
+しかしこの構成には次の問題があった:
+
+1. **公開 URL がない**。kako-jun の手元 PC でしか動かない
+2. **「ブラウザでログインさえすれば編集でき、即本番反映」という運用に構造的に合わない**。push → 別環境が pull → ビルド/再起動 という多段が必要
+3. **マルチデバイスでの編集**ができない（ローカル PC 依存）
+4. **CF Pages（他 kako-jun アプリの標準デプロイ先）に乗らない**。Workers は揮発的で、永続ファイルシステム + git バイナリ + Python ランタイムを要求するこの構成は CF に載らない
+5. **データモデルの歪み**。GitPython で git 作業ツリーを DB の代用にしている
+
+## Decision（決定）
+
+ホスティング戦略を以下に転換する。
+
+### コア構造
+
+- **name-name は「ハード」**。各ゲームリポ（ogurasia, skirts-colour, friday-1930 等）は **「ソフト」（カートリッジ）**
+- エディタとプレイヤーは**同じ React アプリ**。認証で機能が分岐するだけ
+  - 未ログイン: プレイヤーのみ（`/play/<game>`）
+  - kako-jun ログイン済み: 同じプレイヤー画面に編集 UI とデバッグオーバーレイが追加マウントされる（`/edit/<game>`）
+
+### 構成（CF Pages + Worker + GitHub API）
+
+```
+ブラウザ (CF Pages, 静的フロント React+PixiJS+WASM)
+    ↓ fetch
+name-name-api.workers.dev (CF Worker, octokit)
+    ↓ GitHub REST API (Contents API + Git Data API)
+github.com/kako-jun/<game>
+```
+
+- **永続化**: GitHub の各ゲームリポをそのままソース・オブ・トゥルースとする。D1 / R2 は使わない
+- **アセット**: 一般的サイズ（〜5MB）は Contents API、大きいもの（5〜100MB）は Git Data API、>100MB は Git LFS
+- **履歴**: git log がそのまま履歴になる
+- **認証**: CF Access or GitHub OAuth で kako-jun のみ通過。GitHub PAT は Worker Secret に格納（`wrangler secret put GITHUB_TOKEN`）。**ブラウザに一切渡さない**
+- **キャッシュ**: 読み取り側（`/play/*`）は CF Cache API で短時間キャッシュ（30秒〜数分）し、保存時にパージ
+- **楽観ロック**: Contents API は `sha` 必須。別デバイスで先に編集された場合は 409 を返し、エディタ側で「最新を取り直す」を促す
+
+### URL 構造
+
+```
+name-name.llll-ll.com/                 ← ジャンプ風タイトル画面（ゲーム選択）
+name-name.llll-ll.com/play/<game>      ← プレイヤー（一般ユーザー、ログイン不要）
+name-name.llll-ll.com/edit/<game>      ← プレイヤー＋編集UI＋デバッグ（ログイン必須）
+name-name-api.workers.dev/api/...      ← Worker
+```
+
+### ブランチ戦略
+
+- **`develop`**: 編集用。kako-jun が `/edit/<game>` から触る。一般ユーザーから見えない
+- **`main`**: 公開用。`/play/<game>` から見える。`develop` → `main` PR を kako-jun が GitHub UI でマージしたものだけが公開される
+- マージ → Worker キャッシュパージ → 次のリクエストで反映＝**即公開**
+
+### 公開ポリシー
+
+- 各ゲームリポ（ogurasia, skirts-colour, friday-1930 等）は **public のまま**（完成までは隠さない方針）
+- 編集者は **kako-jun のみ**（永続的な仕様）
+
+## Consequences（結果と影響）
+
+### 利点
+
+- **永続化を git から DB に移す大改修が不要**。GitHub をそのまま使う
+- **D1 / R2 不要**。CF Worker 1個で済む
+- **保存→即反映が真に成立する**。ビルドや push の多段がない
+- **マルチデバイスで編集できる**。ブラウザでログインするだけ
+- **他 kako-jun アプリ（orber, 3min, ear-sky 等）と同じ CF Pages デプロイフローに統一**
+- **履歴は git log がそのまま**。バックアップ・diff・rollback が自然
+- **公開 URL `name-name.llll-ll.com` を持てる**
+
+### 廃止される旧計画
+
+- `backend/` (FastAPI + GitPython + projects/) → 移行完了次第削除
+- `compose.yaml` → 削除
+- `backend/BRANCHES.md` の「GCP 本番環境が main を自動デプロイ」記述 → 既に新方針へ書き換え済（旧計画は墓標として「廃止された旧計画」セクションに保存）
+- `POST /api/projects/{name}/switch-branch` 等の FastAPI エンドポイント → 廃止
+
+### トレードオフ
+
+- **GitHub Rate Limit に依存する**（認証付き 5000 req/h）。kako-jun 1人運用ならまず当たらないが、`/play/*` を一般公開するなら Cache API で必ず吸収する
+- **大きいアセットの扱いが2系統に分かれる**（Contents API と Git Data API）。Octokit が helper を提供しているので運用上の負担は小さい
+- **Public リポ前提が崩れたら別方式が要る**。将来 private にしたい場合は Worker 経由で配信に切り替える（GitHub raw URL は使えなくなる）
+
+### 移行作業（Issue 化済）
+
+- #105: ADR 転記（本ドキュメント）
+- #106: CF Worker バックエンド新設
+- #107: フロントの API 層を Worker URL に差し替え
+- #108: EditorScreen / PlayerScreen を権限分岐で1画面に統合
+- #109: ジャンプ風トップページ
+- #110: CF Access or GitHub OAuth で認証
+- #111: CF Pages デプロイ設定
+- #112: 旧 backend 削除
+
+依存関係:
+
+```
+#105 → #106 → (#107, #110) → #108 → (#109, #111) → #112
+```
+
+## 参考
+
+- 永続的な戦略メモ: `repos/private/notes/.agasteer/notes/dev/name-name.md` の「ホスティング戦略（2026-05-08 確定）」セクション
+- Agasteer 方式（参考実装）: `repos/2025/agasteer/src/lib/api/sync.ts`


### PR DESCRIPTION
## Summary

- 2026-05-08 にホスティング戦略を「FastAPI + GitPython + GCP」から「CF Pages + CF Worker + GitHub REST API（Agasteer 方式）」に転換した決定を ADR として転記
- `docs/adr/0001-hosting-architecture.md` を新設
- `README.md` / `CLAUDE.md` / `backend/BRANCHES.md` の旧 GCP 記述を新方針に整合

## Context

正本（永続的な戦略メモ）: `repos/private/notes/.agasteer/notes/dev/name-name.md` の「ホスティング戦略（2026-05-08 確定）」セクション。本 ADR はその要点を name-name リポ内に常駐させるためのもの。

## Decision

- name-name = ハード、各ゲームリポ = ソフト
- エディタとプレイヤーは同じ React アプリ、認証で機能分岐
- 永続化は GitHub のまま、D1/R2 不要
- `develop`/`main` 戦略は「未完成原稿を一般ユーザーから隠す」用途に再定義

## 移行 Issue 依存関係

```
#105 → #106 → (#107, #110) → #108 → (#109, #111) → #112
```

Closes #105

## Test plan

- [x] `docs/adr/0001-hosting-architecture.md` の Context / Decision / Consequences が揃っているか目視
- [x] README.md からの ADR リンクが通っているか
- [x] BRANCHES.md の旧計画が「廃止された旧計画」として残っているか