### PR TITLE
feat: #108 ルーティング再編 + PlayerScreen 新設（最小スライス）

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { BrowserRouter, Routes, Route, useNavigate, useParams } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, useNavigate, useParams, Navigate } from 'react-router-dom'
 import ProjectListScreen from './screens/ProjectListScreen'
 import EditorScreen from './screens/EditorScreen'
 import AssetsScreen from './screens/AssetsScreen'
@@ -68,6 +68,7 @@ function App() {
             />
           }
         />
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
 
       {/* 設定モーダル */}
@@ -237,6 +238,12 @@ function AssetsScreenWrapper({
 function PlayerScreenWrapper({ apiBaseUrl, isDark }: { apiBaseUrl: string; isDark: boolean }) {
   const { projectName } = useParams<{ projectName: string }>()
   const navigate = useNavigate()
+
+  useEffect(() => {
+    if (projectName) {
+      document.title = `${projectName} - Name × Name`
+    }
+  }, [projectName])
 
   if (!projectName) {
     navigate('/')

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, useNavigate, useParams } from 'react-rout
 import ProjectListScreen from './screens/ProjectListScreen'
 import EditorScreen from './screens/EditorScreen'
 import AssetsScreen from './screens/AssetsScreen'
+import PlayerScreen from './screens/PlayerScreen'
 import { get, set } from './utils/storage'
 import { defaultApiBaseUrl } from './api/client'
 
@@ -42,7 +43,11 @@ function App() {
           }
         />
         <Route
-          path="/:projectName"
+          path="/play/:projectName"
+          element={<PlayerScreenWrapper apiBaseUrl={apiBaseUrl} isDark={isDark} />}
+        />
+        <Route
+          path="/edit/:projectName"
           element={
             <EditorScreenWrapper
               apiBaseUrl={apiBaseUrl}
@@ -53,7 +58,7 @@ function App() {
           }
         />
         <Route
-          path="/:projectName/assets"
+          path="/edit/:projectName/assets"
           element={
             <AssetsScreenWrapper
               apiBaseUrl={apiBaseUrl}
@@ -125,7 +130,13 @@ function ProjectListScreenWrapper({
   const navigate = useNavigate()
 
   const handleSelectProject = (projectName: string) => {
-    navigate(`/${projectName}`)
+    // 既定の選択操作は編集モードに遷移する。プレイ専用は ProjectList の
+    // 「プレイ」ボタンから /play/:projectName に直接飛ばす（#108 step 3）。
+    navigate(`/edit/${projectName}`)
+  }
+
+  const handlePlayProject = (projectName: string) => {
+    navigate(`/play/${projectName}`)
   }
 
   return (
@@ -133,6 +144,7 @@ function ProjectListScreenWrapper({
       apiBaseUrl={apiBaseUrl}
       isDark={isDark}
       onSelectProject={handleSelectProject}
+      onPlayProject={handlePlayProject}
       onToggleDark={onToggleDark}
       onOpenSettings={onOpenSettings}
     />
@@ -167,7 +179,7 @@ function EditorScreenWrapper({
   }
 
   const handleNavigateToAssets = () => {
-    navigate(`/${projectName}/assets`)
+    navigate(`/edit/${projectName}/assets`)
   }
 
   return (
@@ -207,7 +219,7 @@ function AssetsScreenWrapper({
   }, [projectName])
 
   const handleBack = () => {
-    navigate(`/${projectName}`)
+    navigate(`/edit/${projectName}`)
   }
 
   return (
@@ -218,6 +230,29 @@ function AssetsScreenWrapper({
       onBack={handleBack}
       onToggleDark={onToggleDark}
       onOpenSettings={onOpenSettings}
+    />
+  )
+}
+
+function PlayerScreenWrapper({ apiBaseUrl, isDark }: { apiBaseUrl: string; isDark: boolean }) {
+  const { projectName } = useParams<{ projectName: string }>()
+  const navigate = useNavigate()
+
+  if (!projectName) {
+    navigate('/')
+    return null
+  }
+
+  const handleBack = () => {
+    navigate('/')
+  }
+
+  return (
+    <PlayerScreen
+      projectName={projectName}
+      apiBaseUrl={apiBaseUrl}
+      isDark={isDark}
+      onBack={handleBack}
     />
   )
 }

--- a/frontend/src/components/ProjectList.tsx
+++ b/frontend/src/components/ProjectList.tsx
@@ -5,9 +5,14 @@ interface ProjectListProps {
   apiBaseUrl: string
   isDark: boolean
   onSelectProject: (projectName: string) => void
+  /**
+   * 「プレイ」ボタン押下時のハンドラ。kako-jun/name-name#108 で追加。
+   * 省略時は表示せず、行クリックで onSelectProject (編集モード) のみ動く。
+   */
+  onPlayProject?: (projectName: string) => void
 }
 
-function ProjectList({ apiBaseUrl, isDark, onSelectProject }: ProjectListProps) {
+function ProjectList({ apiBaseUrl, isDark, onSelectProject, onPlayProject }: ProjectListProps) {
   const [projects, setProjects] = useState<ProjectInfo[]>([])
   const [loading, setLoading] = useState(true)
   // apiBaseUrl が変わるたびにクライアントを作り直す。createApiClient は薄い
@@ -61,37 +66,51 @@ function ProjectList({ apiBaseUrl, isDark, onSelectProject }: ProjectListProps) 
         ) : (
           <div className="space-y-3">
             {projects.map((project) => (
-              <button
+              <div
                 key={project.name}
-                onClick={() => onSelectProject(project.name)}
-                className={`w-full text-left p-4 rounded-lg border transition-colors ${
+                className={`p-4 rounded-lg border ${
                   isDark
-                    ? 'border-gray-700 bg-gray-700 hover:bg-gray-600 text-white'
-                    : 'border-gray-200 bg-gray-50 hover:bg-gray-100 text-gray-900'
+                    ? 'border-gray-700 bg-gray-700 text-white'
+                    : 'border-gray-200 bg-gray-50 text-gray-900'
                 }`}
               >
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h3 className="font-semibold text-lg">{project.title || project.name}</h3>
-                    <p className={`text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
+                <div className="flex items-center justify-between gap-4">
+                  <div className="min-w-0">
+                    <h3 className="font-semibold text-lg truncate">
+                      {project.title || project.name}
+                    </h3>
+                    <p className={`text-sm truncate ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
                       {project.repo}
                     </p>
                   </div>
-                  <svg
-                    className={`w-6 h-6 ${isDark ? 'text-gray-400' : 'text-gray-400'}`}
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 5l7 7-7 7"
-                    />
-                  </svg>
+                  <div className="flex items-center gap-2 shrink-0">
+                    {onPlayProject && (
+                      <button
+                        onClick={() => onPlayProject(project.name)}
+                        aria-label={`${project.title || project.name} をプレイ`}
+                        className={`px-3 py-1.5 rounded font-medium text-sm transition-colors ${
+                          isDark
+                            ? 'bg-green-600 hover:bg-green-700 text-white'
+                            : 'bg-green-500 hover:bg-green-600 text-white'
+                        }`}
+                      >
+                        プレイ
+                      </button>
+                    )}
+                    <button
+                      onClick={() => onSelectProject(project.name)}
+                      aria-label={`${project.title || project.name} を編集`}
+                      className={`px-3 py-1.5 rounded font-medium text-sm transition-colors ${
+                        isDark
+                          ? 'bg-blue-600 hover:bg-blue-700 text-white'
+                          : 'bg-blue-500 hover:bg-blue-600 text-white'
+                      }`}
+                    >
+                      編集
+                    </button>
+                  </div>
                 </div>
-              </button>
+              </div>
             ))}
           </div>
         )}

--- a/frontend/src/screens/PlayerScreen.test.tsx
+++ b/frontend/src/screens/PlayerScreen.test.tsx
@@ -1,0 +1,246 @@
+// kako-jun/name-name#108: PlayerScreen の単体テスト。
+//
+// 検証ポイント:
+//   - listProjects / getContents が main ブランチ指定で呼ばれる
+//   - 取得した chapters/all.md が WASM パーサに渡され、結果が NovelPlayer
+//     (またはRPGシーン含有時 RPGPlayer) に流し込まれる
+//   - 編集系 UI（保存・破棄・タブなど）が一切描画されない
+//   - データ取得失敗時にエラーメッセージが表示される
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+// API クライアントをモック化
+const listProjectsMock = vi.fn()
+const getContentsMock = vi.fn()
+vi.mock('../api/client', () => ({
+  createApiClient: () => ({
+    listProjects: listProjectsMock,
+    getContents: getContentsMock,
+    putContents: vi.fn(),
+    listAssets: vi.fn(),
+    uploadAsset: vi.fn(),
+    getStatus: vi.fn(),
+    commit: vi.fn(),
+    discard: vi.fn(),
+    getTags: vi.fn(),
+  }),
+}))
+
+// WASM パーサをモック化（jsdom で WASM 初期化はしたくない）
+const parseMarkdownMock = vi.fn()
+vi.mock('../wasm/parser', () => ({
+  parseMarkdown: (md: string) => parseMarkdownMock(md),
+  emitMarkdown: vi.fn(),
+}))
+
+// NovelPlayer / RPGPlayer は PixiJS に依存し、jsdom では init できないため
+// props だけ確認できる軽い擬似コンポーネントに差し替える
+const novelPlayerProps = vi.fn()
+vi.mock('../components/NovelPlayer', () => ({
+  default: (props: { events: unknown; assetBaseUrl?: string }) => {
+    novelPlayerProps(props)
+    return (
+      <div
+        data-testid="novel-player"
+        data-event-count={Array.isArray(props.events) ? props.events.length : 0}
+        data-asset-base-url={props.assetBaseUrl ?? ''}
+      />
+    )
+  },
+}))
+
+const rpgPlayerProps = vi.fn()
+vi.mock('../components/RPGPlayer', () => ({
+  default: (props: { gameData?: unknown; view?: string }) => {
+    rpgPlayerProps(props)
+    return <div data-testid="rpg-player" data-view={props.view ?? ''} />
+  },
+}))
+
+import PlayerScreen from './PlayerScreen'
+
+beforeEach(() => {
+  listProjectsMock.mockReset()
+  getContentsMock.mockReset()
+  parseMarkdownMock.mockReset()
+  novelPlayerProps.mockReset()
+  rpgPlayerProps.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('PlayerScreen', () => {
+  it('main ブランチから章データを取得して NovelPlayer に渡す', async () => {
+    listProjectsMock.mockResolvedValue([
+      { name: 'friday-1930', title: '友達 1930', repo: 'kako-jun/friday-1930' },
+    ])
+    getContentsMock.mockResolvedValue({
+      path: 'chapters/all.md',
+      sha: 'sha1',
+      content: '# chapter\n\n## scene\n\n- dialog: hello',
+    })
+    parseMarkdownMock.mockResolvedValue({
+      engine: 'name-name',
+      chapters: [
+        {
+          id: 'c1',
+          title: 'chapter',
+          default_bgm: null,
+          scenes: [
+            {
+              id: 's1',
+              title: 'scene',
+              events: [
+                {
+                  Dialog: {
+                    character: null,
+                    expression: null,
+                    position: null,
+                    text: 'hello',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    render(
+      <PlayerScreen
+        projectName="friday-1930"
+        apiBaseUrl="http://api.test"
+        isDark={false}
+        onBack={() => {}}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('novel-player')).toBeInTheDocument()
+    })
+
+    // main ブランチ指定で取得していること
+    expect(getContentsMock).toHaveBeenCalledWith('friday-1930', 'chapters/all.md', 'main')
+
+    // パース結果が NovelPlayer に流れていること（dialog 1件→1イベント）
+    const player = screen.getByTestId('novel-player')
+    expect(player.getAttribute('data-event-count')).toBe('1')
+    // assets ベース URL は repo + main を参照
+    expect(player.getAttribute('data-asset-base-url')).toBe(
+      'https://raw.githubusercontent.com/kako-jun/friday-1930/main/assets'
+    )
+
+    // タイトル表示
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('友達 1930')
+
+    // 編集 UI が描画されていないこと（編集モード固有の文字列が無い）
+    expect(screen.queryByText('保存')).toBeNull()
+    expect(screen.queryByText('破棄')).toBeNull()
+    expect(screen.queryByText('アセット管理')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'ノベル' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'RPG' })).toBeNull()
+  })
+
+  it('RPG シーンを含むドキュメントは RPGPlayer に渡す', async () => {
+    listProjectsMock.mockResolvedValue([{ name: 'demo', title: 'demo', repo: 'kako-jun/demo' }])
+    getContentsMock.mockResolvedValue({
+      path: 'chapters/all.md',
+      sha: 'sha2',
+      content: '# rpg',
+    })
+    parseMarkdownMock.mockResolvedValue({
+      engine: 'name-name',
+      chapters: [
+        {
+          id: 'c1',
+          title: 'rpg chapter',
+          default_bgm: null,
+          scenes: [
+            {
+              id: 'rpg-map',
+              title: 'rpg scene',
+              events: [
+                {
+                  RpgMap: {
+                    width: 3,
+                    height: 2,
+                    tile_size: 16,
+                    tiles: [
+                      [0, 0, 0],
+                      [0, 0, 0],
+                    ],
+                    wall_heights: null,
+                    floor_heights: null,
+                    ceiling_heights: null,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    render(
+      <PlayerScreen
+        projectName="demo"
+        apiBaseUrl="http://api.test"
+        isDark={false}
+        onBack={() => {}}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rpg-player')).toBeInTheDocument()
+    })
+
+    // NovelPlayer は描画されないこと
+    expect(screen.queryByTestId('novel-player')).toBeNull()
+  })
+
+  it('データ取得に失敗した場合はエラーメッセージを表示する', async () => {
+    listProjectsMock.mockResolvedValue([
+      { name: 'missing', title: 'missing', repo: 'kako-jun/missing' },
+    ])
+    getContentsMock.mockRejectedValue(new Error('not found'))
+
+    render(
+      <PlayerScreen
+        projectName="missing"
+        apiBaseUrl="http://api.test"
+        isDark={false}
+        onBack={() => {}}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('ゲームデータが見つかりません')
+    })
+
+    // プレイヤーは描画されない
+    expect(screen.queryByTestId('novel-player')).toBeNull()
+    expect(screen.queryByTestId('rpg-player')).toBeNull()
+  })
+
+  it('戻るボタンを押すと onBack が呼ばれる', async () => {
+    listProjectsMock.mockResolvedValue([])
+    getContentsMock.mockResolvedValue({
+      path: 'chapters/all.md',
+      sha: 'sha3',
+      content: '',
+    })
+    parseMarkdownMock.mockResolvedValue({ engine: 'name-name', chapters: [] })
+
+    const onBack = vi.fn()
+    render(
+      <PlayerScreen projectName="x" apiBaseUrl="http://api.test" isDark={false} onBack={onBack} />
+    )
+
+    const backButton = await screen.findByLabelText('プロジェクト一覧に戻る')
+    backButton.click()
+    expect(onBack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo, useState } from 'react'
+import NovelPlayer from '../components/NovelPlayer'
+import RPGPlayer from '../components/RPGPlayer'
+import type { Event, EventDocument } from '../types'
+import type { RPGProject } from '../types/rpg'
+import { parseMarkdown } from '../wasm/parser'
+import { findRpgSceneIndex, rpgProjectFromDoc } from '../game/rpgProjectFromDoc'
+import { createApiClient, type ProjectInfo } from '../api/client'
+
+// kako-jun/name-name#108: 一般ユーザー向けの再生専用画面。
+//   - 編集 UI / 保存 / アセット管理 / デバッグは一切表示しない
+//   - chapters/all.md は **main ブランチ**を参照する
+//     （ADR #105: 一般ユーザーは未完成原稿（develop）を見ない）
+//   - 戻るボタンとタイトル表示のみのシンプルなヘッダー
+//   - データ取得失敗時は「ゲームデータが見つかりません」を表示
+const CHAPTERS_PATH = 'chapters/all.md'
+const PUBLIC_BRANCH = 'main'
+
+interface PlayerScreenProps {
+  projectName: string
+  apiBaseUrl: string
+  isDark: boolean
+  onBack: () => void
+}
+
+/**
+ * EventDocument を NovelPlayer 用のフラット Event[] に変換する。
+ * EditorScreen の同名関数と同じ整形（最初のシーン以外の前に SceneTransition を挟む）。
+ * #108 の本格統合時に共通化予定。
+ */
+function flattenDocumentEvents(doc: EventDocument): Event[] {
+  const events: Event[] = []
+  let first = true
+  for (const chapter of doc.chapters) {
+    for (const scene of chapter.scenes) {
+      if (!first) {
+        events.push('SceneTransition')
+      }
+      first = false
+      events.push(...scene.events)
+    }
+  }
+  return events
+}
+
+function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenProps) {
+  const api = useMemo(() => createApiClient({ baseUrl: apiBaseUrl }), [apiBaseUrl])
+  const [doc, setDoc] = useState<EventDocument | null>(null)
+  const [projectInfo, setProjectInfo] = useState<ProjectInfo | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    document.title = `${projectName} - Name × Name`
+  }, [projectName])
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        // 1. プロジェクト情報を取得（タイトル表示・assets ベース URL 解決用）
+        const projects = await api.listProjects()
+        const found = projects.find((p) => p.name === projectName) ?? null
+        if (cancelled) return
+        setProjectInfo(found)
+
+        // 2. main ブランチから章データを取得
+        const data = await api.getContents(projectName, CHAPTERS_PATH, PUBLIC_BRANCH)
+        if (cancelled) return
+        const markdown = data.content || ''
+
+        // 3. WASM で Markdown → EventDocument
+        const parsed = await parseMarkdown(markdown)
+        if (cancelled) return
+        setDoc(parsed)
+      } catch (e) {
+        console.error('PlayerScreen: failed to load project:', e)
+        if (!cancelled) {
+          setError('ゲームデータが見つかりません')
+          setDoc(null)
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [api, projectName])
+
+  // 再生用のフラット Event[]
+  const novelEvents = useMemo(() => (doc ? flattenDocumentEvents(doc) : []), [doc])
+
+  // RPG シーン（最初の RPG シーンのみ採用 — 編集と違いプレイヤーは選択 UI を出さない）
+  const rpgProject: RPGProject | null = useMemo(() => {
+    if (!doc) return null
+    const found = findRpgSceneIndex(doc)
+    if (!found) return null
+    const sceneId = doc.chapters[found.chapterIndex]?.scenes[found.sceneIndex]?.id ?? undefined
+    return rpgProjectFromDoc(doc, sceneId, projectName)
+  }, [doc, projectName])
+
+  // assets のベース URL は main ブランチを参照（#108 で download_url ベースに統一予定）
+  const assetBaseUrl = projectInfo
+    ? `https://raw.githubusercontent.com/${projectInfo.repo}/${PUBLIC_BRANCH}/assets`
+    : `https://raw.githubusercontent.com/kako-jun/${projectName}/${PUBLIC_BRANCH}/assets`
+
+  const title = projectInfo?.title || projectName
+
+  return (
+    <div className={`flex flex-col h-screen ${isDark ? 'dark bg-gray-900' : 'bg-white'}`}>
+      <header
+        className={`border-b ${isDark ? 'border-gray-700 bg-gray-900' : 'border-blue-200 bg-blue-50'}`}
+      >
+        <div className="px-6 py-2 flex items-center gap-3">
+          <button
+            onClick={onBack}
+            aria-label="プロジェクト一覧に戻る"
+            className={`w-8 h-8 flex items-center justify-center rounded transition-colors ${
+              isDark ? 'text-gray-300 hover:bg-gray-800' : 'text-gray-600 hover:bg-gray-100'
+            }`}
+            title="プロジェクト一覧に戻る"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <h1 className={`text-lg font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+            {title}
+          </h1>
+        </div>
+      </header>
+
+      <main className="flex-1 overflow-hidden">
+        {loading ? (
+          <div
+            className={`flex items-center justify-center h-full ${isDark ? 'text-gray-400' : 'text-gray-600'}`}
+          >
+            読み込み中...
+          </div>
+        ) : error !== null ? (
+          <div
+            className={`flex items-center justify-center h-full ${isDark ? 'text-gray-300' : 'text-gray-700'}`}
+          >
+            <p role="alert">{error}</p>
+          </div>
+        ) : rpgProject !== null ? (
+          // RPG シーンを含むプロジェクトは RPGPlayer を優先する。
+          // ノベル+RPG の遷移制御は #108 本統合で扱う。
+          <RPGPlayer gameData={rpgProject} view={rpgProject.view} />
+        ) : (
+          <NovelPlayer events={novelEvents} assetBaseUrl={assetBaseUrl} />
+        )}
+      </main>
+    </div>
+  )
+}
+
+export default PlayerScreen

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -51,10 +51,6 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    document.title = `${projectName} - Name × Name`
-  }, [projectName])
-
-  useEffect(() => {
     let cancelled = false
     const load = async () => {
       setLoading(true)

--- a/frontend/src/screens/ProjectListScreen.tsx
+++ b/frontend/src/screens/ProjectListScreen.tsx
@@ -4,6 +4,11 @@ interface ProjectListScreenProps {
   apiBaseUrl: string
   isDark: boolean
   onSelectProject: (projectName: string) => void
+  /**
+   * 「プレイ」ボタン押下時の遷移先。kako-jun/name-name#108 で追加。
+   * 省略時は onSelectProject にフォールバック（編集モードに飛ぶ）。
+   */
+  onPlayProject?: (projectName: string) => void
   onToggleDark: () => void
   onOpenSettings: () => void
 }
@@ -12,6 +17,7 @@ function ProjectListScreen({
   apiBaseUrl,
   isDark,
   onSelectProject,
+  onPlayProject,
   onToggleDark,
   onOpenSettings,
 }: ProjectListScreenProps) {
@@ -79,7 +85,12 @@ function ProjectListScreen({
       </header>
 
       <main className="flex-1 overflow-hidden">
-        <ProjectList apiBaseUrl={apiBaseUrl} isDark={isDark} onSelectProject={onSelectProject} />
+        <ProjectList
+          apiBaseUrl={apiBaseUrl}
+          isDark={isDark}
+          onSelectProject={onSelectProject}
+          onPlayProject={onPlayProject}
+        />
       </main>
     </div>
   )


### PR DESCRIPTION
## 関連 Issue

closes #108 (最小スライス。完全統合は別作業)

## 概要

エディタとプレイヤーを権限分岐で1画面に統合する Issue #108 のうち、**URL routing による分岐**を最小スライスとして先に実装する。`/play/:project` を一般ユーザー向けプレイヤー、`/edit/:project` を編集モードに分離。同画面で権限差で UI 分岐する完全統合は別作業。

friday-1930 を kako-jun が公開 URL で見られる最短ルートを通すのが目的。

## URL マッピング

| URL | 画面 | branch |
|---|---|---|
| `/` | ProjectListScreen（プレイ/編集ボタン併設） | - |
| `/play/:projectName` | **PlayerScreen（新設）** 再生専用、編集 UI なし | **main** |
| `/edit/:projectName` | EditorScreen（既存維持） | develop |
| `/edit/:projectName/assets` | AssetsScreen（既存維持） | develop |

## 実装

### 新規

- `frontend/src/screens/PlayerScreen.tsx`
  - `apiClient.listProjects()` でプロジェクト情報取得
  - `apiClient.getContents(name, 'chapters/all.md', 'main')` で **main ブランチ** から章データ取得（ADR #105 準拠）
  - WASM パーサーで EventDocument 変換
  - RPG シーン含めば `RPGPlayer`、それ以外は `NovelPlayer`
  - assets ベース URL も main 参照
  - 編集 UI / セーブボタン / アセット管理は一切表示なし
  - 戻るボタンとタイトル表示のみ
- `frontend/src/screens/PlayerScreen.test.tsx`
  - main ブランチ取得 + NovelPlayer props 検証
  - RPG シーン含有時の RPGPlayer 切替
  - データ取得失敗時のエラー表示（`role="alert"`）
  - 戻るボタンの onBack 呼び出し

### 変更

- `frontend/src/App.tsx` — ルート再編、PlayerScreenWrapper 追加
- `frontend/src/components/ProjectList.tsx` — プレイ/編集ボタン
- `frontend/src/screens/ProjectListScreen.tsx` — `onPlayProject` パススルー

## 触っていない領域

- `frontend/src/game/`（NovelPlayer / RPGPlayer 等）
- `frontend/src/wasm/`
- EditorScreen 本体（既存挙動維持）
- AssetsScreen 本体
- Worker (`worker/`)
- 旧 backend (`backend/`、#112 で削除)

## テスト

- 243 tests passed (12 files) — 既存 239 + PlayerScreen 4 ケース
- `npm run build`: PASS

## 動作確認

```bash
cd frontend && npm run dev
# /                       一覧（プレイ/編集ボタン）
# /play/friday-1930        main ブランチから再生
# /edit/friday-1930        編集
# /edit/friday-1930/assets アセット管理
```

Worker (`localhost:8787` または `name-name-api.workers.dev`) が起動している必要あり。

## 残作業（別 Issue/続作業）

- 完全統合（同画面で権限差で UI 分岐 + デバッグオーバーレイ）
- `/edit/*` の認証 gate（#110 で実装）
- ProjectListScreen を「ジャンプ風タイトル画面」に置換（#109）