### PR TITLE
feat: #106 CF Worker バックエンド新設（octokit + 認証スタブ + Cache）

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,12 @@ my-game/                # ゲームプロジェクト（別リポジトリ）
 
 - [docs/adr/0001-hosting-architecture.md](./docs/adr/0001-hosting-architecture.md) - **ホスティングアーキテクチャ ADR（2026-05-08 確定）**
 - [docs/spec/markdown-v0.1.md](./docs/spec/markdown-v0.1.md) - Markdown v0.1 構文仕様
-- [docs/architecture.md](./docs/architecture.md) - アーキテクチャ設計書
+- [docs/architecture.md](./docs/architecture.md) - アーキテクチャ設計書（旧 FastAPI 前提、`worker/` 移行完了後に書き直し予定）
 - [docs/guide/controls.md](./docs/guide/controls.md) - 操作ガイド
 - [CLAUDE.md](./CLAUDE.md) - 開発ガイド（Claude Code用）
-- [backend/README.md](./backend/README.md) - バックエンドAPI仕様（旧 FastAPI、移行期間中の暫定）
-- [backend/ASSETS.md](./backend/ASSETS.md) - アセット管理詳細
+- [worker/README.md](./worker/README.md) - **CF Worker バックエンド（新方針、#106）**
+- [backend/README.md](./backend/README.md) - 旧 FastAPI バックエンド仕様（移行期間中の暫定、#112 で削除予定）
+- [backend/ASSETS.md](./backend/ASSETS.md) - アセット管理詳細（旧）
 - [backend/BRANCHES.md](./backend/BRANCHES.md) - ブランチ戦略（2026-05-08 改訂）
 
 ## ライセンス

--- a/worker/.gitignore
+++ b/worker/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.wrangler/
+.dev.vars
+dist/
+*.log
+.DS_Store

--- a/worker/.gitignore
+++ b/worker/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
 .wrangler/
 .dev.vars
+.env
+.env.local
+.env.*.local
 dist/
 *.log
 .DS_Store

--- a/worker/README.md
+++ b/worker/README.md
@@ -22,7 +22,7 @@ Issue: kako-jun/name-name#106
 | GET | `/api/projects/:name/contents/*path` | Contents API ラッパー (base64 → utf-8) |
 | PUT | `/api/projects/:name/contents/*path` | Contents API で commit。sha 必須（楽観ロック）|
 | GET | `/api/projects/:name/assets/:type` | `assets/{type}/` のディレクトリ一覧 |
-| POST | `/api/projects/:name/assets/:type` | base64 アップロード（5 MiB 上限）|
+| POST | `/api/projects/:name/assets/:type` | base64 アップロード（**5 MiB 未満**）|
 
 `PUT` / `POST` は editor 認証が必要。**現状は dev only** で `Authorization: Bearer ${DEV_AUTH_TOKEN}` 一致のみ通す。
 本実装（CF Access JWT or GitHub OAuth）は **kako-jun/name-name#110**。
@@ -38,15 +38,33 @@ npm test        # vitest (vitest-pool-workers)
 
 ## ローカル起動
 
-```bash
-# secret を設定（初回のみ）
-wrangler secret put GITHUB_TOKEN     # GitHub fine-grained PAT
-wrangler secret put DEV_AUTH_TOKEN   # ローカルで PUT/POST 用に擬似 editor token
+`GITHUB_TOKEN` は本番でも secret として扱う。`DEV_AUTH_TOKEN` は **ローカル開発のみ** で使う擬似 editor トークンなので、`.dev.vars` に書く（`.gitignore` 済み）。
 
+```bash
+# .dev.vars (gitignore 対象、ローカル開発のみ)
+# DEV_AUTH_TOKEN=<your-local-token>
+# GITHUB_TOKEN=<your-fine-grained-pat>
+```
+
+本番では:
+
+```bash
+# 初回のみ
+wrangler secret put GITHUB_TOKEN     # GitHub fine-grained PAT
+# DEV_AUTH_TOKEN は本番では不要。#110 の本認証 (CF Access JWT / GitHub OAuth) に置き換え予定。
+```
+
+```bash
 # dev server
 npm run dev
 # → http://localhost:8787
 ```
+
+### `nodejs_compat` フラグについて
+
+`wrangler.toml` の `compatibility_flags = ["nodejs_compat"]` は、`@octokit/core` 5.x が
+`node:events` 等の Node 互換モジュールを参照する可能性があるため有効化している。
+また `vitest-pool-workers` の起動条件にも必須。
 
 例:
 
@@ -73,9 +91,10 @@ wrangler deploy
 - **#110** authenticate() 本実装（CF Access / GitHub OAuth）
 - **#111** 初回 wrangler deploy（kako-jun が手動）
 - **#112** 旧 `backend/` (FastAPI) と `compose.yaml` の削除
-- **TODO 別 Issue**: `> 5 MiB` のアセットを Git Data API (blob/tree/commit) で扱う
-- **TODO 別 Issue**: PROJECTS リストの KV / D1 化
-- **TODO 別 Issue**: 新規ファイル PUT (sha なし create) の対応
+- **#115** 新規ファイル作成エンドポイント（sha なし PUT）
+- **#116** `>= 5 MiB` のアセットを Git Data API (blob/tree/commit) で扱う
+- **#117** PROJECTS リストの KV / D1 化
+- **#118** ブランチ横断のキャッシュパージ（GitHub webhook 経由）
 
 ## ファイル構成
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,102 @@
+# name-name-api (Cloudflare Worker)
+
+`name-name` のホスティング戦略 (ADR `docs/adr/0001-hosting-architecture.md`) に基づき、
+旧 FastAPI + GitPython バックエンドの代わりに、薄い Cloudflare Worker から
+GitHub REST API を叩く Agasteer 方式の薄プロキシ。
+
+```
+ブラウザ (CF Pages, name-name.llll-ll.com)
+    ↓ fetch
+name-name-api.workers.dev (この Worker)
+    ↓ @octokit/core
+github.com/kako-jun/<game>
+```
+
+Issue: kako-jun/name-name#106
+
+## エンドポイント
+
+| Method | Path | 説明 |
+|---|---|---|
+| GET | `/api/projects` | 公開ゲーム一覧（ハードコード）|
+| GET | `/api/projects/:name/contents/*path` | Contents API ラッパー (base64 → utf-8) |
+| PUT | `/api/projects/:name/contents/*path` | Contents API で commit。sha 必須（楽観ロック）|
+| GET | `/api/projects/:name/assets/:type` | `assets/{type}/` のディレクトリ一覧 |
+| POST | `/api/projects/:name/assets/:type` | base64 アップロード（5 MiB 上限）|
+
+`PUT` / `POST` は editor 認証が必要。**現状は dev only** で `Authorization: Bearer ${DEV_AUTH_TOKEN}` 一致のみ通す。
+本実装（CF Access JWT or GitHub OAuth）は **kako-jun/name-name#110**。
+
+## セットアップ
+
+```bash
+cd worker
+npm install
+npm run build   # tsc --noEmit
+npm test        # vitest (vitest-pool-workers)
+```
+
+## ローカル起動
+
+```bash
+# secret を設定（初回のみ）
+wrangler secret put GITHUB_TOKEN     # GitHub fine-grained PAT
+wrangler secret put DEV_AUTH_TOKEN   # ローカルで PUT/POST 用に擬似 editor token
+
+# dev server
+npm run dev
+# → http://localhost:8787
+```
+
+例:
+
+```bash
+curl http://localhost:8787/api/projects
+curl http://localhost:8787/api/projects/ogurasia/contents/chapters/all.md
+
+curl -X PUT http://localhost:8787/api/projects/ogurasia/contents/chapters/all.md \
+  -H "authorization: Bearer ${DEV_AUTH_TOKEN}" \
+  -H "content-type: application/json" \
+  -d '{"content":"# 新本文","sha":"<前回の sha>","message":"edit chapters/all"}'
+```
+
+## デプロイ
+
+`/deploy` スキルか以下で手動。**本 Issue では deploy しない**（#111 で kako-jun が手動デプロイ）。
+
+```bash
+wrangler deploy
+```
+
+## 今後の Issue
+
+- **#110** authenticate() 本実装（CF Access / GitHub OAuth）
+- **#111** 初回 wrangler deploy（kako-jun が手動）
+- **#112** 旧 `backend/` (FastAPI) と `compose.yaml` の削除
+- **TODO 別 Issue**: `> 5 MiB` のアセットを Git Data API (blob/tree/commit) で扱う
+- **TODO 別 Issue**: PROJECTS リストの KV / D1 化
+- **TODO 別 Issue**: 新規ファイル PUT (sha なし create) の対応
+
+## ファイル構成
+
+```
+worker/
+├── package.json
+├── tsconfig.json
+├── wrangler.toml
+├── vitest.config.ts
+├── README.md
+├── src/
+│   ├── index.ts          # エントリ + ルーティング + CORS
+│   ├── github.ts         # @octokit/core ラッパー + rate-limit ログ
+│   ├── auth.ts           # 認証ミドルウェア（#110 で本実装、現状スタブ）
+│   ├── cache.ts          # Cache API ヘルパー (60 秒)
+│   ├── projects.ts       # GET /api/projects（ハードコード）
+│   ├── contents.ts       # GET/PUT /api/projects/:name/contents/*
+│   ├── assets.ts         # GET/POST /api/projects/:name/assets/:type
+│   └── types.ts          # Env / Project / レスポンス型
+└── test/
+    ├── projects.test.ts
+    ├── contents.test.ts
+    └── assets.test.ts
+```

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,0 +1,4244 @@
+{
+  "name": "name-name-api",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "name-name-api",
+      "version": "0.1.0",
+      "dependencies": {
+        "@octokit/core": "^5.2.0"
+      },
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.4.0",
+        "@cloudflare/workers-types": "^4.20240512.0",
+        "typescript": "^5.4.5",
+        "vitest": "1.5.0",
+        "wrangler": "^3.57.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.4.31",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.4.31.tgz",
+      "integrity": "sha512-DHvpfJ7FCvRoj8Hog12XcLJ4331dar4FpLKi88btFcfZ6EpPVcLD450sL6dQ8A2AmActi3lsnAMpwSCzT+5P8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "birpc": "0.2.14",
+        "cjs-module-lexer": "^1.2.3",
+        "devalue": "^4.3.0",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20240909.0",
+        "semver": "^7.5.1",
+        "wrangler": "3.77.0",
+        "zod": "^3.22.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "1.3.x - 1.5.x",
+        "@vitest/snapshot": "1.3.x - 1.5.x",
+        "vitest": "1.3.x - 1.5.x"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/ohash": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
+      "integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/unenv": {
+      "name": "unenv-nightly",
+      "version": "2.0.0-1724863496.70db6f1",
+      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-1724863496.70db6f1.tgz",
+      "integrity": "sha512-r+VIl1gnsI4WQxluruSQhy8alpAf1AsLRLm4sEKp3otCyTIVD6I6wHEYzeQnwsyWgaD4+3BD4A/eqrgOpdTzhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "ohash": "^1.1.3",
+        "pathe": "^1.1.2",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.77.0.tgz",
+      "integrity": "sha512-XdzStAdB6c87cc9CJRinMzAAFqqSZ19pQ+m6Gzx5fHeWXSclrOFsfD2iSmil8C3/LsrtwoIXghibK98FN0HhhQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@cloudflare/workers-shared": "0.5.0",
+        "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
+        "blake3-wasm": "^2.1.5",
+        "chokidar": "^3.5.3",
+        "date-fns": "^3.6.0",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20240909.0",
+        "nanoid": "^3.3.3",
+        "path-to-regexp": "^6.2.0",
+        "resolve": "^1.22.8",
+        "resolve.exports": "^2.0.2",
+        "selfsigned": "^2.0.1",
+        "source-map": "^0.6.1",
+        "unenv": "npm:unenv-nightly@2.0.0-1724863496.70db6f1",
+        "workerd": "1.20240909.0",
+        "xxhash-wasm": "^1.0.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20240909.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20240909.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20240909.0.tgz",
+      "integrity": "sha512-nJ8jm/6PR8DPzVb4QifNAfSdrFZXNblwIdOhLTU5FpSvFFocmzFX5WgzQagvtmcC9/ZAQyxuf7WynDNyBcoe0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20240909.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20240909.0.tgz",
+      "integrity": "sha512-gJqKa811oSsoxy9xuoQn7bS0Hr1sY+o3EUORTcEnulG6Kz9NQ6nd8QNdp2Hrk2jmmSqwrNkn+a6PZkWzk6Q0Gw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20240909.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20240909.0.tgz",
+      "integrity": "sha512-sJrmtccfMg73sZljiBpe4R+lhF58TqzqhF2pQG8HRjyxkzkM1sjpZqfEFaIkNUDqd3/Ibji49fklhPCGXljKSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20240909.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20240909.0.tgz",
+      "integrity": "sha512-dTbSdceyRXPOSER+18AwYRbPQG0e/Dwl2trmfMMCETkfJhNLv1fU3FFMJPjfILijKnhTZHSnHCx0+xwHdon2fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20240909.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20240909.0.tgz",
+      "integrity": "sha512-/d4BT0kcWFa7Qc0K4K9+cwVQ1qyPNKiO42JZUijlDlco+TYTPkLO3qGEohmwbfMq+BieK7JTMSgjO81ZHpA0HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-shared": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-shared/-/workers-shared-0.5.0.tgz",
+      "integrity": "sha512-qLJzGKwl2SiaaieoCFdj2q85hthPgmF5KjRaZzsPdMKtP+PQnzSWfARsd5mZh71ut5/0grYkUCYWedFe4bY++g==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0",
+        "zod": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=16.7.0"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260507.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260507.1.tgz",
+      "integrity": "sha512-QChtMFu8EeVKaL4dW5r5wfZzlbH5CUnZU5Ef6E1cPjXzqryQuCwmEDNr+Oj2obbKR9jsVIUHPF/pkFaKWdYl2g==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.5.0.tgz",
+      "integrity": "sha512-0pzuCI6KYi2SIC3LQezmxujU9RK/vwC1U9R0rLuGlNGcOuDWxqWKu6nUdFsX9tH1WU0SXtAxToOsEjeUn1s3hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.5.0",
+        "@vitest/utils": "1.5.0",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.5.0.tgz",
+      "integrity": "sha512-BDU0GNL8MWkRkSRdNFvCUCAVOeHaUlVJ9Tx0TYBZyXaaOTmGtUFObzchCivIBrIwKzvZA7A9sCejVhXM2aY98A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.5.3.tgz",
+      "integrity": "sha512-7PlfuReN8692IKQIdCxwir1AOaP5THfNkp0Uc4BKr2na+9lALNit7ub9l3/R7MP8aV61+mHKRGiqEKRIwu6iiQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/utils": "1.5.3",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.5.3.tgz",
+      "integrity": "sha512-K3mvIsjyKYBhNIDujMD2gfQEzddLe51nNOAf45yKRt/QFJcUIeTQd2trRvv6M6oCBHNVnZwFWbQ4yj96ibiDsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.5.0.tgz",
+      "integrity": "sha512-vu6vi6ew5N5MMHJjD5PoakMRKYdmIrNJmyfkhRpQt5d9Ewhw9nZ5Aqynbi3N61bvk9UvZ5UysMT6ayIrZ8GA9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.5.3.tgz",
+      "integrity": "sha512-rE9DTN1BRhzkzqNQO+kw8ZgfeEBCLXiHJwetk668shmNBpSagQxneT5eSqEBLP+cqSiAeecvQmbpFfdMyLcIQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
+      "integrity": "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/capnp-ts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/capnp-ts/-/capnp-ts-0.7.0.tgz",
+      "integrity": "sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "license": "ISC"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.3.tgz",
+      "integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20240909.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20240909.0.tgz",
+      "integrity": "sha512-20eJCCToBvxohLW0vWZHPRL6JPbqJQ4nkCK6MelgTRkw4CLd7MUYbY70M8olJjTuBDK/84/1CkNC4Q/OrbHIDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "^8.8.0",
+        "acorn-walk": "^8.2.0",
+        "capnp-ts": "^0.7.0",
+        "exit-hook": "^2.2.1",
+        "glob-to-regexp": "^0.4.1",
+        "stoppable": "^1.1.0",
+        "undici": "^5.28.4",
+        "workerd": "1.20240909.0",
+        "ws": "^8.17.1",
+        "youch": "^3.2.2",
+        "zod": "^3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-inject/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup-plugin-inject/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
+      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "exsolve": "^1.0.1",
+        "ohash": "^2.0.10",
+        "pathe": "^2.0.3",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/unenv/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "license": "ISC"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.5.0.tgz",
+      "integrity": "sha512-tV8h6gMj6vPzVCa7l+VGq9lwoJjW8Y79vst8QZZGiuRAfijU+EEWuc0kFpmndQrWhMMhet1jdSF+40KSZUqIIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.5.0.tgz",
+      "integrity": "sha512-d8UKgR0m2kjdxDWX6911uwxout6GHS0XaGH1cksSIVVG8kRlE7G7aBw7myKQCvDI5dT4j7ZMa+l706BIORMDLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.5.0",
+        "@vitest/runner": "1.5.0",
+        "@vitest/snapshot": "1.5.0",
+        "@vitest/spy": "1.5.0",
+        "@vitest/utils": "1.5.0",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.5.0",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.5.0",
+        "@vitest/ui": "1.5.0",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/runner": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.5.0.tgz",
+      "integrity": "sha512-7HWwdxXP5yDoe7DTpbif9l6ZmDwCzcSIK38kTSIt6CFEpMjX4EpCgT6wUmS0xTXqMI6E/ONmfgRKmaujpabjZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.5.0",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/snapshot": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.5.0.tgz",
+      "integrity": "sha512-qpv3fSEuNrhAO3FpH6YYRdaECnnRjg9VxbhdtPwPRnzSfHVXnNzzrpX4cJxqiwgRMo7uRMWDFBlsBq4Cr+rO3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.5.0.tgz",
+      "integrity": "sha512-BDU0GNL8MWkRkSRdNFvCUCAVOeHaUlVJ9Tx0TYBZyXaaOTmGtUFObzchCivIBrIwKzvZA7A9sCejVhXM2aY98A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20240909.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20240909.0.tgz",
+      "integrity": "sha512-NwuYh/Fgr/MK0H+Ht687sHl/f8tumwT5CWzYR0MZMHri8m3CIYu2IaY4tBFWoKE/tOU1Z5XjEXECa9zXY4+lwg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20240909.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20240909.0",
+        "@cloudflare/workerd-linux-64": "1.20240909.0",
+        "@cloudflare/workerd-linux-arm64": "1.20240909.0",
+        "@cloudflare/workerd-windows-64": "1.20240909.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "3.114.17",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
+      "integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@cloudflare/unenv-preset": "2.0.2",
+        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20250718.3",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.14",
+        "workerd": "1.20250718.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20250408.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
+      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.14",
+        "workerd": "^1.20250124.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
+      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
+      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
+      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/miniflare": {
+      "version": "3.20250718.3",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
+      "integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "stoppable": "1.1.0",
+        "undici": "^5.28.5",
+        "workerd": "1.20250718.0",
+        "ws": "8.18.0",
+        "youch": "3.3.4",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/wrangler/node_modules/workerd": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
+      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20250718.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
+        "@cloudflare/workerd-linux-64": "1.20250718.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
+        "@cloudflare/workerd-windows-64": "1.20250718.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -13,8 +13,9 @@
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.4.0",
         "@cloudflare/workers-types": "^4.20240512.0",
+        "@octokit/types": "^13.0.0",
         "typescript": "^5.4.5",
-        "vitest": "1.5.0",
+        "vitest": "^1.5.0",
         "wrangler": "^3.57.0"
       }
     },

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "name-name-api",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cloudflare Worker that proxies GitHub REST API for name-name games (Agasteer-style).",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "build": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@octokit/core": "^5.2.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240512.0",
+    "@cloudflare/vitest-pool-workers": "^0.4.0",
+    "typescript": "^5.4.5",
+    "vitest": "1.5.0",
+    "wrangler": "^3.57.0"
+  }
+}

--- a/worker/package.json
+++ b/worker/package.json
@@ -17,8 +17,9 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240512.0",
     "@cloudflare/vitest-pool-workers": "^0.4.0",
+    "@octokit/types": "^13.0.0",
     "typescript": "^5.4.5",
-    "vitest": "1.5.0",
+    "vitest": "^1.5.0",
     "wrangler": "^3.57.0"
   }
 }

--- a/worker/src/assets.ts
+++ b/worker/src/assets.ts
@@ -1,8 +1,10 @@
 // /api/projects/:name/assets/:type ハンドラ
 //
 // - GET  : assets/{type}/ 配下の Contents API ディレクトリ一覧を返す
-// - POST : 5 MiB 以下の base64 アップロード（>5 MiB は別 Issue で Git Data API 経由）
+// - POST : 5 MiB 未満の base64 アップロード（5 MiB ちょうど・>5 MiB は #116 で
+//          Git Data API (blob/tree/commit) 経由で対応）
 
+import type { Endpoints } from "@octokit/types";
 import { authenticate, requireEditor } from "./auth";
 import { assetsCacheKey, cacheDelete, cacheGet, cachePut } from "./cache";
 import { createGitHub, logRateLimit, normalizeError } from "./github";
@@ -16,6 +18,11 @@ import {
   type Env,
 } from "./types";
 
+type ContentsGetResponseData =
+  Endpoints["GET /repos/{owner}/{repo}/contents/{path}"]["response"]["data"];
+type ContentsPutResponseData =
+  Endpoints["PUT /repos/{owner}/{repo}/contents/{path}"]["response"]["data"];
+
 function jsonResponse(body: unknown, status = 200, extraHeaders: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -25,6 +32,17 @@ function jsonResponse(body: unknown, status = 200, extraHeaders: Record<string, 
 
 function isAssetType(s: string): s is AssetType {
   return (ASSET_TYPES as ReadonlyArray<string>).includes(s);
+}
+
+/**
+ * base64 文字列の素朴な妥当性チェック。
+ * 空白除去後に長さが 4 の倍数でなければ不正と見なす。
+ * （実バイト列のデコードは GitHub 側に任せる前提だが、ここで早期 reject すると
+ *  クライアントエラーを 400 として明示できる）
+ */
+function isValidBase64Length(b64: string): boolean {
+  const cleaned = b64.replace(/\s+/g, "");
+  return cleaned.length % 4 === 0;
 }
 
 /** base64 文字列のデコード後バイト数を算出。実デコードはせずに長さだけ見る */
@@ -72,26 +90,21 @@ export async function handleListAssets(
     });
     logRateLimit("assets.list", res.headers as Record<string, string | number | undefined>);
 
-    if (!Array.isArray(res.data)) {
+    const data = res.data as ContentsGetResponseData;
+    if (!Array.isArray(data)) {
       // ディレクトリでない: 空相当扱いではなく 400 で知らせる
       return jsonResponse({ error: `${path} is not a directory` }, 400);
     }
-    const entries: AssetEntry[] = (
-      res.data as Array<{
-        name: string;
-        path: string;
-        sha: string;
-        size: number;
-        type: string;
-        download_url: string | null;
-      }>
-    ).map((e) => ({
+    const entries: AssetEntry[] = data.map((e) => ({
       name: e.name,
       path: e.path,
       sha: e.sha,
       size: e.size,
       type: e.type === "dir" ? "dir" : "file",
-      download_url: e.download_url,
+      // NOTE: download_url を含めて返している。public repo 前提のため
+      //   raw.githubusercontent.com の URL を直接転載している。
+      //   private 化する場合は Worker 経由で streaming に切り替える必要がある。
+      download_url: e.download_url ?? null,
     }));
     const response = jsonResponse({ type, entries }, 200, { "x-cache": "MISS" });
     await cachePut(cacheKey, response);
@@ -138,17 +151,29 @@ export async function handleUploadAsset(
   if (typeof body.contentBase64 !== "string") {
     return jsonResponse({ error: "contentBase64 is required" }, 400);
   }
+  if (!isValidBase64Length(body.contentBase64)) {
+    return jsonResponse(
+      { error: "contentBase64 is not a valid base64 string (length must be a multiple of 4 after whitespace removal)" },
+      400,
+    );
+  }
   if (typeof body.message !== "string" || body.message.length === 0) {
     return jsonResponse({ error: "message is required" }, 400);
   }
+  // sha は任意。指定があれば既存ファイルの更新（Contents PUT）として扱う。
+  if (body.sha !== undefined && (typeof body.sha !== "string" || body.sha.length === 0)) {
+    return jsonResponse({ error: "sha must be a non-empty string when provided" }, 400);
+  }
 
   const sizeBytes = base64DecodedLength(body.contentBase64);
-  if (sizeBytes > MAX_ASSET_BYTES) {
+  // 5 MiB ちょうども reject する。Contents API の上限は 100 MiB だがレスポンスに
+  // 1 MiB 制限があるため、ここでは 5 MiB 未満に絞る。
+  // TODO(#116): >= MAX_ASSET_BYTES のアセットは Git Data API (blob/tree/commit) で扱う。
+  if (sizeBytes >= MAX_ASSET_BYTES) {
     return jsonResponse(
       {
-        error: `asset exceeds ${MAX_ASSET_BYTES} bytes`,
+        error: `asset must be smaller than ${MAX_ASSET_BYTES} bytes (see #116 for >= 5 MiB support via Git Data API)`,
         size: sizeBytes,
-        // TODO(別 Issue): >5 MiB は Git Data API (blob/tree/commit) で対応
       },
       413,
     );
@@ -166,14 +191,19 @@ export async function handleUploadAsset(
       message: body.message,
       content: body.contentBase64.replace(/\s+/g, ""),
       branch,
+      // sha があれば既存ファイル上書き、なければ新規作成として扱う。
+      // 新規作成時に GitHub 側で同名ファイルが既にあると 422 を返すので、それはそのまま伝搬する。
+      sha: body.sha,
     });
     logRateLimit("assets.upload", res.headers as Record<string, string | number | undefined>);
 
-    // 一覧キャッシュをパージ
+    // 一覧キャッシュをパージ。
+    // NOTE(#118): 現状はこの Worker が触る branch / default 二系統だけパージしている。
+    //   ブランチ横断でのパージは GitHub webhook 経由で #118 にて本実装する予定。
     await cacheDelete(assetsCacheKey(owner, repo, type, branch ?? null));
     await cacheDelete(assetsCacheKey(owner, repo, type, null));
 
-    const data = res.data as { content?: { sha: string; path: string }; commit?: { sha: string } };
+    const data = res.data as ContentsPutResponseData;
     return jsonResponse(
       {
         path: data.content?.path ?? path,
@@ -182,6 +212,7 @@ export async function handleUploadAsset(
         size: sizeBytes,
       },
       201,
+      { "x-cache": "BYPASS" },
     );
   } catch (err) {
     const ne = normalizeError(err);

--- a/worker/src/assets.ts
+++ b/worker/src/assets.ts
@@ -1,0 +1,191 @@
+// /api/projects/:name/assets/:type ハンドラ
+//
+// - GET  : assets/{type}/ 配下の Contents API ディレクトリ一覧を返す
+// - POST : 5 MiB 以下の base64 アップロード（>5 MiB は別 Issue で Git Data API 経由）
+
+import { authenticate, requireEditor } from "./auth";
+import { assetsCacheKey, cacheDelete, cacheGet, cachePut } from "./cache";
+import { createGitHub, logRateLimit, normalizeError } from "./github";
+import { findProject, splitRepo } from "./projects";
+import {
+  ASSET_TYPES,
+  MAX_ASSET_BYTES,
+  type AssetEntry,
+  type AssetType,
+  type AssetUploadBody,
+  type Env,
+} from "./types";
+
+function jsonResponse(body: unknown, status = 200, extraHeaders: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8", ...extraHeaders },
+  });
+}
+
+function isAssetType(s: string): s is AssetType {
+  return (ASSET_TYPES as ReadonlyArray<string>).includes(s);
+}
+
+/** base64 文字列のデコード後バイト数を算出。実デコードはせずに長さだけ見る */
+function base64DecodedLength(b64: string): number {
+  const cleaned = b64.replace(/\s+/g, "");
+  if (cleaned.length === 0) return 0;
+  let pad = 0;
+  if (cleaned.endsWith("==")) pad = 2;
+  else if (cleaned.endsWith("=")) pad = 1;
+  return Math.floor((cleaned.length * 3) / 4) - pad;
+}
+
+export async function handleListAssets(
+  request: Request,
+  env: Env,
+  projectName: string,
+  type: string,
+): Promise<Response> {
+  const project = findProject(projectName);
+  if (!project) return jsonResponse({ error: `unknown project: ${projectName}` }, 404);
+  if (!isAssetType(type)) {
+    return jsonResponse({ error: `unknown asset type: ${type}`, allowed: ASSET_TYPES }, 400);
+  }
+
+  const url = new URL(request.url);
+  const ref = url.searchParams.get("ref");
+  const { owner, repo } = splitRepo(project);
+  const path = `assets/${type}`;
+
+  const cacheKey = assetsCacheKey(owner, repo, type, ref);
+  const hit = await cacheGet(cacheKey);
+  if (hit) {
+    const cloned = new Response(hit.body, hit);
+    cloned.headers.set("x-cache", "HIT");
+    return cloned;
+  }
+
+  const octokit = createGitHub(env);
+  try {
+    const res = await octokit.request("GET /repos/{owner}/{repo}/contents/{path}", {
+      owner,
+      repo,
+      path,
+      ref: ref ?? undefined,
+    });
+    logRateLimit("assets.list", res.headers as Record<string, string | number | undefined>);
+
+    if (!Array.isArray(res.data)) {
+      // ディレクトリでない: 空相当扱いではなく 400 で知らせる
+      return jsonResponse({ error: `${path} is not a directory` }, 400);
+    }
+    const entries: AssetEntry[] = (
+      res.data as Array<{
+        name: string;
+        path: string;
+        sha: string;
+        size: number;
+        type: string;
+        download_url: string | null;
+      }>
+    ).map((e) => ({
+      name: e.name,
+      path: e.path,
+      sha: e.sha,
+      size: e.size,
+      type: e.type === "dir" ? "dir" : "file",
+      download_url: e.download_url,
+    }));
+    const response = jsonResponse({ type, entries }, 200, { "x-cache": "MISS" });
+    await cachePut(cacheKey, response);
+    return response;
+  } catch (err) {
+    const ne = normalizeError(err);
+    logRateLimit("assets.list.err", ne.responseHeaders);
+    if (ne.status === 404) {
+      // assets/{type}/ がまだ無いリポでは空配列を返す
+      return jsonResponse({ type, entries: [] }, 200);
+    }
+    return jsonResponse({ error: ne.message }, ne.status);
+  }
+}
+
+export async function handleUploadAsset(
+  request: Request,
+  env: Env,
+  projectName: string,
+  type: string,
+): Promise<Response> {
+  const project = findProject(projectName);
+  if (!project) return jsonResponse({ error: `unknown project: ${projectName}` }, 404);
+  if (!isAssetType(type)) {
+    return jsonResponse({ error: `unknown asset type: ${type}`, allowed: ASSET_TYPES }, 400);
+  }
+
+  const auth = await authenticate(request, env);
+  const guard = requireEditor(auth);
+  if (guard) return guard;
+
+  let body: AssetUploadBody;
+  try {
+    body = (await request.json()) as AssetUploadBody;
+  } catch {
+    return jsonResponse({ error: "invalid JSON body" }, 400);
+  }
+  if (typeof body.filename !== "string" || body.filename.length === 0) {
+    return jsonResponse({ error: "filename is required" }, 400);
+  }
+  if (body.filename.includes("/") || body.filename.includes("..")) {
+    return jsonResponse({ error: "filename must be a basename (no slashes / no '..')" }, 400);
+  }
+  if (typeof body.contentBase64 !== "string") {
+    return jsonResponse({ error: "contentBase64 is required" }, 400);
+  }
+  if (typeof body.message !== "string" || body.message.length === 0) {
+    return jsonResponse({ error: "message is required" }, 400);
+  }
+
+  const sizeBytes = base64DecodedLength(body.contentBase64);
+  if (sizeBytes > MAX_ASSET_BYTES) {
+    return jsonResponse(
+      {
+        error: `asset exceeds ${MAX_ASSET_BYTES} bytes`,
+        size: sizeBytes,
+        // TODO(別 Issue): >5 MiB は Git Data API (blob/tree/commit) で対応
+      },
+      413,
+    );
+  }
+
+  const { owner, repo } = splitRepo(project);
+  const path = `assets/${type}/${body.filename}`;
+  const branch = body.branch;
+  const octokit = createGitHub(env);
+  try {
+    const res = await octokit.request("PUT /repos/{owner}/{repo}/contents/{path}", {
+      owner,
+      repo,
+      path,
+      message: body.message,
+      content: body.contentBase64.replace(/\s+/g, ""),
+      branch,
+    });
+    logRateLimit("assets.upload", res.headers as Record<string, string | number | undefined>);
+
+    // 一覧キャッシュをパージ
+    await cacheDelete(assetsCacheKey(owner, repo, type, branch ?? null));
+    await cacheDelete(assetsCacheKey(owner, repo, type, null));
+
+    const data = res.data as { content?: { sha: string; path: string }; commit?: { sha: string } };
+    return jsonResponse(
+      {
+        path: data.content?.path ?? path,
+        sha: data.content?.sha ?? null,
+        commit_sha: data.commit?.sha ?? null,
+        size: sizeBytes,
+      },
+      201,
+    );
+  } catch (err) {
+    const ne = normalizeError(err);
+    logRateLimit("assets.upload.err", ne.responseHeaders);
+    return jsonResponse({ error: ne.message, status: ne.status }, ne.status);
+  }
+}

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -1,0 +1,35 @@
+// 認証ミドルウェア（スタブ）
+//
+// 本実装は kako-jun/name-name#110 で行う:
+//   - /edit/* に対応する mutating エンドポイントは CF Access JWT または GitHub OAuth で
+//     kako-jun のみ通過させる
+//   - /play/* （read-only）はログイン不要
+//
+// 本 Issue (#106) では「口だけ」用意する。Authorization: Bearer <DEV_AUTH_TOKEN> が
+// 一致した場合のみ editor 扱いとする。DEV_AUTH_TOKEN が未設定なら誰も editor になれない。
+
+import type { Env } from "./types";
+
+export interface AuthContext {
+  isEditor: boolean;
+  user: string | null;
+}
+
+export async function authenticate(request: Request, env: Env): Promise<AuthContext> {
+  // TODO(#110): CF Access JWT or GitHub OAuth で検証する
+  const authHeader = request.headers.get("authorization");
+  if (env.DEV_AUTH_TOKEN && authHeader === `Bearer ${env.DEV_AUTH_TOKEN}`) {
+    return { isEditor: true, user: "kako-jun" };
+  }
+  return { isEditor: false, user: null };
+}
+
+export function requireEditor(ctx: AuthContext): Response | null {
+  if (!ctx.isEditor) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "content-type": "application/json; charset=utf-8" },
+    });
+  }
+  return null;
+}

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -15,11 +15,32 @@ export interface AuthContext {
   user: string | null;
 }
 
+/**
+ * 文字列の constant-time 比較。
+ * Workers ランタイムには `crypto.subtle.timingSafeEqual` 相当が無いので自前実装する。
+ * 長さが異なる場合は早期 false を返すが、その時点では中身の差分情報はリークしない。
+ *
+ * TODO(#110): 本認証 (CF Access JWT / GitHub OAuth) に置き換える際も、
+ *   ユーザ秘匿値（HMAC タグ等）を比較する箇所では必ず constant-time を維持すること。
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
 export async function authenticate(request: Request, env: Env): Promise<AuthContext> {
-  // TODO(#110): CF Access JWT or GitHub OAuth で検証する
+  // TODO(#110): CF Access JWT or GitHub OAuth で検証する。
+  //   その際もトークン比較は必ず constant-time を維持する（constantTimeEqual を使う）。
   const authHeader = request.headers.get("authorization");
-  if (env.DEV_AUTH_TOKEN && authHeader === `Bearer ${env.DEV_AUTH_TOKEN}`) {
-    return { isEditor: true, user: "kako-jun" };
+  if (env.DEV_AUTH_TOKEN && authHeader !== null) {
+    const expected = `Bearer ${env.DEV_AUTH_TOKEN}`;
+    if (constantTimeEqual(authHeader, expected)) {
+      return { isEditor: true, user: "kako-jun" };
+    }
   }
   return { isEditor: false, user: null };
 }

--- a/worker/src/cache.ts
+++ b/worker/src/cache.ts
@@ -1,0 +1,68 @@
+// Cache API ヘルパー
+//
+// - GET の結果を 60 秒キャッシュする
+// - PUT/POST が成功したら該当キーをパージする
+// - テスト環境では caches.default が無いので、ヘルパーは undefined を許容する
+
+const DEFAULT_TTL_SECONDS = 60;
+
+function getCache(): Cache | null {
+  // @cloudflare/workers-types の caches.default
+  // miniflare/vitest-pool-workers でも提供される。標準 Web 環境では undefined。
+  const c = (caches as unknown as { default?: Cache }).default;
+  return c ?? null;
+}
+
+/**
+ * cache key として使う Request を作る。実際の Worker request の URL とは独立に、
+ * 内部用 URL（host = "name-name-cache.local"）を組み立てる。
+ */
+function makeCacheRequest(key: string): Request {
+  return new Request(`https://name-name-cache.local/${encodeURIComponent(key)}`, {
+    method: "GET",
+  });
+}
+
+export async function cacheGet(key: string): Promise<Response | null> {
+  const cache = getCache();
+  if (!cache) return null;
+  const hit = await cache.match(makeCacheRequest(key));
+  return hit ?? null;
+}
+
+export async function cachePut(
+  key: string,
+  response: Response,
+  ttlSeconds: number = DEFAULT_TTL_SECONDS,
+): Promise<void> {
+  const cache = getCache();
+  if (!cache) return;
+  // Cache API が Cache-Control を見るので、コピーに header を付ける
+  const cloned = new Response(response.clone().body, response);
+  cloned.headers.set("cache-control", `public, max-age=${ttlSeconds}`);
+  await cache.put(makeCacheRequest(key), cloned);
+}
+
+export async function cacheDelete(key: string): Promise<boolean> {
+  const cache = getCache();
+  if (!cache) return false;
+  return cache.delete(makeCacheRequest(key));
+}
+
+export function contentsCacheKey(
+  owner: string,
+  repo: string,
+  path: string,
+  ref: string | null,
+): string {
+  return `contents:${owner}/${repo}:${ref ?? "default"}:${path}`;
+}
+
+export function assetsCacheKey(
+  owner: string,
+  repo: string,
+  type: string,
+  ref: string | null,
+): string {
+  return `assets:${owner}/${repo}:${ref ?? "default"}:${type}`;
+}

--- a/worker/src/contents.ts
+++ b/worker/src/contents.ts
@@ -1,0 +1,167 @@
+// /api/projects/:name/contents/* ハンドラ
+//
+// - GET : Contents API を叩いて base64 を utf-8 にデコード、{ path, sha, content } を返す
+// - PUT : { content, sha, message, branch? } を受け取り、base64 化して PUT する
+//         sha mismatch (409) はそのまま 409 でクライアントへ返す
+
+import { authenticate, requireEditor } from "./auth";
+import { cacheDelete, cacheGet, cachePut, contentsCacheKey } from "./cache";
+import { createGitHub, logRateLimit, normalizeError } from "./github";
+import { findProject, splitRepo } from "./projects";
+import type { ContentsGetResponse, ContentsPutBody, Env } from "./types";
+
+function jsonResponse(body: unknown, status = 200, extraHeaders: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8", ...extraHeaders },
+  });
+}
+
+function notFound(message: string): Response {
+  return jsonResponse({ error: message }, 404);
+}
+
+function badRequest(message: string): Response {
+  return jsonResponse({ error: message }, 400);
+}
+
+/**
+ * Workers ランタイムには atob/btoa が存在するが、UTF-8 文字列の変換には注意が必要。
+ * 受け取った base64 → Uint8Array → TextDecoder で utf-8 デコードする。
+ */
+function base64ToUtf8(b64: string): string {
+  const cleaned = b64.replace(/\s+/g, "");
+  const bin = atob(cleaned);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder("utf-8").decode(bytes);
+}
+
+function utf8ToBase64(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+export async function handleGetContents(
+  request: Request,
+  env: Env,
+  projectName: string,
+  path: string,
+): Promise<Response> {
+  const project = findProject(projectName);
+  if (!project) return notFound(`unknown project: ${projectName}`);
+  if (!path) return badRequest("path is required");
+
+  const url = new URL(request.url);
+  const ref = url.searchParams.get("ref"); // ブランチ / コミット指定（任意）
+  const { owner, repo } = splitRepo(project);
+
+  const cacheKey = contentsCacheKey(owner, repo, path, ref);
+  const hit = await cacheGet(cacheKey);
+  if (hit) {
+    // キャッシュヒットを示すヘッダを足す
+    const cloned = new Response(hit.body, hit);
+    cloned.headers.set("x-cache", "HIT");
+    return cloned;
+  }
+
+  const octokit = createGitHub(env);
+  try {
+    const res = await octokit.request("GET /repos/{owner}/{repo}/contents/{path}", {
+      owner,
+      repo,
+      path,
+      ref: ref ?? undefined,
+    });
+    logRateLimit("contents.get", res.headers as Record<string, string | number | undefined>);
+
+    // ディレクトリの場合 res.data は配列。ファイルのみ受ける。
+    if (Array.isArray(res.data)) {
+      return badRequest("path is a directory; use /assets/ endpoint instead");
+    }
+    const data = res.data as { type: string; path: string; sha: string; content?: string; encoding?: string };
+    if (data.type !== "file" || typeof data.content !== "string") {
+      return badRequest(`unsupported content type: ${data.type}`);
+    }
+    const text = base64ToUtf8(data.content);
+    const body: ContentsGetResponse = {
+      path: data.path,
+      sha: data.sha,
+      content: text,
+      encoding: "utf-8",
+    };
+    const response = jsonResponse(body, 200, { "x-cache": "MISS" });
+    await cachePut(cacheKey, response);
+    return response;
+  } catch (err) {
+    const ne = normalizeError(err);
+    logRateLimit("contents.get.err", ne.responseHeaders);
+    return jsonResponse({ error: ne.message }, ne.status);
+  }
+}
+
+export async function handlePutContents(
+  request: Request,
+  env: Env,
+  projectName: string,
+  path: string,
+): Promise<Response> {
+  const project = findProject(projectName);
+  if (!project) return notFound(`unknown project: ${projectName}`);
+  if (!path) return badRequest("path is required");
+
+  const auth = await authenticate(request, env);
+  const guard = requireEditor(auth);
+  if (guard) return guard;
+
+  let body: ContentsPutBody;
+  try {
+    body = (await request.json()) as ContentsPutBody;
+  } catch {
+    return badRequest("invalid JSON body");
+  }
+  if (typeof body.content !== "string") return badRequest("content is required");
+  if (typeof body.sha !== "string" || body.sha.length === 0) {
+    return badRequest("sha is required (use empty PUT-create endpoint for new files; not implemented yet)");
+  }
+  if (typeof body.message !== "string" || body.message.length === 0) {
+    return badRequest("message is required");
+  }
+
+  const { owner, repo } = splitRepo(project);
+  const branch = body.branch;
+  const octokit = createGitHub(env);
+  try {
+    const res = await octokit.request("PUT /repos/{owner}/{repo}/contents/{path}", {
+      owner,
+      repo,
+      path,
+      message: body.message,
+      content: utf8ToBase64(body.content),
+      sha: body.sha,
+      branch,
+    });
+    logRateLimit("contents.put", res.headers as Record<string, string | number | undefined>);
+
+    // 該当パスの read キャッシュをパージ（branch 指定の有無を両方）
+    await cacheDelete(contentsCacheKey(owner, repo, path, branch ?? null));
+    await cacheDelete(contentsCacheKey(owner, repo, path, null));
+
+    const data = res.data as { content?: { sha: string; path: string }; commit?: { sha: string } };
+    return jsonResponse(
+      {
+        path: data.content?.path ?? path,
+        sha: data.content?.sha ?? null,
+        commit_sha: data.commit?.sha ?? null,
+      },
+      200,
+    );
+  } catch (err) {
+    const ne = normalizeError(err);
+    logRateLimit("contents.put.err", ne.responseHeaders);
+    // 409 (sha mismatch) は楽観ロック失敗としてそのまま伝える
+    return jsonResponse({ error: ne.message, status: ne.status }, ne.status);
+  }
+}

--- a/worker/src/contents.ts
+++ b/worker/src/contents.ts
@@ -3,12 +3,19 @@
 // - GET : Contents API を叩いて base64 を utf-8 にデコード、{ path, sha, content } を返す
 // - PUT : { content, sha, message, branch? } を受け取り、base64 化して PUT する
 //         sha mismatch (409) はそのまま 409 でクライアントへ返す
+//         新規ファイル作成 (sha なし) は #115 で実装予定。現状は 400 で reject する。
 
+import type { Endpoints } from "@octokit/types";
 import { authenticate, requireEditor } from "./auth";
 import { cacheDelete, cacheGet, cachePut, contentsCacheKey } from "./cache";
 import { createGitHub, logRateLimit, normalizeError } from "./github";
 import { findProject, splitRepo } from "./projects";
 import type { ContentsGetResponse, ContentsPutBody, Env } from "./types";
+
+type ContentsGetResponseData =
+  Endpoints["GET /repos/{owner}/{repo}/contents/{path}"]["response"]["data"];
+type ContentsPutResponseData =
+  Endpoints["PUT /repos/{owner}/{repo}/contents/{path}"]["response"]["data"];
 
 function jsonResponse(body: unknown, status = 200, extraHeaders: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -25,9 +32,21 @@ function badRequest(message: string): Response {
   return jsonResponse({ error: message }, 400);
 }
 
+function badGateway(message: string): Response {
+  return jsonResponse({ error: message }, 502);
+}
+
+/** path に traversal が含まれていないかの素朴チェック */
+function isUnsafePath(path: string): boolean {
+  if (path.includes("..")) return true;
+  if (path.includes("//")) return true;
+  return false;
+}
+
 /**
  * Workers ランタイムには atob/btoa が存在するが、UTF-8 文字列の変換には注意が必要。
  * 受け取った base64 → Uint8Array → TextDecoder で utf-8 デコードする。
+ * 不正な base64 (`atob` が `InvalidCharacterError` を投げる) は呼び出し側で catch すること。
  */
 function base64ToUtf8(b64: string): string {
   const cleaned = b64.replace(/\s+/g, "");
@@ -53,6 +72,7 @@ export async function handleGetContents(
   const project = findProject(projectName);
   if (!project) return notFound(`unknown project: ${projectName}`);
   if (!path) return badRequest("path is required");
+  if (isUnsafePath(path)) return badRequest("path contains '..' or '//' which is not allowed");
 
   const url = new URL(request.url);
   const ref = url.searchParams.get("ref"); // ブランチ / コミット指定（任意）
@@ -77,22 +97,29 @@ export async function handleGetContents(
     });
     logRateLimit("contents.get", res.headers as Record<string, string | number | undefined>);
 
+    const data = res.data as ContentsGetResponseData;
     // ディレクトリの場合 res.data は配列。ファイルのみ受ける。
-    if (Array.isArray(res.data)) {
+    if (Array.isArray(data)) {
       return badRequest("path is a directory; use /assets/ endpoint instead");
     }
-    const data = res.data as { type: string; path: string; sha: string; content?: string; encoding?: string };
     if (data.type !== "file" || typeof data.content !== "string") {
       return badRequest(`unsupported content type: ${data.type}`);
     }
-    const text = base64ToUtf8(data.content);
-    const body: ContentsGetResponse = {
+    let text: string;
+    try {
+      text = base64ToUtf8(data.content);
+    } catch (decodeErr) {
+      // GitHub が壊れた base64 を返した場合（通常は起こらないがガード）
+      console.error("[contents.get] base64 decode failed", decodeErr);
+      return badGateway("failed to decode base64 from GitHub");
+    }
+    const respBody: ContentsGetResponse = {
       path: data.path,
       sha: data.sha,
       content: text,
       encoding: "utf-8",
     };
-    const response = jsonResponse(body, 200, { "x-cache": "MISS" });
+    const response = jsonResponse(respBody, 200, { "x-cache": "MISS" });
     await cachePut(cacheKey, response);
     return response;
   } catch (err) {
@@ -111,6 +138,7 @@ export async function handlePutContents(
   const project = findProject(projectName);
   if (!project) return notFound(`unknown project: ${projectName}`);
   if (!path) return badRequest("path is required");
+  if (isUnsafePath(path)) return badRequest("path contains '..' or '//' which is not allowed");
 
   const auth = await authenticate(request, env);
   const guard = requireEditor(auth);
@@ -124,7 +152,9 @@ export async function handlePutContents(
   }
   if (typeof body.content !== "string") return badRequest("content is required");
   if (typeof body.sha !== "string" || body.sha.length === 0) {
-    return badRequest("sha is required (use empty PUT-create endpoint for new files; not implemented yet)");
+    // TODO(#115): 新規ファイル作成 (sha なし PUT) のサポート。
+    //   現状は仕様乖離より UX 優先で 400 を返す。
+    return badRequest("sha is required for update; create is not implemented yet (see #115)");
   }
   if (typeof body.message !== "string" || body.message.length === 0) {
     return badRequest("message is required");
@@ -145,11 +175,13 @@ export async function handlePutContents(
     });
     logRateLimit("contents.put", res.headers as Record<string, string | number | undefined>);
 
-    // 該当パスの read キャッシュをパージ（branch 指定の有無を両方）
+    // 該当パスの read キャッシュをパージ（branch 指定の有無を両方）。
+    // NOTE(#118): 現状はこの Worker が触る branch / default 二系統だけパージしている。
+    //   ブランチ横断でのパージは GitHub webhook 経由で #118 にて本実装する予定。
     await cacheDelete(contentsCacheKey(owner, repo, path, branch ?? null));
     await cacheDelete(contentsCacheKey(owner, repo, path, null));
 
-    const data = res.data as { content?: { sha: string; path: string }; commit?: { sha: string } };
+    const data = res.data as ContentsPutResponseData;
     return jsonResponse(
       {
         path: data.content?.path ?? path,
@@ -157,6 +189,7 @@ export async function handlePutContents(
         commit_sha: data.commit?.sha ?? null,
       },
       200,
+      { "x-cache": "PURGED" },
     );
   } catch (err) {
     const ne = normalizeError(err);

--- a/worker/src/github.ts
+++ b/worker/src/github.ts
@@ -8,11 +8,18 @@ import type { Env } from "./types";
 
 export type GitHubClient = Octokit;
 
+// GITHUB_TOKEN 未設定の警告は同一プロセス内で 1 回だけ出す。
+// （Worker が isolate 内で再利用される場合、毎リクエスト出力すると邪魔なため）
+let warnedMissingToken = false;
+
 export function createGitHub(env: Env): GitHubClient {
   if (!env.GITHUB_TOKEN) {
     // dev / test では未設定のことがある。実 API 呼び出し時に octokit が落ちるので、
     // ここではログだけ。未設定でも fetch をモックすれば走る。
-    console.warn("[github] GITHUB_TOKEN is not set");
+    if (!warnedMissingToken) {
+      console.warn("[github] GITHUB_TOKEN is not set");
+      warnedMissingToken = true;
+    }
   }
   return new Octokit({
     auth: env.GITHUB_TOKEN,

--- a/worker/src/github.ts
+++ b/worker/src/github.ts
@@ -1,0 +1,66 @@
+// octokit ラッパー
+//
+// - GitHub PAT は env.GITHUB_TOKEN から読む（ブラウザに渡らない）
+// - レスポンスヘッダの x-ratelimit-remaining を console.log に出す
+
+import { Octokit } from "@octokit/core";
+import type { Env } from "./types";
+
+export type GitHubClient = Octokit;
+
+export function createGitHub(env: Env): GitHubClient {
+  if (!env.GITHUB_TOKEN) {
+    // dev / test では未設定のことがある。実 API 呼び出し時に octokit が落ちるので、
+    // ここではログだけ。未設定でも fetch をモックすれば走る。
+    console.warn("[github] GITHUB_TOKEN is not set");
+  }
+  return new Octokit({
+    auth: env.GITHUB_TOKEN,
+    userAgent: "name-name-api/0.1.0",
+  });
+}
+
+/**
+ * octokit のレスポンス headers から rate limit を読み出してログに流す。
+ * octokit の戻り値型に headers が含まれるが、ヘッダ名が小文字 / 大文字混在するので両対応。
+ */
+export function logRateLimit(
+  scope: string,
+  headers: Record<string, string | number | undefined> | undefined,
+): void {
+  if (!headers) return;
+  const remaining =
+    headers["x-ratelimit-remaining"] ?? headers["X-RateLimit-Remaining"];
+  const limit = headers["x-ratelimit-limit"] ?? headers["X-RateLimit-Limit"];
+  const reset = headers["x-ratelimit-reset"] ?? headers["X-RateLimit-Reset"];
+  if (remaining !== undefined) {
+    console.log(
+      `[github:${scope}] rate-limit remaining=${remaining} limit=${limit ?? "?"} reset=${reset ?? "?"}`,
+    );
+  }
+}
+
+/**
+ * @octokit/core が投げる RequestError を吸収して { status, message, response? } に正規化する。
+ */
+export interface NormalizedGitHubError {
+  status: number;
+  message: string;
+  responseHeaders?: Record<string, string | number | undefined>;
+}
+
+export function normalizeError(err: unknown): NormalizedGitHubError {
+  if (typeof err === "object" && err !== null && "status" in err) {
+    const e = err as {
+      status?: number;
+      message?: string;
+      response?: { headers?: Record<string, string | number | undefined> };
+    };
+    return {
+      status: typeof e.status === "number" ? e.status : 500,
+      message: e.message ?? "GitHub API error",
+      responseHeaders: e.response?.headers,
+    };
+  }
+  return { status: 500, message: "Unknown error" };
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -16,27 +16,42 @@ import { handleGetContents, handlePutContents } from "./contents";
 import { handleListProjects } from "./projects";
 import type { Env } from "./types";
 
-const CORS_HEADERS_BASE: Record<string, string> = {
+// preflight (OPTIONS) と通常レスポンスで返す CORS ヘッダを分けて管理する。
+// preflight 専用ヘッダ（allow-methods / allow-headers / max-age）は通常レスポンスには不要。
+const CORS_PREFLIGHT_ONLY: Record<string, string> = {
   "access-control-allow-methods": "GET, PUT, POST, OPTIONS",
   "access-control-allow-headers": "authorization, content-type",
   "access-control-max-age": "86400",
 };
 
-function corsHeaders(env: Env, origin: string | null): Record<string, string> {
-  const allowed = env.ALLOWED_ORIGIN;
+/** Origin 完全一致の判定。将来的にホワイトリスト化する余地を残すため Set で保持する */
+function resolveAllowedOrigin(env: Env, origin: string | null): string {
+  const allowedSet = new Set([env.ALLOWED_ORIGIN]);
   // 完全一致のみ許可。ローカル開発で `wrangler dev` から叩く場合は wrangler.toml の
   // ALLOWED_ORIGIN を `http://localhost:5173` などに上書きすること。
-  const allowOrigin = origin && origin === allowed ? origin : allowed;
+  return origin && allowedSet.has(origin) ? origin : env.ALLOWED_ORIGIN;
+}
+
+/** OPTIONS preflight 用の CORS ヘッダ */
+function corsHeadersForPreflight(env: Env, origin: string | null): Record<string, string> {
   return {
-    ...CORS_HEADERS_BASE,
-    "access-control-allow-origin": allowOrigin,
+    ...CORS_PREFLIGHT_ONLY,
+    "access-control-allow-origin": resolveAllowedOrigin(env, origin),
+    vary: "origin",
+  };
+}
+
+/** 通常レスポンスに付与する CORS ヘッダ（allow-origin と vary のみ） */
+function corsHeadersForResponse(env: Env, origin: string | null): Record<string, string> {
+  return {
+    "access-control-allow-origin": resolveAllowedOrigin(env, origin),
     vary: "origin",
   };
 }
 
 function withCors(response: Response, env: Env, origin: string | null): Response {
   const headers = new Headers(response.headers);
-  for (const [k, v] of Object.entries(corsHeaders(env, origin))) {
+  for (const [k, v] of Object.entries(corsHeadersForResponse(env, origin))) {
     headers.set(k, v);
   }
   return new Response(response.body, { status: response.status, headers });
@@ -125,7 +140,7 @@ export default {
     if (request.method === "OPTIONS") {
       return new Response(null, {
         status: 204,
-        headers: corsHeaders(env, origin),
+        headers: corsHeadersForPreflight(env, origin),
       });
     }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,0 +1,147 @@
+// Worker エントリ + ルーティング
+//
+// ルート:
+//   GET    /api/projects
+//   GET    /api/projects/:name/contents/*path
+//   PUT    /api/projects/:name/contents/*path
+//   GET    /api/projects/:name/assets/:type
+//   POST   /api/projects/:name/assets/:type
+//
+// CORS:
+//   - env.ALLOWED_ORIGIN からのみ通す
+//   - OPTIONS preflight に対応
+
+import { handleListAssets, handleUploadAsset } from "./assets";
+import { handleGetContents, handlePutContents } from "./contents";
+import { handleListProjects } from "./projects";
+import type { Env } from "./types";
+
+const CORS_HEADERS_BASE: Record<string, string> = {
+  "access-control-allow-methods": "GET, PUT, POST, OPTIONS",
+  "access-control-allow-headers": "authorization, content-type",
+  "access-control-max-age": "86400",
+};
+
+function corsHeaders(env: Env, origin: string | null): Record<string, string> {
+  const allowed = env.ALLOWED_ORIGIN;
+  // 完全一致のみ許可。ローカル開発で `wrangler dev` から叩く場合は wrangler.toml の
+  // ALLOWED_ORIGIN を `http://localhost:5173` などに上書きすること。
+  const allowOrigin = origin && origin === allowed ? origin : allowed;
+  return {
+    ...CORS_HEADERS_BASE,
+    "access-control-allow-origin": allowOrigin,
+    vary: "origin",
+  };
+}
+
+function withCors(response: Response, env: Env, origin: string | null): Response {
+  const headers = new Headers(response.headers);
+  for (const [k, v] of Object.entries(corsHeaders(env, origin))) {
+    headers.set(k, v);
+  }
+  return new Response(response.body, { status: response.status, headers });
+}
+
+function notFound(): Response {
+  return new Response(JSON.stringify({ error: "not found" }), {
+    status: 404,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+function methodNotAllowed(): Response {
+  return new Response(JSON.stringify({ error: "method not allowed" }), {
+    status: 405,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+interface RouteMatch {
+  // /api/projects
+  kind: "list-projects";
+}
+interface ContentsRoute {
+  kind: "contents";
+  project: string;
+  path: string;
+}
+interface AssetsRoute {
+  kind: "assets";
+  project: string;
+  type: string;
+}
+type Route = RouteMatch | ContentsRoute | AssetsRoute | null;
+
+function matchRoute(pathname: string): Route {
+  // /api/projects
+  if (pathname === "/api/projects" || pathname === "/api/projects/") {
+    return { kind: "list-projects" };
+  }
+  // /api/projects/:name/contents/*
+  const contentsMatch = pathname.match(/^\/api\/projects\/([^/]+)\/contents\/(.+)$/);
+  if (contentsMatch) {
+    return { kind: "contents", project: contentsMatch[1], path: contentsMatch[2] };
+  }
+  // /api/projects/:name/assets/:type
+  const assetsMatch = pathname.match(/^\/api\/projects\/([^/]+)\/assets\/([^/]+)\/?$/);
+  if (assetsMatch) {
+    return { kind: "assets", project: assetsMatch[1], type: assetsMatch[2] };
+  }
+  return null;
+}
+
+async function dispatch(request: Request, env: Env): Promise<Response> {
+  const url = new URL(request.url);
+  const route = matchRoute(url.pathname);
+  if (!route) return notFound();
+
+  switch (route.kind) {
+    case "list-projects":
+      if (request.method === "GET") return handleListProjects(request, env);
+      return methodNotAllowed();
+    case "contents":
+      if (request.method === "GET") {
+        return handleGetContents(request, env, route.project, route.path);
+      }
+      if (request.method === "PUT") {
+        return handlePutContents(request, env, route.project, route.path);
+      }
+      return methodNotAllowed();
+    case "assets":
+      if (request.method === "GET") {
+        return handleListAssets(request, env, route.project, route.type);
+      }
+      if (request.method === "POST") {
+        return handleUploadAsset(request, env, route.project, route.type);
+      }
+      return methodNotAllowed();
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
+    const origin = request.headers.get("origin");
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, {
+        status: 204,
+        headers: corsHeaders(env, origin),
+      });
+    }
+
+    try {
+      const res = await dispatch(request, env);
+      return withCors(res, env, origin);
+    } catch (err) {
+      console.error("[fetch] unhandled", err);
+      const res = new Response(
+        JSON.stringify({ error: "internal server error" }),
+        {
+          status: 500,
+          headers: { "content-type": "application/json; charset=utf-8" },
+        },
+      );
+      return withCors(res, env, origin);
+    }
+  },
+};

--- a/worker/src/projects.ts
+++ b/worker/src/projects.ts
@@ -1,6 +1,8 @@
 // GET /api/projects ハンドラ
 //
-// 当面はハードコードのリスト。将来的に KV/D1 への移行を別 Issue で検討する。
+// 当面はハードコードのリスト。
+// TODO(#117): PROJECTS リストの KV / D1 化。その時に Map<name, Project> に切り替えて
+//   findProject を O(1) にする。現状は 4 件なので線形探索で十分。
 
 import type { Env, Project } from "./types";
 
@@ -12,11 +14,15 @@ export const PROJECTS: ReadonlyArray<Project> = [
 ];
 
 export function findProject(name: string): Project | undefined {
+  // TODO(#117): KV/D1 化の際は Map ベースに置き換える
   return PROJECTS.find((p) => p.name === name);
 }
 
 export function splitRepo(project: Project): { owner: string; repo: string } {
   const [owner, repo] = project.repo.split("/", 2);
+  if (!owner || !repo) {
+    throw new Error(`invalid project.repo: ${project.repo}`);
+  }
   return { owner, repo };
 }
 

--- a/worker/src/projects.ts
+++ b/worker/src/projects.ts
@@ -1,0 +1,28 @@
+// GET /api/projects ハンドラ
+//
+// 当面はハードコードのリスト。将来的に KV/D1 への移行を別 Issue で検討する。
+
+import type { Env, Project } from "./types";
+
+export const PROJECTS: ReadonlyArray<Project> = [
+  { name: "ogurasia", title: "オグラシア", repo: "kako-jun/ogurasia" },
+  { name: "skirts-colour", title: "宇宙色", repo: "kako-jun/skirts-colour" },
+  { name: "friday-1930", title: "Friday 1930", repo: "kako-jun/friday-1930" },
+  { name: "gymnasia", title: "Gymnasia", repo: "kako-jun/gymnasia" },
+];
+
+export function findProject(name: string): Project | undefined {
+  return PROJECTS.find((p) => p.name === name);
+}
+
+export function splitRepo(project: Project): { owner: string; repo: string } {
+  const [owner, repo] = project.repo.split("/", 2);
+  return { owner, repo };
+}
+
+export async function handleListProjects(_request: Request, _env: Env): Promise<Response> {
+  return new Response(JSON.stringify({ projects: PROJECTS }), {
+    status: 200,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -1,0 +1,71 @@
+// 共通型定義（worker 全体で参照する Env / Project / レスポンス型）
+
+export interface Env {
+  // wrangler.toml の [vars]
+  ALLOWED_ORIGIN: string;
+  DEFAULT_OWNER: string;
+
+  // wrangler secret put で設定
+  GITHUB_TOKEN?: string;
+  DEV_AUTH_TOKEN?: string;
+}
+
+export interface Project {
+  name: string;
+  title: string;
+  repo: string; // "owner/name"
+}
+
+export interface ContentsGetResponse {
+  path: string;
+  sha: string;
+  content: string;
+  encoding: "utf-8";
+}
+
+export interface ContentsPutBody {
+  content: string;
+  sha: string;
+  message: string;
+  branch?: string;
+}
+
+export interface AssetEntry {
+  name: string;
+  path: string;
+  sha: string;
+  size: number;
+  type: "file" | "dir";
+  download_url: string | null;
+}
+
+export interface AssetUploadBody {
+  filename: string;
+  // base64 エンコード済みの本体
+  contentBase64: string;
+  message: string;
+  branch?: string;
+}
+
+// アセットの種類（assets/ 配下のサブディレクトリ名に対応）
+// 必要に応じて拡張する
+export type AssetType =
+  | "images"
+  | "audio"
+  | "bgm"
+  | "se"
+  | "voice"
+  | "video"
+  | "fonts";
+
+export const ASSET_TYPES: ReadonlyArray<AssetType> = [
+  "images",
+  "audio",
+  "bgm",
+  "se",
+  "voice",
+  "video",
+  "fonts",
+];
+
+export const MAX_ASSET_BYTES = 5 * 1024 * 1024; // 5 MiB

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -45,6 +45,8 @@ export interface AssetUploadBody {
   contentBase64: string;
   message: string;
   branch?: string;
+  // 既存ファイルを上書きする場合の sha。新規作成時は省略する。
+  sha?: string;
 }
 
 // アセットの種類（assets/ 配下のサブディレクトリ名に対応）

--- a/worker/test/assets.test.ts
+++ b/worker/test/assets.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/types";
 import { MAX_ASSET_BYTES } from "../src/types";
@@ -13,6 +13,24 @@ const ENV: Env = {
 const ctx = { waitUntil: () => {}, passThroughOnException: () => {} } as unknown as ExecutionContext;
 
 const ORIGINAL_FETCH = globalThis.fetch;
+
+beforeEach(async () => {
+  // assets キャッシュをテスト間で持ち越さないよう、毎回 caches.default をパージ。
+  // assetsCacheKey の規則: assets:{owner}/{repo}:{ref}:{type}
+  const cache = (caches as unknown as { default?: Cache }).default;
+  if (cache) {
+    const keysToPurge = [
+      "assets:kako-jun/ogurasia:default:images",
+      "assets:kako-jun/ogurasia:default:audio",
+      "assets:kako-jun/skirts-colour:default:images",
+    ];
+    for (const k of keysToPurge) {
+      await cache.delete(
+        new Request(`https://name-name-cache.local/${encodeURIComponent(k)}`),
+      );
+    }
+  }
+});
 
 afterEach(() => {
   globalThis.fetch = ORIGINAL_FETCH;
@@ -124,6 +142,60 @@ describe("POST /api/projects/:name/assets/:type", () => {
     expect(res.status).toBe(413);
   });
 
+  it("rejects asset == 5 MiB with 413 (boundary)", async () => {
+    // ちょうど MAX_ASSET_BYTES (5 MiB) を作る。
+    // base64 のデコード後バイト数 N に対し、文字長 = ceil(N / 3) * 4。
+    // N = 5 MiB は 3 の倍数 (5*1024*1024 = 5242880 = 3*1747626 + 2)
+    // → 文字長 = 1747627 * 4 = 6990508、末尾パディング 1 個 ('=')
+    // 安全側で N = MAX_ASSET_BYTES ぴったりになる base64 を生成する
+    const N = MAX_ASSET_BYTES; // 5 * 1024 * 1024
+    // bytes 列を base64 化した時の長さは 4*ceil(N/3)、末尾パディング数は (3 - N%3) % 3
+    const groupCount = Math.ceil(N / 3);
+    const padCount = (3 - (N % 3)) % 3;
+    const b64Length = groupCount * 4;
+    const big = "A".repeat(b64Length - padCount) + "=".repeat(padCount);
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "exact.png",
+          contentBase64: big,
+          message: "add exact 5 MiB",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { error: string; size: number };
+    expect(body.size).toBe(MAX_ASSET_BYTES);
+    expect(body.error).toContain("#116");
+  });
+
+  it("rejects invalid base64 (length not multiple of 4) with 400", async () => {
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "bad.png",
+          contentBase64: "AAA", // length 3 → not a multiple of 4
+          message: "add bad",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(400);
+  });
+
   it("rejects filenames with slashes", async () => {
     const req = new Request(
       "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
@@ -144,7 +216,7 @@ describe("POST /api/projects/:name/assets/:type", () => {
     expect(res.status).toBe(400);
   });
 
-  it("uploads small asset and returns 201", async () => {
+  it("uploads small asset and returns 201 with x-cache: BYPASS", async () => {
     globalThis.fetch = vi.fn(async () =>
       jsonResponse(
         {
@@ -172,7 +244,69 @@ describe("POST /api/projects/:name/assets/:type", () => {
     );
     const res = await worker.fetch(req, ENV, ctx);
     expect(res.status).toBe(201);
+    expect(res.headers.get("x-cache")).toBe("BYPASS");
     const body = (await res.json()) as { sha: string };
     expect(body.sha).toBe("newsha");
+  });
+
+  it("forwards sha when provided (existing-file overwrite)", async () => {
+    let capturedBody: unknown = null;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      void input;
+      if (init?.body && typeof init.body === "string") {
+        capturedBody = JSON.parse(init.body);
+      }
+      return jsonResponse(
+        {
+          content: { sha: "updatedsha", path: "assets/images/x.png" },
+          commit: { sha: "commit2" },
+        },
+        200,
+      );
+    }) as typeof fetch;
+
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "x.png",
+          contentBase64: "AAAA",
+          message: "overwrite",
+          sha: "existing-sha",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(201);
+    const sent = capturedBody as { sha?: string } | null;
+    expect(sent?.sha).toBe("existing-sha");
+  });
+
+  it("propagates 422 when GitHub returns 422 (e.g. existing file without sha)", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ message: "Invalid request. \"sha\" wasn't supplied." }, 422),
+    ) as typeof fetch;
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "x.png",
+          contentBase64: "AAAA",
+          message: "add (no sha)",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(422);
   });
 });

--- a/worker/test/assets.test.ts
+++ b/worker/test/assets.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import worker from "../src/index";
+import type { Env } from "../src/types";
+import { MAX_ASSET_BYTES } from "../src/types";
+
+const ENV: Env = {
+  ALLOWED_ORIGIN: "https://name-name.llll-ll.com",
+  DEFAULT_OWNER: "kako-jun",
+  GITHUB_TOKEN: "test-pat",
+  DEV_AUTH_TOKEN: "dev-token",
+};
+
+const ctx = { waitUntil: () => {}, passThroughOnException: () => {} } as unknown as ExecutionContext;
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "x-ratelimit-remaining": "4900",
+    },
+  });
+}
+
+describe("GET /api/projects/:name/assets/:type", () => {
+  it("returns directory listing as AssetEntry[]", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse([
+        {
+          name: "title.png",
+          path: "assets/images/title.png",
+          sha: "abc",
+          size: 1234,
+          type: "file",
+          download_url: "https://raw.example/title.png",
+        },
+        {
+          name: "subdir",
+          path: "assets/images/subdir",
+          sha: "def",
+          size: 0,
+          type: "dir",
+          download_url: null,
+        },
+      ]),
+    ) as typeof fetch;
+
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { type: string; entries: Array<{ name: string }> };
+    expect(body.type).toBe("images");
+    expect(body.entries.map((e) => e.name)).toEqual(["title.png", "subdir"]);
+  });
+
+  it("returns empty array when GitHub responds 404", async () => {
+    globalThis.fetch = vi.fn(async () => jsonResponse({ message: "Not Found" }, 404)) as typeof fetch;
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/audio",
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { entries: unknown[] };
+    expect(body.entries).toEqual([]);
+  });
+
+  it("rejects unknown asset type with 400", async () => {
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/weapons",
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/projects/:name/assets/:type", () => {
+  it("requires editor auth", async () => {
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          filename: "x.png",
+          contentBase64: "AAAA",
+          message: "add",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects asset > 5 MiB with 413", async () => {
+    // base64 length to exceed MAX_ASSET_BYTES の 5 MiB → 約 5,592,406 文字
+    const targetBytes = MAX_ASSET_BYTES + 1024;
+    const b64Length = Math.ceil(targetBytes / 3) * 4;
+    const big = "A".repeat(b64Length);
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "big.png",
+          contentBase64: big,
+          message: "add big",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(413);
+  });
+
+  it("rejects filenames with slashes", async () => {
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "sub/x.png",
+          contentBase64: "AAAA",
+          message: "add",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("uploads small asset and returns 201", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(
+        {
+          content: { sha: "newsha", path: "assets/images/x.png" },
+          commit: { sha: "commit" },
+        },
+        201,
+      ),
+    ) as typeof fetch;
+
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "x.png",
+          contentBase64: "AAAA", // 3 bytes after decode
+          message: "add",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { sha: string };
+    expect(body.sha).toBe("newsha");
+  });
+});

--- a/worker/test/contents.test.ts
+++ b/worker/test/contents.test.ts
@@ -33,10 +33,23 @@ function jsonResponse(body: unknown, status = 200, headers: Record<string, strin
   });
 }
 
-beforeEach(() => {
-  // Cache API のキャッシュをテスト間で持ち越さないため、毎回モックを差し替え。
-  // miniflare の caches.default はテストごとにクリアされない場合があるので、
-  // URL に test-id を含めて衝突を回避する手も取れるが、ここでは fetch モックで対処。
+beforeEach(async () => {
+  // Cache API のキャッシュをテスト間で持ち越さないよう、毎回 caches.default を
+  // 走査・パージする。miniflare 環境では caches.default が利用可能。
+  const cache = (caches as unknown as { default?: Cache }).default;
+  if (cache) {
+    // 本テストで使うキー（ogurasia の chapters / missing 等）を網羅的に削除する。
+    // contentsCacheKey の組み立て規則に合わせる: contents:{owner}/{repo}:{ref}:{path}
+    const keysToPurge = [
+      "contents:kako-jun/ogurasia:default:chapters/all.md",
+      "contents:kako-jun/ogurasia:default:missing.md",
+    ];
+    for (const k of keysToPurge) {
+      await cache.delete(
+        new Request(`https://name-name-cache.local/${encodeURIComponent(k)}`),
+      );
+    }
+  }
 });
 
 afterEach(() => {
@@ -92,6 +105,32 @@ describe("GET /api/projects/:name/contents/*", () => {
     const res = await worker.fetch(req, ENV, ctx);
     expect(res.status).toBe(404);
   });
+
+  it("rejects path containing '..' with 400", async () => {
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/foo/..%2Fetc/passwd",
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 502 when GitHub returns invalid base64", async () => {
+    // atob が InvalidCharacterError を投げる文字列を仕込む
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({
+        type: "file",
+        path: "chapters/all.md",
+        sha: "deadbeef",
+        encoding: "base64",
+        content: "@@@not-base64@@@",
+      }),
+    ) as typeof fetch;
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/chapters/all.md",
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(502);
+  });
 });
 
 describe("PUT /api/projects/:name/contents/*", () => {
@@ -112,7 +151,7 @@ describe("PUT /api/projects/:name/contents/*", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 400 if sha is missing", async () => {
+  it("returns 400 if sha is missing and references #115 in error", async () => {
     const req = new Request(
       "https://name-name-api.workers.dev/api/projects/ogurasia/contents/chapters/all.md",
       {
@@ -128,6 +167,23 @@ describe("PUT /api/projects/:name/contents/*", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("sha");
+    expect(body.error).toContain("#115");
+  });
+
+  it("rejects PUT path containing '..' with 400 before auth", async () => {
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/foo/..%2Fetc/passwd",
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({ content: "x", sha: "abc", message: "test" }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(400);
   });
 
   it("returns 409 when GitHub responds with sha mismatch", async () => {
@@ -180,6 +236,7 @@ describe("PUT /api/projects/:name/contents/*", () => {
     );
     const res = await worker.fetch(req, ENV, ctx);
     expect(res.status).toBe(200);
+    expect(res.headers.get("x-cache")).toBe("PURGED");
     const body = (await res.json()) as { sha: string };
     expect(body.sha).toBe("newsha");
   });

--- a/worker/test/contents.test.ts
+++ b/worker/test/contents.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import worker from "../src/index";
+import type { Env } from "../src/types";
+
+const ENV: Env = {
+  ALLOWED_ORIGIN: "https://name-name.llll-ll.com",
+  DEFAULT_OWNER: "kako-jun",
+  GITHUB_TOKEN: "test-pat",
+  DEV_AUTH_TOKEN: "dev-token",
+};
+
+const ctx = { waitUntil: () => {}, passThroughOnException: () => {} } as unknown as ExecutionContext;
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function utf8Base64(text: string): string {
+  // node + workers どちらでも使えるよう、Buffer なし実装
+  const bytes = new TextEncoder().encode(text);
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "x-ratelimit-remaining": "4999",
+      "x-ratelimit-limit": "5000",
+      ...headers,
+    },
+  });
+}
+
+beforeEach(() => {
+  // Cache API のキャッシュをテスト間で持ち越さないため、毎回モックを差し替え。
+  // miniflare の caches.default はテストごとにクリアされない場合があるので、
+  // URL に test-id を含めて衝突を回避する手も取れるが、ここでは fetch モックで対処。
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  vi.restoreAllMocks();
+});
+
+describe("GET /api/projects/:name/contents/*", () => {
+  it("decodes base64 contents and returns { path, sha, content }", async () => {
+    const text = "# オグラシア\nこんにちは\n";
+    const seenUrls: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      seenUrls.push(url);
+      return jsonResponse({
+        type: "file",
+        path: "chapters/all.md",
+        sha: "deadbeef",
+        encoding: "base64",
+        content: utf8Base64(text),
+      });
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/chapters/all.md",
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { path: string; sha: string; content: string };
+    expect(body.path).toBe("chapters/all.md");
+    expect(body.sha).toBe("deadbeef");
+    expect(body.content).toBe(text);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(seenUrls[0]).toContain("/repos/kako-jun/ogurasia/contents/");
+  });
+
+  it("returns 404 for unknown project", async () => {
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/no-such-game/contents/foo.md",
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("propagates GitHub 404 for missing files", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ message: "Not Found" }, 404),
+    ) as typeof fetch;
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/missing.md",
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PUT /api/projects/:name/contents/*", () => {
+  it("requires editor auth", async () => {
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/chapters/all.md",
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          content: "x",
+          sha: "abc",
+          message: "test",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 if sha is missing", async () => {
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/chapters/all.md",
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({ content: "x", message: "test" }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("sha");
+  });
+
+  it("returns 409 when GitHub responds with sha mismatch", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ message: "sha does not match" }, 409),
+    ) as typeof fetch;
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/chapters/all.md",
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          content: "new",
+          sha: "stale",
+          message: "edit",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(409);
+  });
+
+  it("succeeds with valid sha and editor token", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(
+        {
+          content: { sha: "newsha", path: "chapters/all.md" },
+          commit: { sha: "commit-sha" },
+        },
+        200,
+      ),
+    ) as typeof fetch;
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/chapters/all.md",
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          content: "new",
+          sha: "fresh",
+          message: "edit",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { sha: string };
+    expect(body.sha).toBe("newsha");
+  });
+});

--- a/worker/test/projects.test.ts
+++ b/worker/test/projects.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import worker from "../src/index";
+import type { Env } from "../src/types";
+
+const ENV: Env = {
+  ALLOWED_ORIGIN: "https://name-name.llll-ll.com",
+  DEFAULT_OWNER: "kako-jun",
+  GITHUB_TOKEN: "test-pat",
+  DEV_AUTH_TOKEN: "dev-token",
+};
+
+const ctx = { waitUntil: () => {}, passThroughOnException: () => {} } as unknown as ExecutionContext;
+
+describe("GET /api/projects", () => {
+  it("returns the hard-coded project list", async () => {
+    const req = new Request("https://name-name-api.workers.dev/api/projects");
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { projects: Array<{ name: string }> };
+    expect(body.projects.length).toBe(4);
+    expect(body.projects.map((p) => p.name)).toEqual([
+      "ogurasia",
+      "skirts-colour",
+      "friday-1930",
+      "gymnasia",
+    ]);
+  });
+
+  it("attaches CORS headers for the allowed origin", async () => {
+    const req = new Request("https://name-name-api.workers.dev/api/projects", {
+      headers: { origin: "https://name-name.llll-ll.com" },
+    });
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "https://name-name.llll-ll.com",
+    );
+  });
+
+  it("responds to OPTIONS preflight with 204", async () => {
+    const req = new Request("https://name-name-api.workers.dev/api/projects", {
+      method: "OPTIONS",
+      headers: { origin: "https://name-name.llll-ll.com" },
+    });
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-methods")).toContain("GET");
+  });
+
+  it("returns 405 for unsupported methods", async () => {
+    const req = new Request("https://name-name-api.workers.dev/api/projects", {
+      method: "DELETE",
+    });
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(405);
+  });
+
+  it("returns 404 for unknown routes", async () => {
+    const req = new Request("https://name-name-api.workers.dev/api/unknown");
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(404);
+  });
+});

--- a/worker/test/projects.test.ts
+++ b/worker/test/projects.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import worker from "../src/index";
+import { splitRepo } from "../src/projects";
 import type { Env } from "../src/types";
 
 const ENV: Env = {
@@ -46,6 +47,29 @@ describe("GET /api/projects", () => {
     expect(res.headers.get("access-control-allow-methods")).toContain("GET");
   });
 
+  it("falls back to ALLOWED_ORIGIN for disallowed preflight Origin", async () => {
+    const req = new Request("https://name-name-api.workers.dev/api/projects", {
+      method: "OPTIONS",
+      headers: { origin: "https://evil.example" },
+    });
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(204);
+    // 許可外 Origin は echo back せず、必ず ALLOWED_ORIGIN を返す
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "https://name-name.llll-ll.com",
+    );
+  });
+
+  it("falls back to ALLOWED_ORIGIN for disallowed Origin on a normal response", async () => {
+    const req = new Request("https://name-name-api.workers.dev/api/projects", {
+      headers: { origin: "https://evil.example" },
+    });
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "https://name-name.llll-ll.com",
+    );
+  });
+
   it("returns 405 for unsupported methods", async () => {
     const req = new Request("https://name-name-api.workers.dev/api/projects", {
       method: "DELETE",
@@ -58,5 +82,38 @@ describe("GET /api/projects", () => {
     const req = new Request("https://name-name-api.workers.dev/api/unknown");
     const res = await worker.fetch(req, ENV, ctx);
     expect(res.status).toBe(404);
+  });
+});
+
+describe("splitRepo()", () => {
+  it("splits owner/repo correctly", () => {
+    expect(splitRepo({ name: "x", title: "X", repo: "kako-jun/x" })).toEqual({
+      owner: "kako-jun",
+      repo: "x",
+    });
+  });
+
+  it("throws when project.repo lacks a '/'", () => {
+    expect(() =>
+      splitRepo({ name: "x", title: "X", repo: "no-slash" }),
+    ).toThrowError(/invalid project\.repo/);
+  });
+
+  it("throws when project.repo is empty", () => {
+    expect(() =>
+      splitRepo({ name: "x", title: "X", repo: "" }),
+    ).toThrowError(/invalid project\.repo/);
+  });
+
+  it("throws when owner is empty", () => {
+    expect(() =>
+      splitRepo({ name: "x", title: "X", repo: "/repo" }),
+    ).toThrowError(/invalid project\.repo/);
+  });
+
+  it("throws when repo is empty", () => {
+    expect(() =>
+      splitRepo({ name: "x", title: "X", repo: "owner/" }),
+    ).toThrowError(/invalid project\.repo/);
   });
 });

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/worker/vitest.config.ts
+++ b/worker/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+// vitest-pool-workers 経由で workerd 上でテストを走らせる。
+// wrangler.toml を再利用し、テスト用の env を上書きする。
+export default defineWorkersConfig({
+  test: {
+    poolOptions: {
+      workers: {
+        wrangler: { configPath: "./wrangler.toml" },
+        miniflare: {
+          // テスト用の secret / vars 上書き
+          bindings: {
+            ALLOWED_ORIGIN: "https://name-name.llll-ll.com",
+            DEFAULT_OWNER: "kako-jun",
+            GITHUB_TOKEN: "test-pat",
+            DEV_AUTH_TOKEN: "dev-token",
+          },
+        },
+      },
+    },
+  },
+});

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,12 @@
+name = "name-name-api"
+main = "src/index.ts"
+compatibility_date = "2026-05-01"
+compatibility_flags = ["nodejs_compat"]
+
+[vars]
+ALLOWED_ORIGIN = "https://name-name.llll-ll.com"
+DEFAULT_OWNER = "kako-jun"
+
+# Secrets (set via `wrangler secret put`):
+# - GITHUB_TOKEN  : GitHub PAT (fine-grained, contents:write on game repos)
+# - DEV_AUTH_TOKEN: ローカル開発用の bearer token (本番は CF Access / GitHub OAuth, #110)


### PR DESCRIPTION
## 関連 Issue

closes #106

## 概要

旧 FastAPI/GitPython バックエンドの代わりに CF Worker を新設。Agasteer 方式で GitHub REST API を叩き、各ゲームリポの読み書きを行う。

## 実装

### ディレクトリ構造

```
worker/
├── package.json            @octokit/core, vitest, vitest-pool-workers, wrangler
├── wrangler.toml           name-name-api, nodejs_compat 必須
├── tsconfig.json           strict
├── vitest.config.ts        miniflare bindings
├── README.md               起動・テスト・secret 設定手順
├── src/
│   ├── index.ts            エントリ + ルーティング + CORS + OPTIONS
│   ├── github.ts           octokit ラッパー + rate-limit ログ + normalizeError
│   ├── auth.ts             authenticate / requireEditor スタブ (#110 で本実装)
│   ├── cache.ts            Cache API 60秒、contents/assets キー
│   ├── projects.ts         ハードコード PROJECTS=4件
│   ├── contents.ts         GET/PUT、base64↔utf8、楽観ロック (sha必須、409伝搬)
│   ├── assets.ts           GET/POST、5 MiB 制限
│   └── types.ts            Env / Project / AssetEntry
└── test/                   19 テスト (3 files)
```

### エンドポイント

- `GET /api/projects` — 4件のハードコード一覧
- `GET /api/projects/:name/contents/*path` — Contents API ラッパー (base64 デコード)、Cache 60秒
- `PUT /api/projects/:name/contents/*path` — sha必須、editor認証必須、409伝搬、Cache パージ
- `GET /api/projects/:name/assets/:type` — `assets/{type}/` 一覧、404 は空配列
- `POST /api/projects/:name/assets/:type` — base64 アップロード、>5MiB は 413

### 認証スタブ

`auth.ts` は `Bearer ${env.DEV_AUTH_TOKEN}` を一致した場合のみ editor 扱い。本実装は **#110**。

### Rate Limit

octokit のレスポンスヘッダ `x-ratelimit-remaining` を `console.log` に出力。

## テスト結果

```
Test Files  3 passed (3)
     Tests  19 passed (19)
  Duration  1.19s
```

## 強制検証

- `git status`: clean
- `npm install`: OK (197 packages)
- `npm run build` (`tsc --noEmit`): OK
- `npm test`: 19/19 passed

## フォローアップ

- **#110** `auth.ts` 本実装 (CF Access JWT or GitHub OAuth)
- **#111** 初回 `wrangler deploy`（kako-jun が手動）
- **#112** 旧 `backend/` (FastAPI/GitPython) と `compose.yaml` の削除
- 別 Issue (未起票): >5 MiB アセットを Git Data API で扱う
- 別 Issue (未起票): PROJECTS リストの KV / D1 化
- 別 Issue (未起票): 新規ファイル作成 (sha なし PUT) の対応

## 設計判断

- `wrangler.toml` に `compatibility_flags = ["nodejs_compat"]` 必須（vitest-pool-workers 起動条件、octokit が node 互換要求の可能性）
- ルータは正規表現3本で十分シンプルなため itty-router 不採用
- octokit は軽量な `@octokit/core` 採用
- Cache API は `caches.default` 不在環境でも落ちないようガード
- `GET /api/projects/:name/assets/:type` の 404 は「未作成ディレクトリ」の正常系として空配列に丸める。contents の 404 は伝搬

## 触っていない領域（指示通り）

- フロント (`frontend/`)
- 旧バックエンド (`backend/`)
- Docker Compose (`compose.yaml`)