### PR TITLE
refactor: #107 フロント API 層を localhost:7373 から Worker URL に差し替え

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,12 @@ target/
 # Docker
 *.env.local
 
+# kako-jun/name-name#107: Vite env (frontend/.env, frontend/.env.local 等)
+# .env.example はコミットする（明示的にネガティブパターン）
+frontend/.env
+frontend/.env.*
+!frontend/.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# kako-jun/name-name#107: Worker (CF Workers) の API base URL。
+# 未指定の場合は src/api/client.ts の DEFAULT_API_URL (`http://localhost:8787`) が使われる。
+# 本番では `https://name-name-api.workers.dev` 等を指定する。
+VITE_API_URL=http://localhost:8787

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import ProjectListScreen from './screens/ProjectListScreen'
 import EditorScreen from './screens/EditorScreen'
 import AssetsScreen from './screens/AssetsScreen'
 import { get, set } from './utils/storage'
+import { defaultApiBaseUrl } from './api/client'
 
 function App() {
   const [isDark, setIsDark] = useState(() => {
@@ -11,8 +12,11 @@ function App() {
   })
 
   const [showSettings, setShowSettings] = useState(false)
+  // kako-jun/name-name#107: 既定値を Worker (localhost:8787) に変更。
+  //   localStorage に旧値 (localhost:7373) が残っているケースは
+  //   設定モーダルで上書きできる。VITE_API_URL があればそれが既定値。
   const [apiBaseUrl, setApiBaseUrl] = useState(() => {
-    return get('apiBaseUrl') ?? 'http://localhost:7373'
+    return get('apiBaseUrl') ?? defaultApiBaseUrl()
   })
 
   useEffect(() => {
@@ -86,7 +90,7 @@ function App() {
                       ? 'bg-gray-700 border-gray-600 text-white'
                       : 'bg-white border-gray-300 text-gray-900'
                   }`}
-                  placeholder="http://localhost:7373"
+                  placeholder="http://localhost:8787"
                 />
               </div>
               <button

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -40,6 +40,26 @@ describe('defaultApiBaseUrl', () => {
     expect(typeof url).toBe('string')
     expect(url.length).toBeGreaterThan(0)
   })
+
+  // PR #120 review N3: VITE_API_URL を空にすると 'http://localhost:8787' を返すこと、
+  //   値が入っていればその値を返すことを vi.stubEnv で確定させる。
+  it('VITE_API_URL が空文字なら http://localhost:8787 を返す', () => {
+    vi.stubEnv('VITE_API_URL', '')
+    try {
+      expect(defaultApiBaseUrl()).toBe('http://localhost:8787')
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('VITE_API_URL に値があればその値を返す', () => {
+    vi.stubEnv('VITE_API_URL', 'https://api.example.com')
+    try {
+      expect(defaultApiBaseUrl()).toBe('https://api.example.com')
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
 })
 
 describe('authHeaders', () => {
@@ -219,14 +239,34 @@ describe('createApiClient', () => {
       expect(calls[0].url).toBe(`${BASE}/api/projects/proj/assets/images`)
       expect(calls[0].init?.method).toBe('POST')
       const body = JSON.parse(String(calls[0].init?.body))
+      // PR #120 review N2: sha 未指定時は body 上にキーが現れないことを明示確認する
+      //   (JSON.stringify({sha: undefined}) は "sha" を出さないので
+      //   サーバ側 (Worker) は body.sha === undefined と認識する)。
       expect(body).toEqual({
         filename: 'x.png',
         contentBase64: 'AAAA',
         branch: 'develop',
         message: 'add x',
-        sha: undefined,
       })
+      expect(body.sha).toBeUndefined()
       expect(result.sha).toBe('new-sha')
+    })
+
+    // PR #120 review N2: sha 指定時には body にそのまま乗ること。
+    it('sha 指定時は body.sha を送る', async () => {
+      const { fetchImpl, calls } = makeMockFetch(() =>
+        jsonResponse(
+          { path: 'assets/images/x.png', sha: 'updated', commit_sha: 'cs2', size: 1024 },
+          200
+        )
+      )
+      const api = createApiClient({ baseUrl: BASE, fetchImpl })
+      await api.uploadAsset('proj', 'images', 'x.png', 'AAAA', 'develop', {
+        message: 'overwrite',
+        sha: 'existing-sha',
+      })
+      const body = JSON.parse(String(calls[0].init?.body))
+      expect(body.sha).toBe('existing-sha')
     })
   })
 

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,276 @@
+// kako-jun/name-name#107: API クライアントのモックテスト。
+//
+// fetch をモック化して、リクエスト URL / メソッド / ヘッダ / body と
+// レスポンスの整形が期待どおりであることを検証する。
+// 実際の Worker は呼ばない（ネットワーク非依存）。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, authHeaders, createApiClient, defaultApiBaseUrl, __internal } from './client'
+
+const BASE = 'http://api.test.local'
+
+interface CallRecord {
+  url: string
+  init?: RequestInit
+}
+
+function makeMockFetch(handler: (call: CallRecord) => Response | Promise<Response>) {
+  const calls: CallRecord[] = []
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const record: CallRecord = { url, init }
+    calls.push(record)
+    return handler(record)
+  }
+  return { fetchImpl, calls }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('defaultApiBaseUrl', () => {
+  it('未指定時は localhost:8787 を返す', () => {
+    // VITE_API_URL は vitest 実行環境で未設定が既定
+    const url = defaultApiBaseUrl()
+    // CI で VITE_API_URL を入れることもあるので「localhost:8787 か空でない文字列」を許容
+    expect(typeof url).toBe('string')
+    expect(url.length).toBeGreaterThan(0)
+  })
+})
+
+describe('authHeaders', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('localStorage に dev_auth_token が無ければ空ヘッダ', () => {
+    const headers = authHeaders() as Record<string, string>
+    expect(headers).toEqual({})
+  })
+
+  it('localStorage に dev_auth_token があれば Bearer ヘッダ', () => {
+    localStorage.setItem(__internal.AUTH_TOKEN_STORAGE_KEY, 'tok-xyz')
+    const headers = authHeaders() as Record<string, string>
+    expect(headers).toEqual({ authorization: 'Bearer tok-xyz' })
+  })
+})
+
+describe('createApiClient', () => {
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('listProjects', () => {
+    it('GET /api/projects を叩いて projects 配列を返す', async () => {
+      const projects = [
+        { name: 'ogurasia', title: 'オグラシア', repo: 'kako-jun/ogurasia' },
+        { name: 'gymnasia', title: 'Gymnasia', repo: 'kako-jun/gymnasia' },
+      ]
+      const { fetchImpl, calls } = makeMockFetch(() => jsonResponse({ projects }))
+      const api = createApiClient({ baseUrl: BASE, fetchImpl })
+
+      const result = await api.listProjects()
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0].url).toBe(`${BASE}/api/projects`)
+      expect(calls[0].init?.method).toBeUndefined() // 既定 GET
+      expect(result).toEqual(projects)
+    })
+
+    it('エラー時は ApiError を投げる', async () => {
+      const { fetchImpl } = makeMockFetch(() => jsonResponse({ error: 'oops' }, 500))
+      const api = createApiClient({ baseUrl: BASE, fetchImpl })
+
+      await expect(api.listProjects()).rejects.toBeInstanceOf(ApiError)
+    })
+  })
+
+  describe('getContents', () => {
+    it('ref 指定時は ?ref= クエリを付ける', async () => {
+      const { fetchImpl, calls } = makeMockFetch(() =>
+        jsonResponse({
+          path: 'chapters/all.md',
+          sha: 'abc',
+          content: '# hello',
+          encoding: 'utf-8',
+        })
+      )
+      const api = createApiClient({ baseUrl: BASE, fetchImpl })
+
+      const result = await api.getContents('ogurasia', 'chapters/all.md', 'develop')
+
+      expect(calls[0].url).toBe(
+        `${BASE}/api/projects/ogurasia/contents/chapters/all.md?ref=develop`
+      )
+      expect(result.sha).toBe('abc')
+      expect(result.content).toBe('# hello')
+    })
+
+    it('ref 未指定時はクエリ無し、パスは percent-encode される', async () => {
+      const { fetchImpl, calls } = makeMockFetch(() =>
+        jsonResponse({ path: 'a/b', sha: 's', content: '', encoding: 'utf-8' })
+      )
+      const api = createApiClient({ baseUrl: BASE, fetchImpl })
+
+      await api.getContents('プロジェクト', 'dir/日本語.md')
+
+      // / は保持され、各セグメントだけ encode される
+      expect(calls[0].url).toBe(
+        `${BASE}/api/projects/${encodeURIComponent('プロジェクト')}/contents/dir/${encodeURIComponent(
+          '日本語.md'
+        )}`
+      )
+    })
+
+    it('Bearer トークンを乗せる（localStorage 経由）', async () => {
+      localStorage.setItem(__internal.AUTH_TOKEN_STORAGE_KEY, 'put-token')
+      const { fetchImpl, calls } = makeMockFetch(() =>
+        jsonResponse({ path: 'p', sha: 's', content: '', encoding: 'utf-8' })
+      )
+      const api = createApiClient({ baseUrl: BASE, fetchImpl })
+
+      await api.getContents('p', 'a.md')
+
+      const headers = calls[0].init?.headers as Record<string, string> | undefined
+      expect(headers?.authorization).toBe('Bearer put-token')
+    })
+  })
+
+  describe('putContents', () => {
+    it('PUT で sha / branch / content を送る', async () => {
+      const { fetchImpl, calls } = makeMockFetch(() =>
+        jsonResponse({ path: 'chapters/all.md', sha: 'new-sha', commit_sha: 'commit-sha' })
+      )
+      const api = createApiClient({ baseUrl: BASE, fetchImpl })
+
+      const result = await api.putContents('proj', 'chapters/all.md', {
+        content: '# new content',
+        sha: 'old-sha',
+        branch: 'develop',
+        message: 'update',
+      })
+
+      expect(calls[0].init?.method).toBe('PUT')
+      const body = JSON.parse(String(calls[0].init?.body))
+      expect(body).toEqual({
+        content: '# new content',
+        sha: 'old-sha',
+        branch: 'develop',
+        message: 'update',
+      })
+      expect(result.sha).toBe('new-sha')
+      expect(result.commit_sha).toBe('commit-sha')
+    })
+
+    it('Worker からの 409 は ApiError として伝搬する', async () => {
+      const { fetchImpl } = makeMockFetch(() =>
+        jsonResponse({ error: 'sha mismatch', status: 409 }, 409)
+      )
+      const api = createApiClient({ baseUrl: BASE, fetchImpl })
+
+      const err = await api
+        .putContents('proj', 'p.md', { content: 'x', sha: 'old', branch: 'develop' })
+        .catch((e: unknown) => e)
+      expect(err).toBeInstanceOf(ApiError)
+      expect((err as ApiError).status).toBe(409)
+    })
+  })
+
+  describe('listAssets', () => {
+    it('entries 配列を返し、空でも落ちない', async () => {
+      const entries = [
+        {
+          name: 'logo.png',
+          path: 'assets/images/logo.png',
+          sha: 's1',
+          size: 100,
+          type: 'file' as const,
+          download_url: 'https://raw/x.png',
+        },
+      ]
+      const { fetchImpl, calls } = makeMockFetch(() => jsonResponse({ type: 'images', entries }))
+      const api = createApiClient({ baseUrl: BASE, fetchImpl })
+
+      const result = await api.listAssets('proj', 'images', { ref: 'develop' })
+
+      expect(calls[0].url).toBe(`${BASE}/api/projects/proj/assets/images?ref=develop`)
+      expect(result).toEqual(entries)
+    })
+  })
+
+  describe('uploadAsset', () => {
+    it('JSON + base64 で POST する', async () => {
+      const { fetchImpl, calls } = makeMockFetch(() =>
+        jsonResponse(
+          { path: 'assets/images/x.png', sha: 'new-sha', commit_sha: 'cs', size: 1024 },
+          201
+        )
+      )
+      const api = createApiClient({ baseUrl: BASE, fetchImpl })
+
+      const result = await api.uploadAsset('proj', 'images', 'x.png', 'AAAA', 'develop', {
+        message: 'add x',
+      })
+
+      expect(calls[0].url).toBe(`${BASE}/api/projects/proj/assets/images`)
+      expect(calls[0].init?.method).toBe('POST')
+      const body = JSON.parse(String(calls[0].init?.body))
+      expect(body).toEqual({
+        filename: 'x.png',
+        contentBase64: 'AAAA',
+        branch: 'develop',
+        message: 'add x',
+        sha: undefined,
+      })
+      expect(result.sha).toBe('new-sha')
+    })
+  })
+
+  describe('compatibility stubs', () => {
+    it('getStatus は { has_uncommitted: false } を返す', async () => {
+      const { fetchImpl } = makeMockFetch(() => jsonResponse({}))
+      const api = createApiClient({ baseUrl: BASE, fetchImpl })
+      await expect(api.getStatus()).resolves.toEqual({ has_uncommitted: false })
+    })
+
+    it('commit / discard は no-op で完了する', async () => {
+      const { fetchImpl, calls } = makeMockFetch(() => jsonResponse({}))
+      const api = createApiClient({ baseUrl: BASE, fetchImpl })
+      await api.commit()
+      await api.discard()
+      // スタブはネットワークを叩かない
+      expect(calls).toHaveLength(0)
+    })
+
+    it('getTags は空配列を返す', async () => {
+      const { fetchImpl } = makeMockFetch(() => jsonResponse({}))
+      const api = createApiClient({ baseUrl: BASE, fetchImpl })
+      await expect(api.getTags()).resolves.toEqual([])
+    })
+  })
+
+  it('baseUrl の末尾スラッシュは取り除かれる', async () => {
+    const { fetchImpl, calls } = makeMockFetch(() => jsonResponse({ projects: [] }))
+    const api = createApiClient({ baseUrl: `${BASE}/`, fetchImpl })
+    await api.listProjects()
+    expect(calls[0].url).toBe(`${BASE}/api/projects`)
+  })
+})
+
+// vi.fn() を直接使ったケースも残しておく（タスク指示の vi.fn() で fetch を
+// モック化する形のサンプル）
+describe('vi.fn() を使った fetch モック例', () => {
+  it('listProjects を vi.fn() ベースで検証', async () => {
+    const fetchSpy = vi.fn(async () =>
+      jsonResponse({ projects: [{ name: 'x', title: 'X', repo: 'kako-jun/x' }] })
+    )
+    const api = createApiClient({ baseUrl: BASE, fetchImpl: fetchSpy as unknown as typeof fetch })
+    const projects = await api.listProjects()
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(projects).toHaveLength(1)
+  })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,331 @@
+// Worker (CF Workers) 用 API クライアント。kako-jun/name-name#107 で
+// 旧 FastAPI (`localhost:7373`) ベースから Worker (`localhost:8787` / 本番
+// `name-name-api.workers.dev`) ベースに切り替えた。
+//
+// 設計メモ:
+// - すべての API 呼び出しはこのモジュールに集約する。`fetch` を直接
+//   各画面から叩かない。Worker URL をハードコードしない。
+// - base URL は VITE_API_URL → `apiBaseUrl` 引数 → 既定 `localhost:8787`
+//   の優先順位。runtime には `apiBaseUrl` 引数が最終決定値で渡るため、
+//   このモジュールが直接 import.meta.env を読むのは「明示指定が無い場合の
+//   既定値」を作るときだけにする。
+// - 旧 FastAPI モデルにあった "ローカルワーキングディレクトリ" の概念は
+//   Worker モデルでは存在しない（保存 = 即 commit）。`getStatus` /
+//   `commit` / `discard` / `getTags` は #108 (Editor/Player 統合) で
+//   UI を整理するまでの間だけスタブとして残す。
+
+const DEFAULT_API_URL = 'http://localhost:8787'
+
+/**
+ * 環境変数による既定 base URL。`VITE_API_URL` を最優先、未設定なら
+ * `localhost:8787`。createApiClient() に明示的に baseUrl を渡せば
+ * そちらが優先される（App.tsx の設定 UI から動的に変更できる）。
+ */
+export function defaultApiBaseUrl(): string {
+  // import.meta.env は Vite ビルド時に置換される定数。
+  // テスト (vitest jsdom) では undefined のことがあるので optional chain。
+  const envUrl =
+    typeof import.meta !== 'undefined' && import.meta.env
+      ? (import.meta.env.VITE_API_URL as string | undefined)
+      : undefined
+  return envUrl && envUrl.length > 0 ? envUrl : DEFAULT_API_URL
+}
+
+// ---- レスポンス・リクエスト型 ----
+
+export interface ProjectInfo {
+  name: string
+  title: string
+  repo: string
+}
+
+export interface ContentsResponse {
+  path: string
+  sha: string
+  content: string
+  encoding?: 'utf-8'
+}
+
+export interface ContentsPutResponse {
+  path: string
+  sha: string | null
+  commit_sha: string | null
+}
+
+export interface AssetEntry {
+  name: string
+  path: string
+  sha: string
+  size: number
+  type: 'file' | 'dir'
+  download_url: string | null
+}
+
+export interface AssetUploadResponse {
+  path: string
+  sha: string | null
+  commit_sha: string | null
+  size?: number
+}
+
+// アセット種別。Worker 側 (worker/src/types.ts) と完全一致しない（Worker は
+// `audio`/`bgm`/`se`/`voice`/`video`/`fonts` を持つ。フロントの旧モデルは
+// `images`/`sounds`/`movies`/`ideas`）。ここは段階移行のため string で受け、
+// 不一致は Worker 側で 400 になる。最終的に #108 で揃える。
+export type AssetType = 'images' | 'sounds' | 'movies' | 'ideas' | string
+
+// ---- 認証ヘッダ ----
+
+const AUTH_TOKEN_STORAGE_KEY = 'dev_auth_token'
+
+/**
+ * localStorage に保存された開発用トークンを Bearer で送る。
+ * #110 (本番認証) で OAuth フローに置き換わるが、それまでは手動投入。
+ * exported しているのはテストとデバッグから値を覗くため。
+ */
+export function authHeaders(): HeadersInit {
+  // SSR / vitest jsdom 以外で localStorage が無いケースに備えて try-catch
+  try {
+    const token =
+      typeof localStorage !== 'undefined' ? localStorage.getItem(AUTH_TOKEN_STORAGE_KEY) : null
+    return token ? { authorization: `Bearer ${token}` } : {}
+  } catch {
+    return {}
+  }
+}
+
+// ---- 内部 fetch ヘルパー ----
+
+interface ApiClientOptions {
+  baseUrl?: string
+  /** テスト用に fetch を差し替えるためのフック */
+  fetchImpl?: typeof fetch
+}
+
+class ApiError extends Error {
+  status: number
+  body: unknown
+  constructor(status: number, body: unknown, message: string) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.body = body
+  }
+}
+
+export { ApiError }
+
+async function parseJsonOrThrow<T>(res: Response, label: string): Promise<T> {
+  const text = await res.text()
+  let body: unknown = undefined
+  if (text) {
+    try {
+      body = JSON.parse(text)
+    } catch {
+      body = text
+    }
+  }
+  if (!res.ok) {
+    const errMsg =
+      body && typeof body === 'object' && body !== null && 'error' in body
+        ? String((body as { error: unknown }).error)
+        : `${label} failed: ${res.status}`
+    throw new ApiError(res.status, body, errMsg)
+  }
+  return body as T
+}
+
+// ---- API クライアント本体 ----
+
+export interface ApiClient {
+  /** プロジェクト一覧 */
+  listProjects(): Promise<ProjectInfo[]>
+
+  /** Markdown / 設定ファイル 1 本を取得。`ref` はブランチ名（既定 develop） */
+  getContents(projectName: string, path: string, ref?: string): Promise<ContentsResponse>
+
+  /** Markdown / 設定ファイル 1 本を更新（または新規作成）。
+   *  既存ファイルの更新時は sha 必須（楽観ロック）。
+   */
+  putContents(
+    projectName: string,
+    path: string,
+    body: {
+      content: string
+      sha?: string
+      message?: string
+      branch: string
+    }
+  ): Promise<ContentsPutResponse>
+
+  /** assets/{type}/ ディレクトリ一覧 */
+  listAssets(
+    projectName: string,
+    type: AssetType,
+    options?: { ref?: string }
+  ): Promise<AssetEntry[]>
+
+  /** assets/{type}/{filename} を base64 でアップロード（5 MiB 未満） */
+  uploadAsset(
+    projectName: string,
+    type: AssetType,
+    filename: string,
+    contentBase64: string,
+    branch: string,
+    options?: { sha?: string; message?: string }
+  ): Promise<AssetUploadResponse>
+
+  // ---- 旧互換スタブ（#108 の UI 整理で削除予定） ----
+  /** 「未コミット変更あり」概念は Worker モデルに無い。常に false */
+  getStatus(): Promise<{ has_uncommitted: boolean }>
+  /** Worker モデルでは PUT contents が即 commit するため独立 commit は no-op */
+  commit(): Promise<void>
+  /** discard は Worker モデルでは「最新を再取得して上書き」相当。no-op */
+  discard(): Promise<void>
+  /** タグは別 Issue (assets メタ再設計) で対応。暫定で空配列 */
+  getTags(): Promise<string[]>
+}
+
+export function createApiClient(options: ApiClientOptions = {}): ApiClient {
+  const baseUrl = (options.baseUrl ?? defaultApiBaseUrl()).replace(/\/$/, '')
+  const fetchImpl: typeof fetch = options.fetchImpl ?? fetch.bind(globalThis)
+
+  function url(path: string): string {
+    return `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`
+  }
+
+  return {
+    async listProjects(): Promise<ProjectInfo[]> {
+      const res = await fetchImpl(url('/api/projects'), {
+        headers: { ...authHeaders() },
+      })
+      const data = await parseJsonOrThrow<{ projects: ProjectInfo[] }>(res, 'listProjects')
+      return data.projects
+    },
+
+    async getContents(projectName: string, path: string, ref?: string): Promise<ContentsResponse> {
+      const safePath = encodePathPreserveSlashes(path)
+      const qs = ref ? `?ref=${encodeURIComponent(ref)}` : ''
+      const res = await fetchImpl(
+        url(`/api/projects/${encodeURIComponent(projectName)}/contents/${safePath}${qs}`),
+        {
+          headers: { ...authHeaders() },
+        }
+      )
+      return parseJsonOrThrow<ContentsResponse>(res, 'getContents')
+    },
+
+    async putContents(
+      projectName: string,
+      path: string,
+      body: {
+        content: string
+        sha?: string
+        message?: string
+        branch: string
+      }
+    ): Promise<ContentsPutResponse> {
+      const safePath = encodePathPreserveSlashes(path)
+      const res = await fetchImpl(
+        url(`/api/projects/${encodeURIComponent(projectName)}/contents/${safePath}`),
+        {
+          method: 'PUT',
+          headers: {
+            'content-type': 'application/json',
+            ...authHeaders(),
+          },
+          body: JSON.stringify(body),
+        }
+      )
+      return parseJsonOrThrow<ContentsPutResponse>(res, 'putContents')
+    },
+
+    async listAssets(
+      projectName: string,
+      type: AssetType,
+      options: { ref?: string } = {}
+    ): Promise<AssetEntry[]> {
+      const qs = options.ref ? `?ref=${encodeURIComponent(options.ref)}` : ''
+      const res = await fetchImpl(
+        url(
+          `/api/projects/${encodeURIComponent(projectName)}/assets/${encodeURIComponent(type)}${qs}`
+        ),
+        {
+          headers: { ...authHeaders() },
+        }
+      )
+      const data = await parseJsonOrThrow<{
+        type: string
+        entries: AssetEntry[]
+      }>(res, 'listAssets')
+      return data.entries ?? []
+    },
+
+    async uploadAsset(
+      projectName: string,
+      type: AssetType,
+      filename: string,
+      contentBase64: string,
+      branch: string,
+      options: { sha?: string; message?: string } = {}
+    ): Promise<AssetUploadResponse> {
+      const message =
+        options.message && options.message.length > 0 ? options.message : `upload ${filename}`
+      const res = await fetchImpl(
+        url(`/api/projects/${encodeURIComponent(projectName)}/assets/${encodeURIComponent(type)}`),
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            ...authHeaders(),
+          },
+          body: JSON.stringify({
+            filename,
+            contentBase64,
+            branch,
+            message,
+            sha: options.sha,
+          }),
+        }
+      )
+      return parseJsonOrThrow<AssetUploadResponse>(res, 'uploadAsset')
+    },
+
+    // ---- スタブ群 ----
+    async getStatus(): Promise<{ has_uncommitted: boolean }> {
+      return { has_uncommitted: false }
+    },
+    async commit(): Promise<void> {
+      // no-op: Worker モデルでは PUT contents が即 commit
+    },
+    async discard(): Promise<void> {
+      // no-op: 呼び出し側で「最新を再取得」する
+    },
+    async getTags(): Promise<string[]> {
+      return []
+    },
+  }
+}
+
+/**
+ * パスの "/" は残し、各セグメントだけ encodeURIComponent する。
+ * `chapters/all.md` → `chapters/all.md`、`日本語/ファイル.md` → percent-encoded
+ */
+function encodePathPreserveSlashes(path: string): string {
+  return path
+    .split('/')
+    .map((seg) => encodeURIComponent(seg))
+    .join('/')
+}
+
+/**
+ * Module-level の既定インスタンス。`apiBaseUrl` をプロップで切り替える設計の
+ * 都合上、各画面では `createApiClient({ baseUrl: apiBaseUrl })` を毎回作るのが
+ * 基本。ただしテストや小さな utility から軽く使うときのために default も置く。
+ */
+export const apiClient: ApiClient = createApiClient()
+
+export const __internal = {
+  AUTH_TOKEN_STORAGE_KEY,
+  encodePathPreserveSlashes,
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -82,6 +82,12 @@ const AUTH_TOKEN_STORAGE_KEY = 'dev_auth_token'
  * localStorage に保存された開発用トークンを Bearer で送る。
  * #110 (本番認証) で OAuth フローに置き換わるが、それまでは手動投入。
  * exported しているのはテストとデバッグから値を覗くため。
+ *
+ * PR #120 review Q2: 本ヘッダは「Worker のみが受信する」想定で全リクエストに乗せている。
+ *   Worker 以外のドメイン (raw.githubusercontent.com 等) には fetch しない設計
+ *   （アセットの実バイトは <img>/<audio> の src に download_url を直接渡すだけで
+ *   ここの fetch は通らない）。Worker URL を baseUrl に固定することでトークン
+ *   漏洩の経路を物理的に塞いでいる。
  */
 export function authHeaders(): HeadersInit {
   // SSR / vitest jsdom 以外で localStorage が無いケースに備えて try-catch
@@ -115,6 +121,16 @@ class ApiError extends Error {
 
 export { ApiError }
 
+/**
+ * レスポンスを JSON として解釈する。
+ *
+ * PR #120 review N1: 空ボディも考慮する。res.text() が '' のときは body=undefined のまま、
+ *   非 JSON のときは body=text(string) になる。!res.ok のときは Worker から返る
+ *   `{ error: '...' }` を優先してメッセージ化し、body=undefined または error フィールドが
+ *   無い場合は `${label} failed: ${status}` のフォールバックを返す。
+ *   こうしておくと「Worker が落ちて空 body の 502」みたいなケースでも
+ *   ApiError が投げられて呼び出し側で拾える。
+ */
 async function parseJsonOrThrow<T>(res: Response, label: string): Promise<T> {
   const text = await res.text()
   let body: unknown = undefined

--- a/frontend/src/components/ProjectList.tsx
+++ b/frontend/src/components/ProjectList.tsx
@@ -1,10 +1,5 @@
-import { useEffect, useState } from 'react'
-
-interface Project {
-  name: string
-  path: string
-  branch: string
-}
+import { useEffect, useMemo, useState } from 'react'
+import { createApiClient, type ProjectInfo } from '../api/client'
 
 interface ProjectListProps {
   apiBaseUrl: string
@@ -13,18 +8,18 @@ interface ProjectListProps {
 }
 
 function ProjectList({ apiBaseUrl, isDark, onSelectProject }: ProjectListProps) {
-  const [projects, setProjects] = useState<Project[]>([])
+  const [projects, setProjects] = useState<ProjectInfo[]>([])
   const [loading, setLoading] = useState(true)
+  // apiBaseUrl が変わるたびにクライアントを作り直す。createApiClient は薄い
+  // ファクトリなので毎回でも実コストは無いが、useMemo にしておけば
+  // 依存配列のキー値として安定する。
+  const api = useMemo(() => createApiClient({ baseUrl: apiBaseUrl }), [apiBaseUrl])
 
   useEffect(() => {
     const loadProjects = async () => {
       try {
-        const response = await fetch(`${apiBaseUrl}/api/projects`)
-        if (!response.ok) {
-          throw new Error(`Failed to load projects: ${response.status}`)
-        }
-        const data = await response.json()
-        setProjects(data.projects)
+        const list = await api.listProjects()
+        setProjects(list)
       } catch (error) {
         console.error('Failed to load projects:', error)
       } finally {
@@ -32,7 +27,7 @@ function ProjectList({ apiBaseUrl, isDark, onSelectProject }: ProjectListProps) 
       }
     }
     loadProjects()
-  }, [apiBaseUrl])
+  }, [api])
 
   if (loading) {
     return (
@@ -77,9 +72,9 @@ function ProjectList({ apiBaseUrl, isDark, onSelectProject }: ProjectListProps) 
               >
                 <div className="flex items-center justify-between">
                   <div>
-                    <h3 className="font-semibold text-lg">{project.name}</h3>
+                    <h3 className="font-semibold text-lg">{project.title || project.name}</h3>
                     <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
-                      ブランチ: {project.branch}
+                      {project.repo}
                     </p>
                   </div>
                   <svg

--- a/frontend/src/components/SaveDiscardButtons.tsx
+++ b/frontend/src/components/SaveDiscardButtons.tsx
@@ -7,6 +7,10 @@ interface SaveDiscardButtonsProps {
   // プレイモード関連（オプション）
   mode?: 'edit' | 'play'
   onModeChange?: (mode: 'edit' | 'play') => void
+  // PR #120 review Q1: 保存ボタンを強制 disabled にする条件（sha 未取得 / 初期ロード失敗）。
+  //   未指定なら従来挙動（hasUnsavedChanges のみで判断）。
+  saveDisabled?: boolean
+  saveDisabledTitle?: string
 }
 
 function SaveDiscardButtons({
@@ -17,7 +21,15 @@ function SaveDiscardButtons({
   onDiscard,
   mode,
   onModeChange,
+  saveDisabled = false,
+  saveDisabledTitle,
 }: SaveDiscardButtonsProps) {
+  const saveEnabled = hasUnsavedChanges && !isSaving && !saveDisabled
+  const saveTitle = saveDisabled
+    ? (saveDisabledTitle ?? '保存できません')
+    : hasUnsavedChanges
+      ? 'Gitにコミット・プッシュ'
+      : '保存済み'
   return (
     <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 items-end">
       {/* プレイモード切替（オプション） */}
@@ -95,7 +107,7 @@ function SaveDiscardButtons({
         {/* セーブボタン */}
         <button
           className={`w-12 h-12 flex items-center justify-center transition-colors rounded-lg shadow-md border ${
-            hasUnsavedChanges && !isSaving
+            saveEnabled
               ? isDark
                 ? 'bg-blue-600 text-white border-blue-500 hover:bg-blue-700'
                 : 'bg-blue-500 text-white border-blue-400 hover:bg-blue-600'
@@ -104,8 +116,9 @@ function SaveDiscardButtons({
                 : 'bg-gray-200 text-gray-400 border-gray-300 cursor-not-allowed'
           }`}
           onClick={onSave}
-          disabled={!hasUnsavedChanges || isSaving}
-          title={hasUnsavedChanges ? 'Gitにコミット・プッシュ' : '保存済み'}
+          disabled={!saveEnabled}
+          aria-label={saveTitle}
+          title={saveTitle}
         >
           {isSaving ? (
             <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">

--- a/frontend/src/screens/AssetsScreen.tsx
+++ b/frontend/src/screens/AssetsScreen.tsx
@@ -199,47 +199,38 @@ function AssetsScreen({
     }
   }
 
-  // ファイル削除の確認ダイアログを表示
+  // PR #120 review S1: 削除・タグ管理は Worker 側に DELETE / tag エンドポイントが
+  //   無いので、ボタンを disabled にして「ローカルだけ消えてサーバには残る」詐欺 UI を
+  //   防ぐ。実装は #108 以降。確認ダイアログ・追加ハンドラは disabled なので
+  //   実行経路に到達しないが、防御として早期 return も残す。
+  const DISABLED_DELETE_HINT = '削除は #108 以降で実装予定です'
+  const DISABLED_TAG_HINT = 'タグ管理は #108 以降で実装予定です'
+
+  // ファイル削除の確認ダイアログを表示（現状 disabled なので呼ばれない想定）
   const handleDeleteClick = (asset: Asset) => {
     setDeletingAsset(asset)
   }
 
-  // kako-jun/name-name#107: Worker 側に DELETE / tag エンドポイントは未実装。
-  //   削除・タグ管理は #108 (Editor/Player 統合) で再設計するため、当面は
-  //   ローカル UI 上だけ反映する no-op ハンドラに退避する。サーバ状態は変わらない。
-  //   削除確認ダイアログは UX を残すために維持する。
+  // 削除実行（disabled で UI 上到達しないが、保険として no-op）
   const handleDeleteConfirm = async () => {
     if (!deletingAsset) return
-    console.warn(
-      '[AssetsScreen] delete is not yet implemented in Worker; UI-only removal',
-      deletingAsset.name
-    )
-    setAssets(assets.filter((a) => a.name !== deletingAsset.name))
-    if (selectedAsset?.name === deletingAsset.name) {
-      setSelectedAsset(null)
-    }
+    // disabled UI なので通常はここに来ない。万一来てもサーバを触らないだけにする。
+    console.warn('[AssetsScreen] delete is disabled until #108; ignoring', deletingAsset.name)
     setDeletingAsset(null)
   }
 
-  // タグ追加（ローカルのみ）
-  const handleAddTag = async (asset: Asset, tagName: string) => {
-    const trimmed = tagName.trim()
-    if (!trimmed || asset.tags.includes(trimmed)) return
-    const newTags = [...asset.tags, trimmed]
-    setAssets(assets.map((a) => (a.name === asset.name ? { ...a, tags: newTags } : a)))
-    if (selectedAsset?.name === asset.name) {
-      setSelectedAsset({ ...asset, tags: newTags })
-    }
-    setNewTagInput('')
+  // タグ追加（disabled で UI 上到達しない）
+  const handleAddTag = async (_asset: Asset, _tagName: string) => {
+    void _asset
+    void _tagName
+    console.warn('[AssetsScreen] tag add is disabled until #108')
   }
 
-  // タグ削除（ローカルのみ）
-  const handleRemoveTag = async (asset: Asset, tagName: string) => {
-    const newTags = asset.tags.filter((t) => t !== tagName)
-    setAssets(assets.map((a) => (a.name === asset.name ? { ...a, tags: newTags } : a)))
-    if (selectedAsset?.name === asset.name) {
-      setSelectedAsset({ ...asset, tags: newTags })
-    }
+  // タグ削除（disabled で UI 上到達しない）
+  const handleRemoveTag = async (_asset: Asset, _tagName: string) => {
+    void _asset
+    void _tagName
+    console.warn('[AssetsScreen] tag remove is disabled until #108')
   }
 
   const formatFileSize = (bytes: number): string => {
@@ -494,12 +485,12 @@ function AssetsScreen({
                           e.stopPropagation()
                           handleDeleteClick(asset)
                         }}
-                        className={`p-1 rounded transition-colors flex-shrink-0 ${
-                          isDark
-                            ? 'text-gray-400 hover:text-red-400 hover:bg-red-900/20'
-                            : 'text-gray-500 hover:text-red-600 hover:bg-red-50'
+                        disabled
+                        aria-label={DISABLED_DELETE_HINT}
+                        className={`p-1 rounded transition-colors flex-shrink-0 cursor-not-allowed opacity-40 ${
+                          isDark ? 'text-gray-400' : 'text-gray-500'
                         }`}
-                        title="削除"
+                        title={DISABLED_DELETE_HINT}
                       >
                         <svg
                           className="w-4 h-4"
@@ -628,7 +619,10 @@ function AssetsScreen({
                       {tag}
                       <button
                         onClick={() => handleRemoveTag(selectedAsset, tag)}
-                        className={`hover:text-red-400 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}
+                        disabled
+                        aria-label={DISABLED_TAG_HINT}
+                        title={DISABLED_TAG_HINT}
+                        className={`cursor-not-allowed opacity-40 ${isDark ? 'text-gray-500' : 'text-gray-400'}`}
                       >
                         ×
                       </button>
@@ -638,15 +632,13 @@ function AssetsScreen({
                 <div className="flex gap-2">
                   <input
                     type="text"
-                    placeholder="タグを追加..."
+                    placeholder={DISABLED_TAG_HINT}
                     value={newTagInput}
                     onChange={(e) => setNewTagInput(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && newTagInput.trim()) {
-                        handleAddTag(selectedAsset, newTagInput)
-                      }
-                    }}
-                    className={`flex-1 px-3 py-1.5 text-sm rounded border ${
+                    disabled
+                    aria-label={DISABLED_TAG_HINT}
+                    title={DISABLED_TAG_HINT}
+                    className={`flex-1 px-3 py-1.5 text-sm rounded border cursor-not-allowed opacity-50 ${
                       isDark
                         ? 'bg-gray-700 border-gray-600 text-white placeholder-gray-400'
                         : 'bg-white border-gray-300 text-gray-900 placeholder-gray-500'
@@ -656,10 +648,11 @@ function AssetsScreen({
                     onClick={() => {
                       if (newTagInput.trim()) handleAddTag(selectedAsset, newTagInput)
                     }}
-                    className={`px-3 py-1.5 text-sm rounded transition-colors ${
-                      isDark
-                        ? 'bg-blue-600 hover:bg-blue-700 text-white'
-                        : 'bg-blue-500 hover:bg-blue-600 text-white'
+                    disabled
+                    aria-label={DISABLED_TAG_HINT}
+                    title={DISABLED_TAG_HINT}
+                    className={`px-3 py-1.5 text-sm rounded transition-colors cursor-not-allowed opacity-50 ${
+                      isDark ? 'bg-blue-600 text-white' : 'bg-blue-500 text-white'
                     }`}
                   >
                     追加

--- a/frontend/src/screens/AssetsScreen.tsx
+++ b/frontend/src/screens/AssetsScreen.tsx
@@ -1,13 +1,30 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import SaveDiscardButtons from '../components/SaveDiscardButtons'
+import { createApiClient, type AssetEntry } from '../api/client'
 
 type AssetType = 'images' | 'sounds' | 'movies' | 'ideas'
 
+// kako-jun/name-name#107: 旧 FastAPI は assets を { name, size, url, tags } で返し、
+// `${apiBaseUrl}${url}` で raw bytes を直接返していた。Worker は AssetEntry
+// (`{ name, path, sha, size, type, download_url }`) を返し、bytes は
+// download_url (raw.githubusercontent.com) から直接取る。
+// ローカル UI 用に旧 Asset 型と互換のあるラッパを作る。tags は #108 で再設計予定。
 interface Asset {
   name: string
   size: number
-  url: string
-  tags: string[]
+  url: string // 表示・再生用 URL（download_url ?? '' のフォールバック）
+  tags: string[] // 暫定で常に []
+}
+
+const DEFAULT_BRANCH = 'develop'
+
+function entryToAsset(entry: AssetEntry): Asset {
+  return {
+    name: entry.name,
+    size: entry.size,
+    url: entry.download_url ?? '',
+    tags: [],
+  }
 }
 
 interface AssetsScreenProps {
@@ -43,6 +60,9 @@ function AssetsScreen({
   const [newTagInput, setNewTagInput] = useState('')
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // apiBaseUrl が変わるたびにクライアントを作り直す
+  const api = useMemo(() => createApiClient({ baseUrl: apiBaseUrl }), [apiBaseUrl])
+
   // 検索入力のデバウンス (300ms)
   const handleSearchChange = useCallback((value: string) => {
     setSearchInput(value)
@@ -57,63 +77,34 @@ function AssetsScreen({
     }
   }, [])
 
-  // 初回ロード時と5秒ごとにgit statusをチェック
+  // kako-jun/name-name#107: Worker モデルでは「未コミット変更」概念無し。
+  //   旧 5 秒間隔の git status ポーリングは廃止。hasUnsavedChanges は常に false 維持。
+  //   保存/破棄ボタンは UI として残すが、押しても no-op + 一覧再取得のみ
+  //   （UI 統合は #108 で行う）。
   useEffect(() => {
-    const checkStatus = async () => {
-      try {
-        const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/status`)
-        if (response.ok) {
-          const data = await response.json()
-          setHasUnsavedChanges(data.has_uncommitted_changes)
-        }
-      } catch (error) {
-        console.error('Failed to check status:', error)
-      }
-    }
+    setHasUnsavedChanges(false)
+  }, [projectName])
 
-    checkStatus()
-    const interval = setInterval(checkStatus, 5000)
-    return () => clearInterval(interval)
-  }, [apiBaseUrl, projectName])
-
-  // セーブボタン: Gitコミット・プッシュ
+  // セーブボタン: Worker モデルではアップロード時点で commit 済み。no-op + フラグクリア
   const handleSave = async () => {
     setIsSaving(true)
     try {
-      const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/commit`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          message: 'アセット更新',
-        }),
-      })
-      if (!response.ok) {
-        throw new Error(`Failed to commit: ${response.status}`)
-      }
+      // PUT contents が即 commit する設計のため、ここで個別に何かをする必要はない。
       setHasUnsavedChanges(false)
-    } catch (error) {
-      console.error('Failed to save:', error)
     } finally {
       setIsSaving(false)
     }
   }
 
-  // 変更を破棄
+  // 変更を破棄: Worker では「未コミット差分」が無いので一覧再取得だけ
   const handleDiscard = async () => {
     setShowDiscardConfirm(false)
     setIsSaving(true)
     try {
-      const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/discard`, {
-        method: 'POST',
-      })
-      if (!response.ok) {
-        throw new Error(`Failed to discard: ${response.status}`)
-      }
-      // アセット一覧を再読み込み（フィルタ維持）
       await fetchAssets()
       setHasUnsavedChanges(false)
     } catch (error) {
-      console.error('Failed to discard changes:', error)
+      console.error('Failed to refresh assets:', error)
     } finally {
       setIsSaving(false)
     }
@@ -133,77 +124,73 @@ function AssetsScreen({
     setNewTagInput('')
   }, [selectedAsset?.name])
 
-  // タグ一覧を取得・再取得
+  // kako-jun/name-name#107: タグは Worker 側未実装。暫定で空配列。
+  //   別 Issue (assets メタ再設計) で本実装する予定。
   const fetchTags = useCallback(async () => {
-    try {
-      const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/tags`)
-      if (response.ok) {
-        const data = await response.json()
-        setAllTags(data.tags)
-      }
-    } catch (error) {
-      console.error('Failed to load tags:', error)
-    }
-  }, [apiBaseUrl, projectName])
+    setAllTags([])
+  }, [])
 
   useEffect(() => {
     fetchTags()
   }, [fetchTags])
 
-  // アセット一覧URLを構築するヘルパー
-  const buildAssetsUrl = useCallback(() => {
-    const params = new URLSearchParams()
-    if (debouncedQuery) params.set('q', debouncedQuery)
-    if (selectedTag) params.set('tag', selectedTag)
-    const queryString = params.toString()
-    return `${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}${queryString ? '?' + queryString : ''}`
-  }, [apiBaseUrl, projectName, selectedType, debouncedQuery, selectedTag])
-
-  // アセット一覧を取得
+  // アセット一覧を取得。
+  // 旧 FastAPI は q / tag をサーバ側で絞り込んでいたが、Worker は単純な
+  // ディレクトリリストしか返さないため、検索とタグ絞り込みは クライアント側で行う。
+  // tags は #108 で再導入予定なので現状は空。
   const fetchAssets = useCallback(async () => {
     setLoading(true)
     try {
-      const response = await fetch(buildAssetsUrl())
-      if (!response.ok) {
-        throw new Error(`Failed to load assets: ${response.status}`)
-      }
-      const data = await response.json()
-      setAssets(data.assets)
+      const entries = await api.listAssets(projectName, selectedType, { ref: DEFAULT_BRANCH })
+      const all = entries.filter((e) => e.type === 'file').map(entryToAsset)
+      const filtered = debouncedQuery
+        ? all.filter((a) => a.name.toLowerCase().includes(debouncedQuery.toLowerCase()))
+        : all
+      // tag フィルタは現状空なので素通し（selectedTag が null のまま）
+      setAssets(filtered)
     } catch (error) {
       console.error('Failed to load assets:', error)
+      setAssets([])
     } finally {
       setLoading(false)
     }
-  }, [buildAssetsUrl])
+  }, [api, projectName, selectedType, debouncedQuery])
 
   useEffect(() => {
     fetchAssets()
   }, [fetchAssets])
 
-  // ファイルアップロード
+  // File を base64 に変換（FileReader.readAsDataURL の prefix を剥がす）
+  function fileToBase64(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => {
+        const result = reader.result
+        if (typeof result !== 'string') {
+          reject(new Error('FileReader returned non-string result'))
+          return
+        }
+        const idx = result.indexOf(',')
+        resolve(idx >= 0 ? result.slice(idx + 1) : result)
+      }
+      reader.onerror = () => reject(reader.error ?? new Error('FileReader failed'))
+      reader.readAsDataURL(file)
+    })
+  }
+
+  // ファイルアップロード（Worker は JSON + base64 を受け取る）
   const handleFileUpload = async (files: FileList | null) => {
     if (!files || files.length === 0) return
 
     setUploading(true)
     try {
       for (const file of Array.from(files)) {
-        const formData = new FormData()
-        formData.append('file', file)
-
-        const response = await fetch(
-          `${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}`,
-          {
-            method: 'POST',
-            body: formData,
-          }
-        )
-
-        if (!response.ok) {
-          throw new Error(`Failed to upload ${file.name}: ${response.status}`)
-        }
+        const base64 = await fileToBase64(file)
+        await api.uploadAsset(projectName, selectedType, file.name, base64, DEFAULT_BRANCH, {
+          message: `upload ${file.name}`,
+        })
       }
-
-      // アップロード成功後、一覧を再取得（フィルタ維持）
+      // アップロード成功後、一覧を再取得
       await fetchAssets()
     } catch (error) {
       console.error('Failed to upload files:', error)
@@ -217,80 +204,41 @@ function AssetsScreen({
     setDeletingAsset(asset)
   }
 
-  // ファイル削除を実行
+  // kako-jun/name-name#107: Worker 側に DELETE / tag エンドポイントは未実装。
+  //   削除・タグ管理は #108 (Editor/Player 統合) で再設計するため、当面は
+  //   ローカル UI 上だけ反映する no-op ハンドラに退避する。サーバ状態は変わらない。
+  //   削除確認ダイアログは UX を残すために維持する。
   const handleDeleteConfirm = async () => {
     if (!deletingAsset) return
-
-    try {
-      const response = await fetch(
-        `${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}/${deletingAsset.name}`,
-        {
-          method: 'DELETE',
-        }
-      )
-
-      if (!response.ok) {
-        throw new Error(`Failed to delete ${deletingAsset.name}: ${response.status}`)
-      }
-
-      // 削除成功後、一覧とタグを再取得
-      setAssets(assets.filter((a) => a.name !== deletingAsset.name))
-      if (selectedAsset?.name === deletingAsset.name) {
-        setSelectedAsset(null)
-      }
-      setDeletingAsset(null)
-      fetchTags()
-    } catch (error) {
-      console.error('Failed to delete file:', error)
-      setDeletingAsset(null)
+    console.warn(
+      '[AssetsScreen] delete is not yet implemented in Worker; UI-only removal',
+      deletingAsset.name
+    )
+    setAssets(assets.filter((a) => a.name !== deletingAsset.name))
+    if (selectedAsset?.name === deletingAsset.name) {
+      setSelectedAsset(null)
     }
+    setDeletingAsset(null)
   }
 
-  // タグを追加
+  // タグ追加（ローカルのみ）
   const handleAddTag = async (asset: Asset, tagName: string) => {
     const trimmed = tagName.trim()
     if (!trimmed || asset.tags.includes(trimmed)) return
-
     const newTags = [...asset.tags, trimmed]
-    try {
-      const response = await fetch(
-        `${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}/${asset.name}/tags`,
-        {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ tags: newTags }),
-        }
-      )
-      if (response.ok) {
-        setAssets(assets.map((a) => (a.name === asset.name ? { ...a, tags: newTags } : a)))
-        if (selectedAsset?.name === asset.name) {
-          setSelectedAsset({ ...asset, tags: newTags })
-        }
-        setNewTagInput('')
-        fetchTags()
-      }
-    } catch (error) {
-      console.error('Failed to add tag:', error)
+    setAssets(assets.map((a) => (a.name === asset.name ? { ...a, tags: newTags } : a)))
+    if (selectedAsset?.name === asset.name) {
+      setSelectedAsset({ ...asset, tags: newTags })
     }
+    setNewTagInput('')
   }
 
-  // タグを削除
+  // タグ削除（ローカルのみ）
   const handleRemoveTag = async (asset: Asset, tagName: string) => {
-    try {
-      const response = await fetch(
-        `${apiBaseUrl}/api/projects/${projectName}/assets/${selectedType}/${asset.name}/tags/${encodeURIComponent(tagName)}`,
-        { method: 'DELETE' }
-      )
-      if (response.ok) {
-        const newTags = asset.tags.filter((t) => t !== tagName)
-        setAssets(assets.map((a) => (a.name === asset.name ? { ...a, tags: newTags } : a)))
-        if (selectedAsset?.name === asset.name) {
-          setSelectedAsset({ ...asset, tags: newTags })
-        }
-        fetchTags()
-      }
-    } catch (error) {
-      console.error('Failed to remove tag:', error)
+    const newTags = asset.tags.filter((t) => t !== tagName)
+    setAssets(assets.map((a) => (a.name === asset.name ? { ...a, tags: newTags } : a)))
+    if (selectedAsset?.name === asset.name) {
+      setSelectedAsset({ ...asset, tags: newTags })
     }
   }
 
@@ -510,7 +458,7 @@ function AssetsScreen({
                       {/* サムネイル（画像のみ） */}
                       {selectedType === 'images' && (
                         <img
-                          src={`${apiBaseUrl}${asset.url}`}
+                          src={asset.url}
                           alt={asset.name}
                           className="w-12 h-12 object-cover rounded flex-shrink-0"
                         />
@@ -623,7 +571,7 @@ function AssetsScreen({
               {selectedType === 'images' && (
                 <div className="flex justify-center">
                   <img
-                    src={`${apiBaseUrl}${selectedAsset.url}`}
+                    src={selectedAsset.url}
                     alt={selectedAsset.name}
                     className="max-w-full max-h-[600px] rounded-lg shadow-lg"
                   />
@@ -633,7 +581,7 @@ function AssetsScreen({
               {selectedType === 'sounds' && (
                 <div className="flex justify-center">
                   <audio controls className="w-full max-w-md">
-                    <source src={`${apiBaseUrl}${selectedAsset.url}`} />
+                    <source src={selectedAsset.url} />
                     お使いのブラウザは音声の再生に対応していません。
                   </audio>
                 </div>
@@ -642,7 +590,7 @@ function AssetsScreen({
               {selectedType === 'movies' && (
                 <div className="flex justify-center">
                   <video controls className="max-w-full max-h-[600px] rounded-lg shadow-lg">
-                    <source src={`${apiBaseUrl}${selectedAsset.url}`} />
+                    <source src={selectedAsset.url} />
                     お使いのブラウザは動画の再生に対応していません。
                   </video>
                 </div>
@@ -655,7 +603,7 @@ function AssetsScreen({
                   }`}
                 >
                   <iframe
-                    src={`${apiBaseUrl}${selectedAsset.url}`}
+                    src={selectedAsset.url}
                     className="w-full min-h-[600px] border-none"
                     title={selectedAsset.name}
                   />

--- a/frontend/src/screens/EditorScreen.tsx
+++ b/frontend/src/screens/EditorScreen.tsx
@@ -84,6 +84,10 @@ function EditorScreen({
   const shaRef = useRef<string | null>(null)
   const [rawMarkdown, setRawMarkdown] = useState<string>('')
   const [rpgSubTab, setRpgSubTab] = useState<'map' | 'npc' | 'play'>('map')
+  // PR #120 review Q1: shaRef.current を state にも反映して、保存ボタンの
+  //   disabled 制御に使う。ref 単体だと React が再レンダリングしないため
+  //   ボタンの enabled/disabled が更新されない。
+  const [hasSha, setHasSha] = useState(false)
   // PR #120 review S4: 初期ロードに失敗したら autosave / 保存ボタンを止める。
   //   失敗時に空 doc で上書きすると localStorage の draft も '' で潰れて
   //   ユーザーの未保存原稿が消えるので、loadFailed のうちはサーバ書き戻し系を
@@ -255,6 +259,7 @@ function EditorScreen({
         const data = await api.getContents(projectName, CHAPTERS_PATH, DEFAULT_BRANCH)
         const markdown = data.content || ''
         shaRef.current = data.sha
+        setHasSha(Boolean(data.sha))
         setLoadFailed(false)
         initialMarkdownRef.current = markdown
 
@@ -277,6 +282,7 @@ function EditorScreen({
         //   autosave と保存ボタンを止めることで、ユーザーが既に書いた原稿の
         //   draft を保護する。doc は空フォールバックで操作可能にだけしておく。
         shaRef.current = null
+        setHasSha(false)
         setLoadFailed(true)
         setDoc({ engine: 'name-name', chapters: [] })
         setSaveError('プロジェクトの読み込みに失敗しました。再読み込みしてください。')
@@ -329,24 +335,28 @@ function EditorScreen({
   // 保存ボタン: Worker の PUT contents を直接叩く（保存 = 即 commit）。
   // Worker モデルでは独立した「commit」概念が無いので、PUT が成功した時点で
   // GitHub にコミットされている。
+  // PR #120 review Q1: shaRef が null（初期ロード失敗 / 未取得）のときは保存を
+  //   実行しない。ボタン側でも disabled にしているので通常はここに来ないが、
+  //   保険として早期 return する。
   const handleSave = async () => {
+    if (loadFailed || shaRef.current === null) {
+      setSaveError('再読み込みしてから保存してください')
+      return
+    }
     setIsSaving(true)
     setSaveError(null)
     try {
       const sha = shaRef.current
-      if (!sha) {
-        // 初回ロードに失敗していて sha が無い場合は作成扱いで PUT する
-        // （Worker は sha 無しを新規作成として扱う。chapters/all.md が
-        //  既存なら 409 が返るのでエラー表示する）。
-        console.warn('No sha available; attempting create-style PUT')
-      }
       const result = await api.putContents(projectName, CHAPTERS_PATH, {
         content: rawMarkdown,
         sha: sha ?? undefined,
         branch: DEFAULT_BRANCH,
         message: '原稿保存',
       })
-      if (result.sha) shaRef.current = result.sha
+      if (result.sha) {
+        shaRef.current = result.sha
+        setHasSha(true)
+      }
       initialMarkdownRef.current = rawMarkdown
       setHasUnsavedChanges(false)
       try {
@@ -386,6 +396,7 @@ function EditorScreen({
       }
 
       shaRef.current = data.sha
+      setHasSha(Boolean(data.sha))
       setLoadFailed(false)
       initialMarkdownRef.current = markdown
       setRawMarkdown(markdown)
@@ -754,6 +765,11 @@ function EditorScreen({
         onDiscard={() => setShowDiscardConfirm(true)}
         mode={editorTab === 'novel' ? mode : undefined}
         onModeChange={editorTab === 'novel' ? setMode : undefined}
+        // PR #120 review Q1: shaRef 未取得（loadFailed / 未ロード）時は保存不可。
+        saveDisabled={loadFailed || !hasSha}
+        saveDisabledTitle={
+          loadFailed ? '再読み込みしてから保存してください' : !hasSha ? '読み込み中…' : undefined
+        }
       />
     </div>
   )

--- a/frontend/src/screens/EditorScreen.tsx
+++ b/frontend/src/screens/EditorScreen.tsx
@@ -14,7 +14,7 @@ import {
   findRpgSceneIndex,
   findAllRpgScenes,
 } from '../game/rpgProjectFromDoc'
-import { createApiClient } from '../api/client'
+import { createApiClient, type ProjectInfo } from '../api/client'
 
 // kako-jun/name-name#107: 旧 FastAPI モデルでは autosave 1s debounce で
 // ワーキングディレクトリに PUT し、commit ボタンで Git push していた。
@@ -84,6 +84,10 @@ function EditorScreen({
   const shaRef = useRef<string | null>(null)
   const [rawMarkdown, setRawMarkdown] = useState<string>('')
   const [rpgSubTab, setRpgSubTab] = useState<'map' | 'npc' | 'play'>('map')
+  // PR #120 review S2: NovelPlayer に渡す assets のベース URL。kako-jun ハードコードを
+  //   やめ、Worker (listProjects) から取得した repo (`owner/name`) を使う。
+  //   ロード前は null。
+  const [projectRepo, setProjectRepo] = useState<string | null>(null)
 
   // apiBaseUrl が変わるたびにクライアントを作り直す。
   const api = useMemo(() => createApiClient({ baseUrl: apiBaseUrl }), [apiBaseUrl])
@@ -212,6 +216,28 @@ function EditorScreen({
     setRpgSceneId(newSceneId)
     await handleDocChange(newDoc)
   }
+
+  // PR #120 review S2: projectName から repo (`owner/name`) を解決する。
+  //   listProjects の結果は Worker の projects.ts に固定で入っており短いため、
+  //   毎回呼んでも問題ない。失敗時は projectRepo=null のまま → assetBaseUrl は
+  //   フォールバック（kako-jun/<name>）で動かす。
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const list = await api.listProjects()
+        if (cancelled) return
+        const found = list.find((p: ProjectInfo) => p.name === projectName)
+        setProjectRepo(found?.repo ?? null)
+      } catch (error) {
+        console.error('Failed to resolve project repo:', error)
+        if (!cancelled) setProjectRepo(null)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [api, projectName])
 
   // 初回ロード: Worker (Contents API) から chapters/all.md を取得しWASMでパース。
   // 取得時の sha を shaRef に保持し、後続の PUT 時に楽観ロック用に渡す。
@@ -485,14 +511,17 @@ function EditorScreen({
           ) : (
             <NovelPlayer
               events={novelEvents}
-              // kako-jun/name-name#107: 旧 FastAPI は静的ファイルを直接返していたが、
+              // PR #120 review S2: 旧 FastAPI は静的ファイルを直接返していたが、
               //   Worker は /assets/:type の一覧 API しか提供しない（個別ファイルは
               //   GitHub の download_url 経由になる）。
-              //   暫定で raw.githubusercontent.com を直接指す。プロジェクト一覧に
-              //   含まれる repo は現状 "kako-jun/<projectName>" 固定なので
-              //   このフォールバックで動く。Editor/Player 統合 (#108) で
-              //   download_url ベースに置き換える。
-              assetBaseUrl={`https://raw.githubusercontent.com/kako-jun/${projectName}/${DEFAULT_BRANCH}/assets`}
+              //   暫定で raw.githubusercontent.com を直接指す。
+              //   プロジェクトリポジトリ owner/name は listProjects() の結果
+              //   (ProjectInfo.repo) から取得する。未取得時は kako-jun/<name> に
+              //   フォールバックして動作互換を保つ（Editor/Player 統合 #108 で
+              //   download_url ベースに置き換える）。
+              assetBaseUrl={`https://raw.githubusercontent.com/${
+                projectRepo ?? `kako-jun/${projectName}`
+              }/${DEFAULT_BRANCH}/assets`}
             />
           )
         ) : (

--- a/frontend/src/screens/EditorScreen.tsx
+++ b/frontend/src/screens/EditorScreen.tsx
@@ -14,6 +14,19 @@ import {
   findRpgSceneIndex,
   findAllRpgScenes,
 } from '../game/rpgProjectFromDoc'
+import { createApiClient } from '../api/client'
+
+// kako-jun/name-name#107: 旧 FastAPI モデルでは autosave 1s debounce で
+// ワーキングディレクトリに PUT し、commit ボタンで Git push していた。
+// Worker モデルでは「保存ボタン押下 = PUT contents = 即 commit」になるため、
+// 編集中の値は localStorage に退避し、サーバ保存は明示「保存」のみとする。
+// UI の本格的な改修（保存ボタン名変更・autosave 表示など）は #108 で行う。
+const CHAPTERS_PATH = 'chapters/all.md'
+const DEFAULT_BRANCH = 'develop'
+
+function localStorageKey(projectName: string): string {
+  return `name-name:editor-draft:${projectName}`
+}
 
 interface EditorScreenProps {
   projectName: string
@@ -64,10 +77,16 @@ function EditorScreen({
   const [isSaving, setIsSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
-  const saveTimeoutRef = useRef<number | null>(null)
+  const draftSaveTimeoutRef = useRef<number | null>(null)
   const initialMarkdownRef = useRef<string>('')
+  // GitHub Contents API の sha。PUT 時の楽観ロックに必須。
+  // ロード時に getContents() のレスポンスから設定し、PUT 成功時に新しい sha で更新する。
+  const shaRef = useRef<string | null>(null)
   const [rawMarkdown, setRawMarkdown] = useState<string>('')
   const [rpgSubTab, setRpgSubTab] = useState<'map' | 'npc' | 'play'>('map')
+
+  // apiBaseUrl が変わるたびにクライアントを作り直す。
+  const api = useMemo(() => createApiClient({ baseUrl: apiBaseUrl }), [apiBaseUrl])
   // 現在 RPG タブが編集対象としているシーン ID（doc 内の最初の RPG シーン）
   const [rpgSceneId, setRpgSceneId] = useState<string | null>(null)
 
@@ -194,151 +213,134 @@ function EditorScreen({
     await handleDocChange(newDoc)
   }
 
-  // 初回ロード: APIからMarkdownを取得しWASMでパース
+  // 初回ロード: Worker (Contents API) から chapters/all.md を取得しWASMでパース。
+  // 取得時の sha を shaRef に保持し、後続の PUT 時に楽観ロック用に渡す。
+  // ロード前に localStorage の draft を見て、復元できる場合は draft を表示する
+  // （draft があるが ref と sha の世代が古い場合は #108 でマージ UI を入れる予定。
+  //  暫定では「ロード後に draft で上書き」する素直な復元のみ）。
   useEffect(() => {
     const loadChapters = async () => {
       try {
-        const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/chapters`)
-        if (!response.ok) {
-          console.error(`Failed to load chapters: ${response.status}`)
-          // ロード失敗時もエディタで操作を開始できるよう、空 doc にフォールバックする
-          setDoc({ engine: 'name-name', chapters: [] })
-          setSaveError('プロジェクトの読み込みに失敗しました')
-          return
-        }
-        const data = await response.json()
+        const data = await api.getContents(projectName, CHAPTERS_PATH, DEFAULT_BRANCH)
         const markdown = data.content || ''
-        setRawMarkdown(markdown)
+        shaRef.current = data.sha
         initialMarkdownRef.current = markdown
 
-        await parseAndSetDoc(markdown)
-
-        // git statusをチェック
-        const statusResponse = await fetch(`${apiBaseUrl}/api/projects/${projectName}/status`)
-        if (statusResponse.ok) {
-          const statusData = await statusResponse.json()
-          setHasUnsavedChanges(statusData.has_uncommitted_changes)
+        // localStorage に draft があれば復元、無ければサーバ値をそのまま使う。
+        // 現状は単純復元。サーバ側が更新されている可能性は #108 で対処。
+        let localDraft: string | null = null
+        try {
+          localDraft = localStorage.getItem(localStorageKey(projectName))
+        } catch {
+          localDraft = null
         }
+        const startMarkdown = localDraft !== null && localDraft !== '' ? localDraft : markdown
+        setRawMarkdown(startMarkdown)
+        await parseAndSetDoc(startMarkdown)
+        setHasUnsavedChanges(localDraft !== null && localDraft !== markdown)
       } catch (error) {
         console.error('Failed to load chapters:', error)
+        // ロード失敗時もエディタで操作を開始できるよう、空 doc にフォールバックする
         setDoc({ engine: 'name-name', chapters: [] })
         setSaveError('プロジェクトの読み込みに失敗しました')
       }
     }
     loadChapters()
-  }, [apiBaseUrl, projectName])
+    // api は apiBaseUrl から派生する useMemo の値、projectName が変わったらもう一度ロード
+  }, [api, projectName])
 
-  // 5秒ごとにgit statusをチェック（フロント側の変更を優先）
+  // Markdown の変更を検出して未保存フラグを立てる。
+  // Worker モデルでは status ポーリングは行わない（保存=即commit のためサーバに
+  // 「未コミット差分」が存在しない）。
   useEffect(() => {
-    const checkStatus = async () => {
-      try {
-        const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/status`)
-        if (response.ok) {
-          const data = await response.json()
-          const hasLocalChanges =
-            initialMarkdownRef.current !== '' && rawMarkdown !== initialMarkdownRef.current
-          if (!hasLocalChanges) {
-            setHasUnsavedChanges(data.has_uncommitted_changes)
-          } else {
-            setHasUnsavedChanges(true)
-          }
-        }
-      } catch (error) {
-        console.error('Failed to check status:', error)
-      }
-    }
-
-    const interval = setInterval(checkStatus, 5000)
-    return () => clearInterval(interval)
-  }, [apiBaseUrl, projectName, rawMarkdown])
-
-  // Markdownの変更を検出
-  useEffect(() => {
-    if (initialMarkdownRef.current === '') return
-    if (rawMarkdown !== initialMarkdownRef.current) {
-      setHasUnsavedChanges(true)
-    }
+    if (initialMarkdownRef.current === '' && rawMarkdown === '') return
+    setHasUnsavedChanges(rawMarkdown !== initialMarkdownRef.current)
   }, [rawMarkdown])
 
-  // rawMarkdownが変更されたら自動的にワーキングディレクトリに保存
+  // rawMarkdown が変更されたら localStorage に下書き退避（debounce 1s）。
+  // サーバへの保存は handleSave で明示的に行う。
   useEffect(() => {
-    if (!rawMarkdown || rawMarkdown === initialMarkdownRef.current) return
+    if (!rawMarkdown && initialMarkdownRef.current === '') return
 
-    if (saveTimeoutRef.current !== null) {
-      clearTimeout(saveTimeoutRef.current)
+    if (draftSaveTimeoutRef.current !== null) {
+      clearTimeout(draftSaveTimeoutRef.current)
     }
 
-    saveTimeoutRef.current = window.setTimeout(async () => {
+    draftSaveTimeoutRef.current = window.setTimeout(() => {
       try {
-        const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/chapters`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content: rawMarkdown }),
-        })
-        if (!response.ok) {
-          console.error(`Failed to auto-save: ${response.status}`)
+        if (rawMarkdown === initialMarkdownRef.current) {
+          // 変更が無ければ draft を消しておく
+          localStorage.removeItem(localStorageKey(projectName))
+        } else {
+          localStorage.setItem(localStorageKey(projectName), rawMarkdown)
         }
       } catch (error) {
-        console.error('Failed to auto-save:', error)
+        console.error('Failed to persist draft to localStorage:', error)
       }
     }, 1000)
 
     return () => {
-      if (saveTimeoutRef.current !== null) {
-        clearTimeout(saveTimeoutRef.current)
+      if (draftSaveTimeoutRef.current !== null) {
+        clearTimeout(draftSaveTimeoutRef.current)
       }
     }
-  }, [rawMarkdown, apiBaseUrl, projectName])
+  }, [rawMarkdown, projectName])
 
-  // 保存ボタン: Gitコミット・プッシュ
+  // 保存ボタン: Worker の PUT contents を直接叩く（保存 = 即 commit）。
+  // Worker モデルでは独立した「commit」概念が無いので、PUT が成功した時点で
+  // GitHub にコミットされている。
   const handleSave = async () => {
     setIsSaving(true)
     setSaveError(null)
     try {
-      const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/commit`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          message: '原稿保存',
-        }),
-      })
-      if (!response.ok) {
-        console.error(`Failed to commit: ${response.status}`)
-        setSaveError('保存に失敗しました')
-        return
+      const sha = shaRef.current
+      if (!sha) {
+        // 初回ロードに失敗していて sha が無い場合は作成扱いで PUT する
+        // （Worker は sha 無しを新規作成として扱う。chapters/all.md が
+        //  既存なら 409 が返るのでエラー表示する）。
+        console.warn('No sha available; attempting create-style PUT')
       }
+      const result = await api.putContents(projectName, CHAPTERS_PATH, {
+        content: rawMarkdown,
+        sha: sha ?? undefined,
+        branch: DEFAULT_BRANCH,
+        message: '原稿保存',
+      })
+      if (result.sha) shaRef.current = result.sha
       initialMarkdownRef.current = rawMarkdown
       setHasUnsavedChanges(false)
+      try {
+        localStorage.removeItem(localStorageKey(projectName))
+      } catch {
+        // ignore
+      }
     } catch (error) {
-      console.error('Failed to commit:', error)
+      console.error('Failed to save:', error)
       setSaveError('保存に失敗しました')
     } finally {
       setIsSaving(false)
     }
   }
 
-  // 破棄ボタン: 未コミットの変更を破棄
+  // 破棄ボタン: localStorage の draft を消し、サーバから最新を再取得して上書き。
+  // Worker モデルでは「未コミット変更を捨てて HEAD に戻す」ではなく、
+  // 「ローカルで持っている下書きを捨てて GitHub の最新を引き直す」になる。
   const handleDiscard = async () => {
     setShowDiscardConfirm(false)
     setIsSaving(true)
     setSaveError(null)
     try {
-      const response = await fetch(`${apiBaseUrl}/api/projects/${projectName}/discard`, {
-        method: 'POST',
-      })
-      if (!response.ok) {
-        console.error(`Failed to discard: ${response.status}`)
-        setSaveError('変更の破棄に失敗しました')
-        return
+      try {
+        localStorage.removeItem(localStorageKey(projectName))
+      } catch {
+        // ignore
       }
-      const chaptersResponse = await fetch(`${apiBaseUrl}/api/projects/${projectName}/chapters`)
-      if (chaptersResponse.ok) {
-        const data = await chaptersResponse.json()
-        const markdown = data.content || ''
-        setRawMarkdown(markdown)
-        initialMarkdownRef.current = markdown
-        await parseAndSetDoc(markdown)
-      }
+      const data = await api.getContents(projectName, CHAPTERS_PATH, DEFAULT_BRANCH)
+      const markdown = data.content || ''
+      shaRef.current = data.sha
+      initialMarkdownRef.current = markdown
+      setRawMarkdown(markdown)
+      await parseAndSetDoc(markdown)
       // discard で doc が差し替わるため、選択状態・CanvasEditor 内部 state を完全リセット
       setSelectedEvent(null)
       setRpgSceneId(null)
@@ -483,7 +485,14 @@ function EditorScreen({
           ) : (
             <NovelPlayer
               events={novelEvents}
-              assetBaseUrl={`${apiBaseUrl}/api/projects/${projectName}/assets`}
+              // kako-jun/name-name#107: 旧 FastAPI は静的ファイルを直接返していたが、
+              //   Worker は /assets/:type の一覧 API しか提供しない（個別ファイルは
+              //   GitHub の download_url 経由になる）。
+              //   暫定で raw.githubusercontent.com を直接指す。プロジェクト一覧に
+              //   含まれる repo は現状 "kako-jun/<projectName>" 固定なので
+              //   このフォールバックで動く。Editor/Player 統合 (#108) で
+              //   download_url ベースに置き換える。
+              assetBaseUrl={`https://raw.githubusercontent.com/kako-jun/${projectName}/${DEFAULT_BRANCH}/assets`}
             />
           )
         ) : (

--- a/frontend/src/screens/EditorScreen.tsx
+++ b/frontend/src/screens/EditorScreen.tsx
@@ -84,6 +84,11 @@ function EditorScreen({
   const shaRef = useRef<string | null>(null)
   const [rawMarkdown, setRawMarkdown] = useState<string>('')
   const [rpgSubTab, setRpgSubTab] = useState<'map' | 'npc' | 'play'>('map')
+  // PR #120 review S4: 初期ロードに失敗したら autosave / 保存ボタンを止める。
+  //   失敗時に空 doc で上書きすると localStorage の draft も '' で潰れて
+  //   ユーザーの未保存原稿が消えるので、loadFailed のうちはサーバ書き戻し系を
+  //   全部停止し、再読み込みを促すエラーメッセージを出す。
+  const [loadFailed, setLoadFailed] = useState(false)
   // PR #120 review S2: NovelPlayer に渡す assets のベース URL。kako-jun ハードコードを
   //   やめ、Worker (listProjects) から取得した repo (`owner/name`) を使う。
   //   ロード前は null。
@@ -250,6 +255,7 @@ function EditorScreen({
         const data = await api.getContents(projectName, CHAPTERS_PATH, DEFAULT_BRANCH)
         const markdown = data.content || ''
         shaRef.current = data.sha
+        setLoadFailed(false)
         initialMarkdownRef.current = markdown
 
         // localStorage に draft があれば復元、無ければサーバ値をそのまま使う。
@@ -266,9 +272,14 @@ function EditorScreen({
         setHasUnsavedChanges(localDraft !== null && localDraft !== markdown)
       } catch (error) {
         console.error('Failed to load chapters:', error)
-        // ロード失敗時もエディタで操作を開始できるよう、空 doc にフォールバックする
+        // PR #120 review S4: 失敗時に setRawMarkdown('') すると autosave 経由で
+        //   localStorage の draft が空文字で潰れる。loadFailed フラグを立てて
+        //   autosave と保存ボタンを止めることで、ユーザーが既に書いた原稿の
+        //   draft を保護する。doc は空フォールバックで操作可能にだけしておく。
+        shaRef.current = null
+        setLoadFailed(true)
         setDoc({ engine: 'name-name', chapters: [] })
-        setSaveError('プロジェクトの読み込みに失敗しました')
+        setSaveError('プロジェクトの読み込みに失敗しました。再読み込みしてください。')
       }
     }
     loadChapters()
@@ -285,7 +296,10 @@ function EditorScreen({
 
   // rawMarkdown が変更されたら localStorage に下書き退避（debounce 1s）。
   // サーバへの保存は handleSave で明示的に行う。
+  // PR #120 review S4: 初期ロード失敗時 (loadFailed) は draft を一切触らない。
+  //   失敗状態で空 doc を設定しているので、autosave すると既存 draft を上書きする。
   useEffect(() => {
+    if (loadFailed) return
     if (!rawMarkdown && initialMarkdownRef.current === '') return
 
     if (draftSaveTimeoutRef.current !== null) {
@@ -310,7 +324,7 @@ function EditorScreen({
         clearTimeout(draftSaveTimeoutRef.current)
       }
     }
-  }, [rawMarkdown, projectName])
+  }, [rawMarkdown, projectName, loadFailed])
 
   // 保存ボタン: Worker の PUT contents を直接叩く（保存 = 即 commit）。
   // Worker モデルでは独立した「commit」概念が無いので、PUT が成功した時点で
@@ -351,19 +365,28 @@ function EditorScreen({
   // 破棄ボタン: localStorage の draft を消し、サーバから最新を再取得して上書き。
   // Worker モデルでは「未コミット変更を捨てて HEAD に戻す」ではなく、
   // 「ローカルで持っている下書きを捨てて GitHub の最新を引き直す」になる。
+  // PR #120 review S3: 先に localStorage を消すと、その直後に getContents が
+  //   失敗したとき draft が消えた上にエディタも空のままになり、ユーザーの
+  //   作業が完全に失われる。サーバから取り直しが成功した「後」で draft を消す
+  //   順序にする。
   const handleDiscard = async () => {
     setShowDiscardConfirm(false)
     setIsSaving(true)
     setSaveError(null)
     try {
+      // 1. 先にサーバから最新を取り直す
+      const data = await api.getContents(projectName, CHAPTERS_PATH, DEFAULT_BRANCH)
+      const markdown = data.content || ''
+
+      // 2. 取得成功したら draft を消す（失敗時は draft を保持して再試行可能に）
       try {
         localStorage.removeItem(localStorageKey(projectName))
       } catch {
         // ignore
       }
-      const data = await api.getContents(projectName, CHAPTERS_PATH, DEFAULT_BRANCH)
-      const markdown = data.content || ''
+
       shaRef.current = data.sha
+      setLoadFailed(false)
       initialMarkdownRef.current = markdown
       setRawMarkdown(markdown)
       await parseAndSetDoc(markdown)

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,13 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /**
+   * Worker (CF Workers) の API base URL。
+   * 未設定時は src/api/client.ts の DEFAULT_API_URL (`http://localhost:8787`) が使われる。
+   */
+  readonly VITE_API_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,16 +3,12 @@ import react from '@vitejs/plugin-react'
 import wasm from 'vite-plugin-wasm'
 import topLevelAwait from 'vite-plugin-top-level-await'
 
+// kako-jun/name-name#107: 旧 FastAPI (localhost:7373) への dev proxy は廃止。
+//   フロントは絶対 URL (Worker) を直接叩く。CORS は Worker 側 ALLOWED_ORIGIN で対応。
 export default defineConfig({
   plugins: [react(), wasm(), topLevelAwait()],
   server: {
     port: 7374,
     open: true,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:7373',
-        changeOrigin: true,
-      },
-    },
   },
 })

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -52,9 +52,20 @@ export interface AssetUploadBody {
 }
 
 // アセットの種類（assets/ 配下のサブディレクトリ名に対応）
-// 必要に応じて拡張する
+//
+// kako-jun/name-name#107 (PR #120 review M1): 実態のゲームリポ
+// (friday-1930, ogurasia 等) は assets/{images, sounds, movies, ideas}/ の
+// 4 種類で運用している。Worker 側のホワイトリストを 4 種に絞ると将来拡張で
+// 毎回 Worker をデプロイし直すことになるため、実態 4 種 + 将来拡張 6 種を
+// 両方許容する。フロントは現状 images/sounds/movies/ideas のみ送るが、
+// 拡張時に Worker 側のコードを触らずに済む。
 export type AssetType =
+  // 実態（ゲームリポで実際に使われているサブディレクトリ）
   | "images"
+  | "sounds"
+  | "movies"
+  | "ideas"
+  // 将来拡張用（細分化したいときの予約）
   | "audio"
   | "bgm"
   | "se"
@@ -64,6 +75,9 @@ export type AssetType =
 
 export const ASSET_TYPES: ReadonlyArray<AssetType> = [
   "images",
+  "sounds",
+  "movies",
+  "ideas",
   "audio",
   "bgm",
   "se",

--- a/worker/test/assets.test.ts
+++ b/worker/test/assets.test.ts
@@ -98,6 +98,23 @@ describe("GET /api/projects/:name/assets/:type", () => {
     const res = await worker.fetch(req, ENV, ctx);
     expect(res.status).toBe(400);
   });
+
+  // PR #120 review M1: 実ゲームリポ (friday-1930 / ogurasia 等) の
+  //   assets/{sounds, movies, ideas}/ をホワイトリストに含めて 200 を返す。
+  it.each(["sounds", "movies", "ideas"] as const)(
+    "accepts real-world asset type %s with 200",
+    async (type) => {
+      globalThis.fetch = vi.fn(async () => jsonResponse([])) as typeof fetch;
+      const req = new Request(
+        `https://name-name-api.workers.dev/api/projects/ogurasia/assets/${type}`,
+      );
+      const res = await worker.fetch(req, ENV, ctx);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { type: string; entries: unknown[] };
+      expect(body.type).toBe(type);
+      expect(Array.isArray(body.entries)).toBe(true);
+    },
+  );
 });
 
 describe("POST /api/projects/:name/assets/:type", () => {


### PR DESCRIPTION
## 関連 Issue

closes #107

## 概要

旧 FastAPI バックエンド (`localhost:7373`) を叩いていたフロントを、#106 で新設した CF Worker (`localhost:8787` for dev、本番は `name-name-api.workers.dev`) に切り替える。FastAPI を起動しなくても `frontend/` 単独で `npm run dev` できる状態にする。

## 変更点

### 新規

- `frontend/src/api/client.ts` — Worker 用 API クライアント集約
  - `listProjects` / `getContents` / `putContents` / `listAssets` / `uploadAsset`
  - 旧互換 stub: `getStatus` (always `has_uncommitted: false`) / `commit` / `discard` / `getTags` (always `[]`)
  - 認証ヘッダ: `localStorage.dev_auth_token` を Bearer で送信（#110 で本実装に置換）
- `frontend/src/api/client.test.ts` — vi.fn() で fetch モック化、17 ケース
- `frontend/.env.example` — `VITE_API_URL=http://localhost:8787`

### 変更

- `frontend/src/components/ProjectList.tsx` — `apiClient.listProjects()` に切替、新レスポンス形式 `{ name, title, repo }` 対応
- `frontend/src/screens/EditorScreen.tsx`
  - `chapters` GET/PUT を `contents/chapters/all.md` に切替
  - 取得時の `sha` を state 保持、保存時に必須として渡す
  - 旧 status ポーリング・autosave-to-server を廃止し、**localStorage への draft 退避**に変更
  - 保存ボタン押下時のみ PUT contents（=即 commit）
- `frontend/src/screens/AssetsScreen.tsx`
  - `listAssets` / `uploadAsset` (base64) に切替
  - preview URL を `download_url` 直参照
  - tags / delete はローカル state のみの no-op に退避（#108 で再設計）
- `frontend/src/App.tsx` — 既定 URL を `defaultApiBaseUrl()` (`localhost:8787`) に
- `frontend/src/vite-env.d.ts` — `ImportMetaEnv` に `VITE_API_URL` を型付け
- `frontend/vite.config.ts` — 旧 dev proxy (`localhost:7373`) を削除
- `.gitignore` — `frontend/.env` / `.env.*` を ignore、`.env.example` はネガティブパターンで残す

## テスト

- 11 files / 236 tests passed (新規 client.test.ts 17 含む)
- `npm run build`: エラーなし（既存 PIXI 由来 chunk size 警告のみ）
- `npx tsc --noEmit -p .`: エラーなし
- `rg "localhost:7373" frontend/`: コメント内 3 箇所のみ。**fetch URL のハードコードは 0 件**

## 暫定処置（#108 で本実装）

- **NovelPlayer の `assetBaseUrl`**: Worker は個別ファイルを返さないため暫定で `https://raw.githubusercontent.com/kako-jun/{projectName}/develop/assets` 直指し
- **AssetsScreen の delete / tag PUT/DELETE**: Worker 側未実装のためローカル state のみの no-op + console.warn に退避
- **EditorScreen の autosave**: 1 秒 debounce サーバ PUT → localStorage draft 退避に変更

## 受け入れ条件

- [x] `frontend/src/api/client.ts` で Worker URL ベースの API 呼び出しを集約
- [x] 既存の `localhost:7373` fetch 呼び出しを全部削除
- [x] `npm run build` エラーなし
- [x] 既存テストが通り続ける（破壊なし）
- [x] `client.test.ts` で各メソッドのモックテスト追加
- [x] FastAPI を起動せずに `frontend/` 単独で `npm run dev` できる

## 触っていない領域

- WASM パーサー (`frontend/src/wasm/`)
- ゲーム描画 (`frontend/src/game/`)
- Editor / Player の UI 統合（#108 のスコープ）
- 旧 `backend/` ディレクトリ（#112 で削除）
- Worker (`worker/`) は無変更