### PR TITLE
feat: #115 PUT contents で sha 任意化（新規ファイル作成対応）

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -20,7 +20,7 @@ Issue: kako-jun/name-name#106
 |---|---|---|
 | GET | `/api/projects` | 公開ゲーム一覧（ハードコード）|
 | GET | `/api/projects/:name/contents/*path` | Contents API ラッパー (base64 → utf-8) |
-| PUT | `/api/projects/:name/contents/*path` | Contents API で commit。sha 必須（楽観ロック）|
+| PUT | `/api/projects/:name/contents/*path` | Contents API で commit。**新規作成 + 更新どちらも対応**（#115 で実装済）|
 | GET | `/api/projects/:name/assets/:type` | `assets/{type}/` のディレクトリ一覧 |
 | POST | `/api/projects/:name/assets/:type` | base64 アップロード（**5 MiB 未満**）|
 
@@ -72,11 +72,26 @@ npm run dev
 curl http://localhost:8787/api/projects
 curl http://localhost:8787/api/projects/ogurasia/contents/chapters/all.md
 
+# 既存ファイルの更新（sha 必須・楽観ロック）
 curl -X PUT http://localhost:8787/api/projects/ogurasia/contents/chapters/all.md \
   -H "authorization: Bearer ${DEV_AUTH_TOKEN}" \
   -H "content-type: application/json" \
   -d '{"content":"# 新本文","sha":"<前回の sha>","message":"edit chapters/all"}'
+
+# 新規ファイルの作成（sha 省略 / message も省略可：デフォルト `create <path>`）
+curl -X PUT http://localhost:8787/api/projects/ogurasia/contents/chapters/new.md \
+  -H "authorization: Bearer ${DEV_AUTH_TOKEN}" \
+  -H "content-type: application/json" \
+  -d '{"content":"# 新シーン"}'
 ```
+
+`PUT` のセマンティクス（#115）:
+
+- `sha` あり → 既存ファイル更新。GitHub が sha 不一致を検知すると `409 Conflict`。
+- `sha` なし → 新規ファイル作成。同名ファイルが既にある場合、GitHub が返す `422` を
+  Worker 側で `409 Conflict` に正規化して返す（更新するなら `sha` を渡してくださいの旨）。
+- `message` 任意（省略時は `create <path>` / `update <path>` のデフォルト）。
+- 成功時はどちらも `200 OK` で `{ path, sha, commit_sha }` を返し、`x-cache: PURGED`。
 
 ## デプロイ
 
@@ -91,10 +106,13 @@ wrangler deploy
 - **#110** authenticate() 本実装（CF Access / GitHub OAuth）
 - **#111** 初回 wrangler deploy（kako-jun が手動）
 - **#112** 旧 `backend/` (FastAPI) と `compose.yaml` の削除
-- **#115** 新規ファイル作成エンドポイント（sha なし PUT）
 - **#116** `>= 5 MiB` のアセットを Git Data API (blob/tree/commit) で扱う
 - **#117** PROJECTS リストの KV / D1 化
 - **#118** ブランチ横断のキャッシュパージ（GitHub webhook 経由）
+
+実装済:
+
+- **#115** 新規ファイル作成エンドポイント（sha なし PUT）— 422 → 409 正規化、`PUT` で create + update 両対応
 
 ## ファイル構成
 

--- a/worker/src/contents.ts
+++ b/worker/src/contents.ts
@@ -1,9 +1,10 @@
 // /api/projects/:name/contents/* ハンドラ
 //
 // - GET : Contents API を叩いて base64 を utf-8 にデコード、{ path, sha, content } を返す
-// - PUT : { content, sha, message, branch? } を受け取り、base64 化して PUT する
-//         sha mismatch (409) はそのまま 409 でクライアントへ返す
-//         新規ファイル作成 (sha なし) は #115 で実装予定。現状は 400 で reject する。
+// - PUT : { content, sha?, message?, branch? } を受け取り、base64 化して PUT する
+//         sha あり → 既存ファイル更新（GitHub は sha 不一致で 409 を返す。そのまま伝搬）
+//         sha なし → 新規ファイル作成（#115）。GitHub は同名ファイル既存で 422 を返すので
+//                    `409 Conflict` に正規化してクライアントへ返す。
 
 import type { Endpoints } from "@octokit/types";
 import { authenticate, requireEditor } from "./auth";
@@ -151,14 +152,19 @@ export async function handlePutContents(
     return badRequest("invalid JSON body");
   }
   if (typeof body.content !== "string") return badRequest("content is required");
-  if (typeof body.sha !== "string" || body.sha.length === 0) {
-    // TODO(#115): 新規ファイル作成 (sha なし PUT) のサポート。
-    //   現状は仕様乖離より UX 優先で 400 を返す。
-    return badRequest("sha is required for update; create is not implemented yet (see #115)");
-  }
-  if (typeof body.message !== "string" || body.message.length === 0) {
-    return badRequest("message is required");
-  }
+
+  // sha は任意。あれば update、なければ create として扱う（#115）。
+  const sha: string | undefined =
+    typeof body.sha === "string" && body.sha.length > 0 ? body.sha : undefined;
+  const isCreate = sha === undefined;
+
+  // message はデフォルトを用意（明示指定があればそちらを優先）。
+  const message =
+    typeof body.message === "string" && body.message.length > 0
+      ? body.message
+      : isCreate
+        ? `create ${path}`
+        : `update ${path}`;
 
   const { owner, repo } = splitRepo(project);
   const branch = body.branch;
@@ -168,14 +174,16 @@ export async function handlePutContents(
       owner,
       repo,
       path,
-      message: body.message,
+      message,
       content: utf8ToBase64(body.content),
-      sha: body.sha,
+      // sha が undefined のままだと octokit がペイロードに含めないため、新規作成扱いになる。
+      sha,
       branch,
     });
     logRateLimit("contents.put", res.headers as Record<string, string | number | undefined>);
 
     // 該当パスの read キャッシュをパージ（branch 指定の有無を両方）。
+    // create 成功時も同じパスに対する古い 404 キャッシュを掃除しておく。
     // NOTE(#118): 現状はこの Worker が触る branch / default 二系統だけパージしている。
     //   ブランチ横断でのパージは GitHub webhook 経由で #118 にて本実装する予定。
     await cacheDelete(contentsCacheKey(owner, repo, path, branch ?? null));
@@ -194,6 +202,18 @@ export async function handlePutContents(
   } catch (err) {
     const ne = normalizeError(err);
     logRateLimit("contents.put.err", ne.responseHeaders);
+    // create 経路で同名ファイルが既にある場合、GitHub は 422 を返す。
+    // クライアント視点では「衝突」なので 409 Conflict に正規化する。
+    if (isCreate && ne.status === 422) {
+      return jsonResponse(
+        {
+          error:
+            "file already exists at this path; pass `sha` to update the existing file",
+          status: 409,
+        },
+        409,
+      );
+    }
     // 409 (sha mismatch) は楽観ロック失敗としてそのまま伝える
     return jsonResponse({ error: ne.message, status: ne.status }, ne.status);
   }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -25,8 +25,10 @@ export interface ContentsGetResponse {
 
 export interface ContentsPutBody {
   content: string;
-  sha: string;
-  message: string;
+  // sha があれば既存ファイル更新（楽観ロック）、なければ新規作成。
+  // GitHub の Contents API は sha 不一致 → 409、同名ファイル既存で sha なし → 422 を返す。
+  sha?: string;
+  message?: string;
   branch?: string;
 }
 

--- a/worker/test/contents.test.ts
+++ b/worker/test/contents.test.ts
@@ -151,25 +151,6 @@ describe("PUT /api/projects/:name/contents/*", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 400 if sha is missing and references #115 in error", async () => {
-    const req = new Request(
-      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/chapters/all.md",
-      {
-        method: "PUT",
-        headers: {
-          "content-type": "application/json",
-          authorization: "Bearer dev-token",
-        },
-        body: JSON.stringify({ content: "x", message: "test" }),
-      },
-    );
-    const res = await worker.fetch(req, ENV, ctx);
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toContain("sha");
-    expect(body.error).toContain("#115");
-  });
-
   it("rejects PUT path containing '..' with 400 before auth", async () => {
     const req = new Request(
       "https://name-name-api.workers.dev/api/projects/ogurasia/contents/foo/..%2Fetc/passwd",

--- a/worker/test/contents.test.ts
+++ b/worker/test/contents.test.ts
@@ -190,7 +190,7 @@ describe("PUT /api/projects/:name/contents/*", () => {
     expect(res.status).toBe(409);
   });
 
-  it("succeeds with valid sha and editor token", async () => {
+  it("succeeds with valid sha and editor token (update)", async () => {
     globalThis.fetch = vi.fn(async () =>
       jsonResponse(
         {
@@ -220,5 +220,143 @@ describe("PUT /api/projects/:name/contents/*", () => {
     expect(res.headers.get("x-cache")).toBe("PURGED");
     const body = (await res.json()) as { sha: string };
     expect(body.sha).toBe("newsha");
+  });
+
+  // --- #115: 新規ファイル作成（sha なし PUT） ---
+
+  it("creates a new file when sha is omitted and forwards no sha to GitHub (#115)", async () => {
+    const seenBodies: unknown[] = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.body && typeof init.body === "string") {
+        seenBodies.push(JSON.parse(init.body));
+      }
+      return jsonResponse(
+        {
+          content: { sha: "createdsha", path: "chapters/new.md" },
+          commit: { sha: "create-commit-sha" },
+        },
+        200,
+      );
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/chapters/new.md",
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          // sha を渡さない → create 経路
+          content: "# 新規シーン\n",
+          message: "create chapters/new",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-cache")).toBe("PURGED");
+    const body = (await res.json()) as { sha: string; commit_sha: string; path: string };
+    expect(body.sha).toBe("createdsha");
+    expect(body.commit_sha).toBe("create-commit-sha");
+    expect(body.path).toBe("chapters/new.md");
+
+    // GitHub に送ったペイロードに sha が含まれていないことを確認
+    expect(seenBodies.length).toBe(1);
+    const sent = seenBodies[0] as Record<string, unknown>;
+    expect(sent.sha).toBeUndefined();
+    expect(typeof sent.content).toBe("string");
+  });
+
+  it("normalizes GitHub 422 to 409 when creating but file already exists (#115)", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(
+        {
+          message: "Invalid request.\n\n\"sha\" wasn't supplied.",
+        },
+        422,
+      ),
+    ) as typeof fetch;
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/chapters/all.md",
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          // sha 省略の create だが、サーバ側に既存ファイルがある
+          content: "# 上書きしたい",
+          message: "create",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string; status?: number };
+    expect(body.error.toLowerCase()).toContain("already exists");
+    expect(body.error).toContain("sha");
+  });
+
+  it("creates with default commit message when message is omitted (#115)", async () => {
+    const seenBodies: unknown[] = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.body && typeof init.body === "string") {
+        seenBodies.push(JSON.parse(init.body));
+      }
+      return jsonResponse(
+        {
+          content: { sha: "createdsha", path: "chapters/new.md" },
+          commit: { sha: "create-commit-sha" },
+        },
+        200,
+      );
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/chapters/new.md",
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        // sha も message も省略
+        body: JSON.stringify({ content: "x" }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(200);
+    const sent = seenBodies[0] as Record<string, unknown>;
+    expect(typeof sent.message).toBe("string");
+    expect((sent.message as string).length).toBeGreaterThan(0);
+  });
+
+  it("preserves 409 sha-mismatch behavior on update path (regression for #115)", async () => {
+    // sha あり PUT で GitHub が 409 を返したら、Worker は 409 のまま返す
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse({ message: "sha does not match" }, 409),
+    ) as typeof fetch;
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/contents/chapters/all.md",
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          content: "new",
+          sha: "stale",
+          message: "edit",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(409);
   });
 });


### PR DESCRIPTION
## 関連 Issue

closes #115

## 概要

#106 で実装した `PUT /api/projects/:name/contents/*path` は sha 必須（更新専用）だったため、新規ファイル作成が完全に塞がれていた。#107 でフロントが Worker URL に切り替わると新シーン追加で詰まるため、create 経路を解禁する。

## 変更点

### `worker/src/contents.ts`
- `handlePutContents` の `sha` を任意に変更
- `sha` あり → 更新（GitHub Contents API は sha 一致を要求、不一致は 409）
- `sha` なし → 新規作成（既存ファイルがあれば GitHub が 422 を返す）
- 422 を **409 Conflict** に正規化してクライアントに返却（「ファイル既存。更新するなら sha を渡してください」）
- `message` も任意化、デフォルト `create <path>` / `update <path>`

### `worker/src/types.ts`
- `ContentsPutBody.sha` / `message` を任意化

### `worker/test/contents.test.ts`
- 旧「sha なし → 400/#115 文言」テスト削除
- 4 つの新規テスト追加:
  - sha なし create 成功
  - sha なし create で既存ファイル → 409
  - message デフォルト生成
  - sha あり update で sha 不一致 → 409（楽観ロック維持）

### `worker/README.md`
- PUT 説明を「create + update どちらも対応」に更新
- curl サンプル追加
- #115 を「実装済」に

## テスト

- 36/36 passed (projects 12 + assets 11 + contents 13)
- `npm run build`: エラーなし
- 既存 32 テストは全件維持（旧 #115 ガード 1 件のみ削除＝仕様逆転のため）

## 触っていない領域

- assets.ts / auth.ts / cache.ts / github.ts / index.ts / projects.ts は無変更
- フロント (`frontend/`) は無変更
- 旧 backend (`backend/`) は無変更