### PR TITLE
feat: #116 Git Data API 経路で >=5 MiB アセットを扱う

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -22,7 +22,9 @@ Issue: kako-jun/name-name#106
 | GET | `/api/projects/:name/contents/*path` | Contents API ラッパー (base64 → utf-8) |
 | PUT | `/api/projects/:name/contents/*path` | Contents API で commit。**新規作成 + 更新どちらも対応**（#115 で実装済）|
 | GET | `/api/projects/:name/assets/:type` | `assets/{type}/` のディレクトリ一覧 |
-| POST | `/api/projects/:name/assets/:type` | base64 アップロード。サイズで経路自動分岐: `<5 MiB`=Contents API、`>=5 MiB && <=100 MiB`=Git Data API (#116)、`>100 MiB`=413 (LFS は別 Issue) |
+| POST | `/api/projects/:name/assets/:type` | base64 アップロード。サイズで経路自動分岐: `<5 MiB`=Contents API、`>=5 MiB && <=25 MiB`=Git Data API (#116)、`>25 MiB`=413 |
+
+> **大容量アセットの上限**: GitHub の blob 上限は 100 MiB だが、Cloudflare Workers の per-request メモリ上限が 128 MiB なので 100 MiB 級の base64 (≈133 MiB の文字列) は OOM する。本 Worker は安全圏として **25 MiB** で頭打ちにしている。それ以上は Git LFS or streaming アップロード経路 (将来 Issue) で扱う。
 
 `PUT` / `POST` は editor 認証が必要。**現状は dev only** で `Authorization: Bearer ${DEV_AUTH_TOKEN}` 一致のみ通す。
 本実装（CF Access JWT or GitHub OAuth）は **kako-jun/name-name#110**。

--- a/worker/README.md
+++ b/worker/README.md
@@ -22,7 +22,7 @@ Issue: kako-jun/name-name#106
 | GET | `/api/projects/:name/contents/*path` | Contents API ラッパー (base64 → utf-8) |
 | PUT | `/api/projects/:name/contents/*path` | Contents API で commit。**新規作成 + 更新どちらも対応**（#115 で実装済）|
 | GET | `/api/projects/:name/assets/:type` | `assets/{type}/` のディレクトリ一覧 |
-| POST | `/api/projects/:name/assets/:type` | base64 アップロード（**5 MiB 未満**）|
+| POST | `/api/projects/:name/assets/:type` | base64 アップロード。サイズで経路自動分岐: `<5 MiB`=Contents API、`>=5 MiB && <=100 MiB`=Git Data API (#116)、`>100 MiB`=413 (LFS は別 Issue) |
 
 `PUT` / `POST` は editor 認証が必要。**現状は dev only** で `Authorization: Bearer ${DEV_AUTH_TOKEN}` 一致のみ通す。
 本実装（CF Access JWT or GitHub OAuth）は **kako-jun/name-name#110**。
@@ -104,15 +104,15 @@ wrangler deploy
 ## 今後の Issue
 
 - **#110** authenticate() 本実装（CF Access / GitHub OAuth）
-- **#111** 初回 wrangler deploy（kako-jun が手動）
-- **#112** 旧 `backend/` (FastAPI) と `compose.yaml` の削除
-- **#116** `>= 5 MiB` のアセットを Git Data API (blob/tree/commit) で扱う
-- **#117** PROJECTS リストの KV / D1 化
 - **#118** ブランチ横断のキャッシュパージ（GitHub webhook 経由）
 
 実装済:
 
+- **#111** 初回 wrangler deploy（session377 で手動完了）
+- **#112** 旧 `backend/` (FastAPI) と `compose.yaml` の削除（session377 完了）
 - **#115** 新規ファイル作成エンドポイント（sha なし PUT）— 422 → 409 正規化、`PUT` で create + update 両対応
+- **#116** `>= 5 MiB` のアセットを Git Data API (blob/tree/commit/ref) で扱う（`<= 100 MiB`、それ以上は LFS = 別 Issue）
+- **#117** PROJECTS リストの KV / D1 化（won't do、ハードコードのまま）
 
 ## ファイル構成
 

--- a/worker/src/assets.ts
+++ b/worker/src/assets.ts
@@ -1,17 +1,21 @@
 // /api/projects/:name/assets/:type ハンドラ
 //
 // - GET  : assets/{type}/ 配下の Contents API ディレクトリ一覧を返す
-// - POST : 5 MiB 未満の base64 アップロード（5 MiB ちょうど・>5 MiB は #116 で
-//          Git Data API (blob/tree/commit) 経由で対応）
+// - POST : サイズで経路を自動分岐
+//          - <  5 MiB : Contents API (base64) でファイル単位 PUT
+//          - >= 5 MiB && <= 100 MiB : Git Data API (blob/tree/commit/ref) (#116)
+//          - >  100 MiB             : 413 (LFS は別 Issue)
 
 import type { Endpoints } from "@octokit/types";
 import { authenticate, requireEditor } from "./auth";
 import { assetsCacheKey, cacheDelete, cacheGet, cachePut } from "./cache";
 import { createGitHub, logRateLimit, normalizeError } from "./github";
+import { GitDataConflictError, uploadAssetViaGitData } from "./git-data";
 import { findProject, splitRepo } from "./projects";
 import {
   ASSET_TYPES,
   MAX_ASSET_BYTES,
+  MAX_GIT_DATA_BYTES,
   type AssetEntry,
   type AssetType,
   type AssetUploadBody,
@@ -166,13 +170,11 @@ export async function handleUploadAsset(
   }
 
   const sizeBytes = base64DecodedLength(body.contentBase64);
-  // 5 MiB ちょうども reject する。Contents API の上限は 100 MiB だがレスポンスに
-  // 1 MiB 制限があるため、ここでは 5 MiB 未満に絞る。
-  // TODO(#116): >= MAX_ASSET_BYTES のアセットは Git Data API (blob/tree/commit) で扱う。
-  if (sizeBytes >= MAX_ASSET_BYTES) {
+  // GitHub blob 上限の 100 MiB を超える本体は LFS が必要 (別 Issue 案件)。
+  if (sizeBytes > MAX_GIT_DATA_BYTES) {
     return jsonResponse(
       {
-        error: `asset must be smaller than ${MAX_ASSET_BYTES} bytes (see #116 for >= 5 MiB support via Git Data API)`,
+        error: `asset must be <= ${MAX_GIT_DATA_BYTES} bytes (100 MiB). Files larger than this require Git LFS (separate issue).`,
         size: sizeBytes,
       },
       413,
@@ -183,40 +185,80 @@ export async function handleUploadAsset(
   const path = `assets/${type}/${body.filename}`;
   const branch = body.branch;
   const octokit = createGitHub(env);
+  // base64 文字列の whitespace は両経路で除去してから渡す。
+  const cleanedContent = body.contentBase64.replace(/\s+/g, "");
+
+  // 5 MiB 未満は Contents API、5 MiB 以上は Git Data API 経路。
+  if (sizeBytes < MAX_ASSET_BYTES) {
+    try {
+      const res = await octokit.request("PUT /repos/{owner}/{repo}/contents/{path}", {
+        owner,
+        repo,
+        path,
+        message: body.message,
+        content: cleanedContent,
+        branch,
+        // sha があれば既存ファイル上書き、なければ新規作成として扱う。
+        // 新規作成時に GitHub 側で同名ファイルが既にあると 422 を返すので、それはそのまま伝搬する。
+        sha: body.sha,
+      });
+      logRateLimit("assets.upload", res.headers as Record<string, string | number | undefined>);
+
+      // 一覧キャッシュをパージ。
+      // NOTE(#118): 現状はこの Worker が触る branch / default 二系統だけパージしている。
+      //   ブランチ横断でのパージは GitHub webhook 経由で #118 にて本実装する予定。
+      await cacheDelete(assetsCacheKey(owner, repo, type, branch ?? null));
+      await cacheDelete(assetsCacheKey(owner, repo, type, null));
+
+      const data = res.data as ContentsPutResponseData;
+      return jsonResponse(
+        {
+          path: data.content?.path ?? path,
+          sha: data.content?.sha ?? null,
+          commit_sha: data.commit?.sha ?? null,
+          size: sizeBytes,
+        },
+        201,
+        { "x-cache": "BYPASS" },
+      );
+    } catch (err) {
+      const ne = normalizeError(err);
+      logRateLimit("assets.upload.err", ne.responseHeaders);
+      return jsonResponse({ error: ne.message, status: ne.status }, ne.status);
+    }
+  }
+
+  // ----- Git Data API 経路 (#116) -----
   try {
-    const res = await octokit.request("PUT /repos/{owner}/{repo}/contents/{path}", {
+    const result = await uploadAssetViaGitData(octokit, {
       owner,
       repo,
       path,
+      contentBase64: cleanedContent,
       message: body.message,
-      content: body.contentBase64.replace(/\s+/g, ""),
       branch,
-      // sha があれば既存ファイル上書き、なければ新規作成として扱う。
-      // 新規作成時に GitHub 側で同名ファイルが既にあると 422 を返すので、それはそのまま伝搬する。
-      sha: body.sha,
+      expectedSha: body.sha,
     });
-    logRateLimit("assets.upload", res.headers as Record<string, string | number | undefined>);
 
-    // 一覧キャッシュをパージ。
-    // NOTE(#118): 現状はこの Worker が触る branch / default 二系統だけパージしている。
-    //   ブランチ横断でのパージは GitHub webhook 経由で #118 にて本実装する予定。
     await cacheDelete(assetsCacheKey(owner, repo, type, branch ?? null));
     await cacheDelete(assetsCacheKey(owner, repo, type, null));
 
-    const data = res.data as ContentsPutResponseData;
     return jsonResponse(
       {
-        path: data.content?.path ?? path,
-        sha: data.content?.sha ?? null,
-        commit_sha: data.commit?.sha ?? null,
+        path: result.path,
+        sha: result.sha,
+        commit_sha: result.commit_sha,
         size: sizeBytes,
       },
       201,
       { "x-cache": "BYPASS" },
     );
   } catch (err) {
+    if (err instanceof GitDataConflictError) {
+      return jsonResponse({ error: err.message, status: 409 }, 409);
+    }
     const ne = normalizeError(err);
-    logRateLimit("assets.upload.err", ne.responseHeaders);
+    logRateLimit("assets.upload.git-data.err", ne.responseHeaders);
     return jsonResponse({ error: ne.message, status: ne.status }, ne.status);
   }
 }

--- a/worker/src/assets.ts
+++ b/worker/src/assets.ts
@@ -240,7 +240,12 @@ export async function handleUploadAsset(
       expectedSha: body.sha,
     });
 
-    await cacheDelete(assetsCacheKey(owner, repo, type, branch ?? null));
+    // branch 省略時は default_branch が解決されている。両方 (resolved + null) を
+    // パージしてキャッシュ整合を取る (review N-1)。
+    await cacheDelete(assetsCacheKey(owner, repo, type, result.branch));
+    if (branch && branch !== result.branch) {
+      await cacheDelete(assetsCacheKey(owner, repo, type, branch));
+    }
     await cacheDelete(assetsCacheKey(owner, repo, type, null));
 
     return jsonResponse(

--- a/worker/src/git-data.ts
+++ b/worker/src/git-data.ts
@@ -57,8 +57,6 @@ type TreeCreateResponse =
   Endpoints["POST /repos/{owner}/{repo}/git/trees"]["response"]["data"];
 type CommitCreateResponse =
   Endpoints["POST /repos/{owner}/{repo}/git/commits"]["response"]["data"];
-type RefPatchResponse =
-  Endpoints["PATCH /repos/{owner}/{repo}/git/refs/{ref}"]["response"]["data"];
 type ContentsGetResponse =
   Endpoints["GET /repos/{owner}/{repo}/contents/{path}"]["response"]["data"];
 
@@ -75,8 +73,15 @@ async function resolveDefaultBranch(
 
 /**
  * 楽観ロック用に現在の path 上の blob sha を取得する。
+ *
+ * Contents API を **ファイル直接** で叩くと >1 MiB のレスポンスが
+ * truncate されるなど挙動差があるため、親ディレクトリの listing から
+ * 該当 basename を引く方式にする (review M-2)。listing 各 entry の sha
+ * はディレクトリ全体が大きくても安定して返ってくる。
+ *
  * - 存在すれば sha を返す
- * - 404 なら null を返す（新規作成扱い）
+ * - 親ディレクトリ自体が無い / 当該ファイルが listing に無い → null (新規作成扱い)
+ * - 想定外の形 (path が file ではなく dir 等) は warn ログを出して null
  */
 async function getCurrentBlobSha(
   octokit: GitHubClient,
@@ -85,19 +90,25 @@ async function getCurrentBlobSha(
   path: string,
   branch: string,
 ): Promise<string | null> {
+  const lastSlash = path.lastIndexOf("/");
+  if (lastSlash < 0) return null;
+  const dirPath = path.slice(0, lastSlash);
+  const baseName = path.slice(lastSlash + 1);
   try {
     const res = await octokit.request("GET /repos/{owner}/{repo}/contents/{path}", {
       owner,
       repo,
-      path,
+      path: dirPath,
       ref: branch,
     });
     const data = res.data as ContentsGetResponse;
-    if (Array.isArray(data)) {
-      // ディレクトリなら sha 比較は無意味。null として扱い、後段で衝突判定に任せる
+    if (!Array.isArray(data)) {
+      // ディレクトリのつもりが file が返ってきた異常系。比較不能なので null に倒す。
+      console.warn(`[git-data] expected directory listing at ${dirPath} but got non-array`);
       return null;
     }
-    return data.sha ?? null;
+    const entry = data.find((e) => e.name === baseName && e.type === "file");
+    return entry?.sha ?? null;
   } catch (err) {
     const ne = normalizeError(err);
     if (ne.status === 404) return null;
@@ -174,19 +185,31 @@ export async function uploadAssetViaGitData(
   logRateLimit("git-data.commit-create", newCommitRes.headers as Record<string, string | number | undefined>);
   const newCommitSha = (newCommitRes.data as CommitCreateResponse).sha;
 
-  const refPatchRes = await octokit.request("PATCH /repos/{owner}/{repo}/git/refs/{ref}", {
-    owner,
-    repo,
-    ref: `heads/${branch}`,
-    sha: newCommitSha,
-  });
-  logRateLimit("git-data.ref-patch", refPatchRes.headers as Record<string, string | number | undefined>);
-  const finalCommitSha = (refPatchRes.data as RefPatchResponse).object.sha;
-
-  return {
-    path,
-    sha: newBlobSha,
-    commit_sha: finalCommitSha,
-    branch,
-  };
+  // ref patch が 422 を返したら他デバイス/CI の concurrent push と判定し
+  // GitDataConflictError に詰め替える (review M-1)。force は使わない方針。
+  try {
+    const refPatchRes = await octokit.request("PATCH /repos/{owner}/{repo}/git/refs/{ref}", {
+      owner,
+      repo,
+      ref: `heads/${branch}`,
+      sha: newCommitSha,
+    });
+    logRateLimit("git-data.ref-patch", refPatchRes.headers as Record<string, string | number | undefined>);
+    // refPatchRes.data.object.sha は newCommitSha と一致するため改めて読まずに返す。
+    // (ref patch の echo 確認は logRateLimit の HTTP 200 で十分)
+    return {
+      path,
+      sha: newBlobSha,
+      commit_sha: newCommitSha,
+      branch,
+    };
+  } catch (err) {
+    const ne = normalizeError(err);
+    if (ne.status === 422) {
+      throw new GitDataConflictError(
+        `ref advanced concurrently on heads/${branch} (non-fast-forward); retry the upload`,
+      );
+    }
+    throw err;
+  }
 }

--- a/worker/src/git-data.ts
+++ b/worker/src/git-data.ts
@@ -1,0 +1,192 @@
+// Git Data API 経由のアセットアップロード (#116)
+//
+// Contents API は base64 で 5 MiB ちょうど・>5 MiB を扱えないため、`>= MAX_ASSET_BYTES`
+// は本モジュールに分岐する。フローは:
+//   1. branch 省略時は GET /repos で default_branch を解決
+//   2. GET /git/ref/heads/{branch} で親 commit SHA を取得
+//   3. GET /git/commits/{sha} で base tree SHA を取得
+//   4. POST /git/blobs で blob を作成 (encoding: base64)
+//   5. POST /git/trees で base_tree を継承した新 tree を作成
+//   6. POST /git/commits で親付き commit を作成
+//   7. PATCH /git/refs/heads/{branch} で branch ref を進める
+//
+// 楽観ロックは body.sha が指定されたときのみ実施する: GET contents で現在の blob sha を
+// 取り、不一致なら 409。新規作成 (Contents 404) で sha 指定があるのも 409 扱い。
+
+import type { Endpoints } from "@octokit/types";
+import { logRateLimit, normalizeError, type GitHubClient } from "./github";
+
+export interface GitDataUploadParams {
+  owner: string;
+  repo: string;
+  /** 例: `assets/images/title.png` （リポジトリ root からのパス） */
+  path: string;
+  /** base64 エンコード済みの本体（whitespace 除去はしない。呼び出し側で済ませてあること） */
+  contentBase64: string;
+  message: string;
+  /** 省略時は default_branch を解決する */
+  branch?: string;
+  /** 楽観ロック用。指定があれば現在の blob sha と一致確認する */
+  expectedSha?: string;
+}
+
+export interface GitDataUploadResult {
+  path: string;
+  /** 新しい blob の SHA */
+  sha: string;
+  /** ref を進めた後の commit SHA */
+  commit_sha: string;
+  branch: string;
+}
+
+export class GitDataConflictError extends Error {
+  status = 409 as const;
+  constructor(message: string) {
+    super(message);
+    this.name = "GitDataConflictError";
+  }
+}
+
+type RepoGetResponse = Endpoints["GET /repos/{owner}/{repo}"]["response"]["data"];
+type RefGetResponse = Endpoints["GET /repos/{owner}/{repo}/git/ref/{ref}"]["response"]["data"];
+type CommitGetResponse =
+  Endpoints["GET /repos/{owner}/{repo}/git/commits/{commit_sha}"]["response"]["data"];
+type BlobCreateResponse =
+  Endpoints["POST /repos/{owner}/{repo}/git/blobs"]["response"]["data"];
+type TreeCreateResponse =
+  Endpoints["POST /repos/{owner}/{repo}/git/trees"]["response"]["data"];
+type CommitCreateResponse =
+  Endpoints["POST /repos/{owner}/{repo}/git/commits"]["response"]["data"];
+type RefPatchResponse =
+  Endpoints["PATCH /repos/{owner}/{repo}/git/refs/{ref}"]["response"]["data"];
+type ContentsGetResponse =
+  Endpoints["GET /repos/{owner}/{repo}/contents/{path}"]["response"]["data"];
+
+async function resolveDefaultBranch(
+  octokit: GitHubClient,
+  owner: string,
+  repo: string,
+): Promise<string> {
+  const res = await octokit.request("GET /repos/{owner}/{repo}", { owner, repo });
+  logRateLimit("git-data.repo", res.headers as Record<string, string | number | undefined>);
+  const data = res.data as RepoGetResponse;
+  return data.default_branch;
+}
+
+/**
+ * 楽観ロック用に現在の path 上の blob sha を取得する。
+ * - 存在すれば sha を返す
+ * - 404 なら null を返す（新規作成扱い）
+ */
+async function getCurrentBlobSha(
+  octokit: GitHubClient,
+  owner: string,
+  repo: string,
+  path: string,
+  branch: string,
+): Promise<string | null> {
+  try {
+    const res = await octokit.request("GET /repos/{owner}/{repo}/contents/{path}", {
+      owner,
+      repo,
+      path,
+      ref: branch,
+    });
+    const data = res.data as ContentsGetResponse;
+    if (Array.isArray(data)) {
+      // ディレクトリなら sha 比較は無意味。null として扱い、後段で衝突判定に任せる
+      return null;
+    }
+    return data.sha ?? null;
+  } catch (err) {
+    const ne = normalizeError(err);
+    if (ne.status === 404) return null;
+    throw err;
+  }
+}
+
+export async function uploadAssetViaGitData(
+  octokit: GitHubClient,
+  params: GitDataUploadParams,
+): Promise<GitDataUploadResult> {
+  const { owner, repo, path, contentBase64, message, expectedSha } = params;
+
+  const branch = params.branch ?? (await resolveDefaultBranch(octokit, owner, repo));
+
+  if (expectedSha !== undefined) {
+    const currentSha = await getCurrentBlobSha(octokit, owner, repo, path, branch);
+    if (currentSha !== expectedSha) {
+      throw new GitDataConflictError(
+        currentSha === null
+          ? `path ${path} does not exist on branch ${branch} but sha was provided (optimistic lock failed)`
+          : `sha mismatch on ${path}: expected ${expectedSha} but current is ${currentSha}`,
+      );
+    }
+  }
+
+  const refRes = await octokit.request("GET /repos/{owner}/{repo}/git/ref/{ref}", {
+    owner,
+    repo,
+    ref: `heads/${branch}`,
+  });
+  logRateLimit("git-data.ref", refRes.headers as Record<string, string | number | undefined>);
+  const parentCommitSha = (refRes.data as RefGetResponse).object.sha;
+
+  const commitRes = await octokit.request(
+    "GET /repos/{owner}/{repo}/git/commits/{commit_sha}",
+    { owner, repo, commit_sha: parentCommitSha },
+  );
+  logRateLimit("git-data.commit-get", commitRes.headers as Record<string, string | number | undefined>);
+  const baseTreeSha = (commitRes.data as CommitGetResponse).tree.sha;
+
+  const blobRes = await octokit.request("POST /repos/{owner}/{repo}/git/blobs", {
+    owner,
+    repo,
+    content: contentBase64,
+    encoding: "base64",
+  });
+  logRateLimit("git-data.blob", blobRes.headers as Record<string, string | number | undefined>);
+  const newBlobSha = (blobRes.data as BlobCreateResponse).sha;
+
+  const treeRes = await octokit.request("POST /repos/{owner}/{repo}/git/trees", {
+    owner,
+    repo,
+    base_tree: baseTreeSha,
+    tree: [
+      {
+        path,
+        mode: "100644",
+        type: "blob",
+        sha: newBlobSha,
+      },
+    ],
+  });
+  logRateLimit("git-data.tree", treeRes.headers as Record<string, string | number | undefined>);
+  const newTreeSha = (treeRes.data as TreeCreateResponse).sha;
+
+  const newCommitRes = await octokit.request("POST /repos/{owner}/{repo}/git/commits", {
+    owner,
+    repo,
+    message,
+    tree: newTreeSha,
+    parents: [parentCommitSha],
+  });
+  logRateLimit("git-data.commit-create", newCommitRes.headers as Record<string, string | number | undefined>);
+  const newCommitSha = (newCommitRes.data as CommitCreateResponse).sha;
+
+  const refPatchRes = await octokit.request("PATCH /repos/{owner}/{repo}/git/refs/{ref}", {
+    owner,
+    repo,
+    ref: `heads/${branch}`,
+    sha: newCommitSha,
+  });
+  logRateLimit("git-data.ref-patch", refPatchRes.headers as Record<string, string | number | undefined>);
+  const finalCommitSha = (refPatchRes.data as RefPatchResponse).object.sha;
+
+  return {
+    path,
+    sha: newBlobSha,
+    commit_sha: finalCommitSha,
+    branch,
+  };
+}

--- a/worker/src/git-data.ts
+++ b/worker/src/git-data.ts
@@ -90,6 +90,9 @@ async function getCurrentBlobSha(
   path: string,
   branch: string,
 ): Promise<string | null> {
+  // 前提: path は `assets/<type>/<file>` 形式 (handleUploadAsset で構築)。
+  // トップレベル (スラッシュ無し) の path は呼び出し側で発生しない想定だが、
+  // 将来そうなった場合に listing 親を引けないので null に倒して新規扱いにする。
   const lastSlash = path.lastIndexOf("/");
   if (lastSlash < 0) return null;
   const dirPath = path.slice(0, lastSlash);

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -93,4 +93,11 @@ export const ASSET_TYPES: ReadonlyArray<AssetType> = [
   "fonts",
 ];
 
+// Contents API 経由でアップロードできる上限。GitHub Contents API のレスポンス側に
+// 1 MiB 制限があるため安全側で 5 MiB に絞る。これを超えるアセットは Git Data API
+// (blob/tree/commit) 経路で扱う (#116)。
 export const MAX_ASSET_BYTES = 5 * 1024 * 1024; // 5 MiB
+
+// Git Data API の blob 上限。GitHub の blob サイズ上限は 100 MiB で、これを超えるものは
+// Git LFS が必要 (別 Issue 案件)。100 MiB を超える本体は 413 で reject する。
+export const MAX_GIT_DATA_BYTES = 100 * 1024 * 1024; // 100 MiB

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -98,6 +98,11 @@ export const ASSET_TYPES: ReadonlyArray<AssetType> = [
 // (blob/tree/commit) 経路で扱う (#116)。
 export const MAX_ASSET_BYTES = 5 * 1024 * 1024; // 5 MiB
 
-// Git Data API の blob 上限。GitHub の blob サイズ上限は 100 MiB で、これを超えるものは
-// Git LFS が必要 (別 Issue 案件)。100 MiB を超える本体は 413 で reject する。
-export const MAX_GIT_DATA_BYTES = 100 * 1024 * 1024; // 100 MiB
+// Git Data API 経由でアップロードできる実用上限。
+//
+// GitHub の blob サイズ上限自体は 100 MiB だが、Cloudflare Workers の per-request
+// メモリ上限が 128 MiB なので 100 MiB の base64 (≈133 MiB の文字列、UTF-16 内部表現で
+// 倍プラス octokit の JSON.stringify コピーが乗ると 256 MiB 超) は確実に OOM する。
+// 安全圏は 20-25 MiB 程度。25 MiB を超える本体は 413 で reject し、それ以上は
+// Git LFS or streaming 経路 (将来 Issue) で扱う。
+export const MAX_GIT_DATA_BYTES = 25 * 1024 * 1024; // 25 MiB (Worker memory practical limit)

--- a/worker/test/assets.test.ts
+++ b/worker/test/assets.test.ts
@@ -135,8 +135,8 @@ describe("POST /api/projects/:name/assets/:type", () => {
     expect(res.status).toBe(401);
   });
 
-  it("rejects asset > 100 MiB with 413 (LFS required)", async () => {
-    // base64 length to exceed MAX_GIT_DATA_BYTES の 100 MiB
+  it("rejects asset > MAX_GIT_DATA_BYTES with 413 (Worker memory limit)", async () => {
+    // MAX_GIT_DATA_BYTES (25 MiB) を超える本体は Worker メモリ制約で reject する
     const targetBytes = MAX_GIT_DATA_BYTES + 1024;
     const b64Length = Math.ceil(targetBytes / 3) * 4;
     const big = "A".repeat(b64Length);
@@ -291,13 +291,24 @@ describe("POST /api/projects/:name/assets/:type", () => {
    */
   function makeGitDataMock(opts: {
     defaultBranch?: string;
-    contentsSha?: string | null; // null = 404, undefined = not called
+    /**
+     * 楽観ロック用 listing 応答の sha。
+     *  - undefined: contents lookup は来ない想定 (テスト失敗時は呼ばれてしまう)
+     *  - null: 親ディレクトリは存在するが当該ファイル無し (新規扱い)
+     *  - string: 当該 file の sha として返す
+     *  - "404": 親ディレクトリごと 404
+     */
+    contentsSha?: string | null | "404";
+    /** 楽観ロック用 listing で返すファイル名 (default: "big.png") */
+    contentsFilename?: string;
     refSha?: string;
     parentTreeSha?: string;
     newBlobSha?: string;
     newTreeSha?: string;
     newCommitSha?: string;
-    finalRefSha?: string;
+    /** PATCH ref のレスポンス status を強制したいとき (default: 200) */
+    refPatchStatus?: number;
+    refPatchBody?: unknown;
   }): { fetch: typeof fetch; calls: Record<string, number> } {
     const calls: Record<string, number> = {
       repo: 0,
@@ -317,18 +328,27 @@ describe("POST /api/projects/:name/assets/:type", () => {
         calls.repo++;
         return jsonResponse({ default_branch: opts.defaultBranch ?? "main" });
       }
-      // GET /repos/.../contents/...
+      // GET /repos/.../contents/... (親ディレクトリ listing 経由で sha を引く)
       if (method === "GET" && url.includes("/contents/")) {
         calls.contents++;
-        if (opts.contentsSha === null) {
+        if (opts.contentsSha === "404") {
           return jsonResponse({ message: "Not Found" }, 404);
         }
-        return jsonResponse({
-          path: "assets/images/big.png",
-          sha: opts.contentsSha,
-          size: 999,
-          type: "file",
-        });
+        const fname = opts.contentsFilename ?? "big.png";
+        if (opts.contentsSha === null || opts.contentsSha === undefined) {
+          // 親ディレクトリは存在するが当該ファイルなし
+          return jsonResponse([]);
+        }
+        return jsonResponse([
+          {
+            name: fname,
+            path: `assets/images/${fname}`,
+            sha: opts.contentsSha,
+            size: 999,
+            type: "file",
+            download_url: null,
+          },
+        ]);
       }
       // GET /git/ref/heads/{branch} (octokit url-encodes the slash → heads%2F)
       if (method === "GET" && /\/git\/ref\/heads(%2F|\/)/.test(url)) {
@@ -356,9 +376,12 @@ describe("POST /api/projects/:name/assets/:type", () => {
         return jsonResponse({ sha: opts.newCommitSha ?? "new-commit" }, 201);
       }
       // PATCH /git/refs/heads/{branch} (octokit url-encodes the slash → heads%2F)
+      // NOTE: method が PATCH のため POST /git/commits とは衝突しない。
       if (method === "PATCH" && /\/git\/refs\/heads(%2F|\/)/.test(url)) {
         calls.refPatch++;
-        return jsonResponse({ object: { sha: opts.finalRefSha ?? opts.newCommitSha ?? "new-commit" } });
+        const status = opts.refPatchStatus ?? 200;
+        const body = opts.refPatchBody ?? { object: { sha: opts.newCommitSha ?? "new-commit" } };
+        return jsonResponse(body, status);
       }
       throw new Error(`unexpected fetch: ${method} ${url}`);
     }) as typeof fetch;
@@ -505,6 +528,105 @@ describe("POST /api/projects/:name/assets/:type", () => {
     // sha 不一致で短絡したので blob 作成等は呼ばれない
     expect(calls.blob).toBe(0);
     expect(calls.refPatch).toBe(0);
+  });
+
+  it("returns 409 when ref PATCH responds 422 non-fast-forward (concurrent push)", async () => {
+    // review M-1: PATCH /git/refs が 422 を返したら GitDataConflictError → 409 に正規化
+    const { fetch: mockFetch, calls } = makeGitDataMock({
+      newCommitSha: "would-be-commit",
+      refPatchStatus: 422,
+      refPatchBody: { message: "Update is not a fast forward" },
+    });
+    globalThis.fetch = mockFetch;
+
+    const big = makeBase64OfBytes(MAX_ASSET_BYTES + 100);
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "race.png",
+          contentBase64: big,
+          message: "race",
+          branch: "main",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(409);
+    expect(calls.refPatch).toBe(1);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("concurrent");
+  });
+
+  it("resolves default_branch AND performs optimistic locking when both are required", async () => {
+    // review S-4: branch 省略 + sha 指定の合わせ技
+    const { fetch: mockFetch, calls } = makeGitDataMock({
+      defaultBranch: "main",
+      contentsSha: "match-sha",
+      newBlobSha: "blob-merged",
+    });
+    globalThis.fetch = mockFetch;
+
+    const big = makeBase64OfBytes(MAX_ASSET_BYTES + 100);
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "big.png",
+          contentBase64: big,
+          message: "update",
+          sha: "match-sha",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(201);
+    expect(calls.repo).toBe(1); // default_branch 解決
+    expect(calls.contents).toBe(1); // 楽観ロック
+    expect(calls.refPatch).toBe(1);
+  });
+
+  it("strips whitespace from base64 in Git Data API path", async () => {
+    // review S-4: 既存の Contents API path にはあったが Git Data path にも必要
+    const { fetch: mockFetch, calls } = makeGitDataMock({
+      newBlobSha: "blob-clean",
+    });
+    globalThis.fetch = mockFetch;
+
+    // 5 MiB 強の base64 に改行を混ぜる (typical PEM-like wrapping を想定)
+    const cleanLength = Math.ceil((MAX_ASSET_BYTES + 100) / 3) * 4;
+    const cleanBig = "A".repeat(cleanLength);
+    const wrappedBig = cleanBig.match(/.{1,76}/g)!.join("\n");
+
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "wrapped.png",
+          contentBase64: wrappedBig,
+          message: "wrapped",
+          branch: "main",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(201);
+    expect(calls.blob).toBe(1);
   });
 
   it("propagates 422 when GitHub returns 422 (e.g. existing file without sha)", async () => {

--- a/worker/test/assets.test.ts
+++ b/worker/test/assets.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/types";
-import { MAX_ASSET_BYTES } from "../src/types";
+import { MAX_ASSET_BYTES, MAX_GIT_DATA_BYTES } from "../src/types";
 
 const ENV: Env = {
   ALLOWED_ORIGIN: "https://name-name.llll-ll.com",
@@ -135,9 +135,9 @@ describe("POST /api/projects/:name/assets/:type", () => {
     expect(res.status).toBe(401);
   });
 
-  it("rejects asset > 5 MiB with 413", async () => {
-    // base64 length to exceed MAX_ASSET_BYTES の 5 MiB → 約 5,592,406 文字
-    const targetBytes = MAX_ASSET_BYTES + 1024;
+  it("rejects asset > 100 MiB with 413 (LFS required)", async () => {
+    // base64 length to exceed MAX_GIT_DATA_BYTES の 100 MiB
+    const targetBytes = MAX_GIT_DATA_BYTES + 1024;
     const b64Length = Math.ceil(targetBytes / 3) * 4;
     const big = "A".repeat(b64Length);
     const req = new Request(
@@ -149,48 +149,16 @@ describe("POST /api/projects/:name/assets/:type", () => {
           authorization: "Bearer dev-token",
         },
         body: JSON.stringify({
-          filename: "big.png",
+          filename: "huge.bin",
           contentBase64: big,
-          message: "add big",
-        }),
-      },
-    );
-    const res = await worker.fetch(req, ENV, ctx);
-    expect(res.status).toBe(413);
-  });
-
-  it("rejects asset == 5 MiB with 413 (boundary)", async () => {
-    // ちょうど MAX_ASSET_BYTES (5 MiB) を作る。
-    // base64 のデコード後バイト数 N に対し、文字長 = ceil(N / 3) * 4。
-    // N = 5 MiB は 3 の倍数 (5*1024*1024 = 5242880 = 3*1747626 + 2)
-    // → 文字長 = 1747627 * 4 = 6990508、末尾パディング 1 個 ('=')
-    // 安全側で N = MAX_ASSET_BYTES ぴったりになる base64 を生成する
-    const N = MAX_ASSET_BYTES; // 5 * 1024 * 1024
-    // bytes 列を base64 化した時の長さは 4*ceil(N/3)、末尾パディング数は (3 - N%3) % 3
-    const groupCount = Math.ceil(N / 3);
-    const padCount = (3 - (N % 3)) % 3;
-    const b64Length = groupCount * 4;
-    const big = "A".repeat(b64Length - padCount) + "=".repeat(padCount);
-    const req = new Request(
-      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
-      {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          authorization: "Bearer dev-token",
-        },
-        body: JSON.stringify({
-          filename: "exact.png",
-          contentBase64: big,
-          message: "add exact 5 MiB",
+          message: "add huge",
         }),
       },
     );
     const res = await worker.fetch(req, ENV, ctx);
     expect(res.status).toBe(413);
     const body = (await res.json()) as { error: string; size: number };
-    expect(body.size).toBe(MAX_ASSET_BYTES);
-    expect(body.error).toContain("#116");
+    expect(body.error).toContain("LFS");
   });
 
   it("rejects invalid base64 (length not multiple of 4) with 400", async () => {
@@ -302,6 +270,241 @@ describe("POST /api/projects/:name/assets/:type", () => {
     expect(res.status).toBe(201);
     const sent = capturedBody as { sha?: string } | null;
     expect(sent?.sha).toBe("existing-sha");
+  });
+
+  // ----- Git Data API 経路 (#116) -----
+  //
+  // Contents API の 5 MiB 上限を超えるアセットは Worker が自動で Git Data API
+  // (blob/tree/commit/ref) 経路に切り替える。フローは 7 ステップ:
+  //   GET /repos/{o}/{r}                          (branch 省略時のみ)
+  //   GET /contents/{path}                        (sha 指定時のみ、楽観ロック)
+  //   GET /git/ref/heads/{branch}
+  //   GET /git/commits/{sha}
+  //   POST /git/blobs
+  //   POST /git/trees
+  //   POST /git/commits
+  //   PATCH /git/refs/heads/{branch}
+
+  /**
+   * URL パターンに応じて mock レスポンスを返す fetch を組み立てる。
+   * 各 step が呼ばれた回数を `calls` で観測できる。
+   */
+  function makeGitDataMock(opts: {
+    defaultBranch?: string;
+    contentsSha?: string | null; // null = 404, undefined = not called
+    refSha?: string;
+    parentTreeSha?: string;
+    newBlobSha?: string;
+    newTreeSha?: string;
+    newCommitSha?: string;
+    finalRefSha?: string;
+  }): { fetch: typeof fetch; calls: Record<string, number> } {
+    const calls: Record<string, number> = {
+      repo: 0,
+      contents: 0,
+      ref: 0,
+      commitGet: 0,
+      blob: 0,
+      tree: 0,
+      commitCreate: 0,
+      refPatch: 0,
+    };
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : (input as Request).url ?? String(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      // GET /repos/{owner}/{repo} (default branch resolution)
+      if (method === "GET" && /\/repos\/[^/]+\/[^/]+$/.test(url)) {
+        calls.repo++;
+        return jsonResponse({ default_branch: opts.defaultBranch ?? "main" });
+      }
+      // GET /repos/.../contents/...
+      if (method === "GET" && url.includes("/contents/")) {
+        calls.contents++;
+        if (opts.contentsSha === null) {
+          return jsonResponse({ message: "Not Found" }, 404);
+        }
+        return jsonResponse({
+          path: "assets/images/big.png",
+          sha: opts.contentsSha,
+          size: 999,
+          type: "file",
+        });
+      }
+      // GET /git/ref/heads/{branch} (octokit url-encodes the slash → heads%2F)
+      if (method === "GET" && /\/git\/ref\/heads(%2F|\/)/.test(url)) {
+        calls.ref++;
+        return jsonResponse({ object: { sha: opts.refSha ?? "parent-commit" } });
+      }
+      // GET /git/commits/{sha}
+      if (method === "GET" && url.includes("/git/commits/")) {
+        calls.commitGet++;
+        return jsonResponse({ tree: { sha: opts.parentTreeSha ?? "base-tree" } });
+      }
+      // POST /git/blobs
+      if (method === "POST" && url.endsWith("/git/blobs")) {
+        calls.blob++;
+        return jsonResponse({ sha: opts.newBlobSha ?? "new-blob" }, 201);
+      }
+      // POST /git/trees
+      if (method === "POST" && url.endsWith("/git/trees")) {
+        calls.tree++;
+        return jsonResponse({ sha: opts.newTreeSha ?? "new-tree" }, 201);
+      }
+      // POST /git/commits
+      if (method === "POST" && url.endsWith("/git/commits")) {
+        calls.commitCreate++;
+        return jsonResponse({ sha: opts.newCommitSha ?? "new-commit" }, 201);
+      }
+      // PATCH /git/refs/heads/{branch} (octokit url-encodes the slash → heads%2F)
+      if (method === "PATCH" && /\/git\/refs\/heads(%2F|\/)/.test(url)) {
+        calls.refPatch++;
+        return jsonResponse({ object: { sha: opts.finalRefSha ?? opts.newCommitSha ?? "new-commit" } });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as typeof fetch;
+    return { fetch: fetchMock, calls };
+  }
+
+  /** N バイトの base64 文字列を生成 (中身は 'A' 連打、適切なパディング付き) */
+  function makeBase64OfBytes(N: number): string {
+    const groupCount = Math.ceil(N / 3);
+    const padCount = (3 - (N % 3)) % 3;
+    const b64Length = groupCount * 4;
+    return "A".repeat(b64Length - padCount) + "=".repeat(padCount);
+  }
+
+  it("uploads 5 MiB asset via Git Data API and returns 201 with new blob sha", async () => {
+    const { fetch: mockFetch, calls } = makeGitDataMock({
+      newBlobSha: "blob-abc",
+      newCommitSha: "commit-xyz",
+    });
+    globalThis.fetch = mockFetch;
+
+    const big = makeBase64OfBytes(MAX_ASSET_BYTES); // ちょうど 5 MiB
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "exact.png",
+          contentBase64: big,
+          message: "add 5 MiB",
+          branch: "main",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { sha: string; commit_sha: string; size: number };
+    expect(body.sha).toBe("blob-abc");
+    expect(body.commit_sha).toBe("commit-xyz");
+    expect(body.size).toBe(MAX_ASSET_BYTES);
+    // branch が指定されているので default_branch 解決は呼ばれない
+    expect(calls.repo).toBe(0);
+    // sha 未指定なので contents lookup も呼ばれない
+    expect(calls.contents).toBe(0);
+    // Git Data API 5 ステップが全部呼ばれる
+    expect(calls.ref).toBe(1);
+    expect(calls.commitGet).toBe(1);
+    expect(calls.blob).toBe(1);
+    expect(calls.tree).toBe(1);
+    expect(calls.commitCreate).toBe(1);
+    expect(calls.refPatch).toBe(1);
+  });
+
+  it("resolves default_branch when branch is omitted (Git Data API path)", async () => {
+    const { fetch: mockFetch, calls } = makeGitDataMock({
+      defaultBranch: "develop",
+      newBlobSha: "blob-def",
+    });
+    globalThis.fetch = mockFetch;
+
+    const big = makeBase64OfBytes(MAX_ASSET_BYTES + 100);
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/sounds",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "bgm.ogg",
+          contentBase64: big,
+          message: "add bgm",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(201);
+    expect(calls.repo).toBe(1); // default_branch 解決のため呼ばれる
+  });
+
+  it("performs optimistic locking (sha matches) on Git Data API path", async () => {
+    const { fetch: mockFetch, calls } = makeGitDataMock({
+      contentsSha: "existing-sha-xyz",
+      newBlobSha: "blob-updated",
+    });
+    globalThis.fetch = mockFetch;
+
+    const big = makeBase64OfBytes(MAX_ASSET_BYTES + 100);
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "big.png",
+          contentBase64: big,
+          message: "update",
+          branch: "main",
+          sha: "existing-sha-xyz",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(201);
+    expect(calls.contents).toBe(1);
+    expect(calls.refPatch).toBe(1);
+  });
+
+  it("returns 409 when optimistic lock sha mismatches (Git Data API path)", async () => {
+    const { fetch: mockFetch, calls } = makeGitDataMock({
+      contentsSha: "actual-sha",
+    });
+    globalThis.fetch = mockFetch;
+
+    const big = makeBase64OfBytes(MAX_ASSET_BYTES + 100);
+    const req = new Request(
+      "https://name-name-api.workers.dev/api/projects/ogurasia/assets/images",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer dev-token",
+        },
+        body: JSON.stringify({
+          filename: "big.png",
+          contentBase64: big,
+          message: "update",
+          branch: "main",
+          sha: "stale-sha",
+        }),
+      },
+    );
+    const res = await worker.fetch(req, ENV, ctx);
+    expect(res.status).toBe(409);
+    expect(calls.contents).toBe(1);
+    // sha 不一致で短絡したので blob 作成等は呼ばれない
+    expect(calls.blob).toBe(0);
+    expect(calls.refPatch).toBe(0);
   });
 
   it("propagates 422 when GitHub returns 422 (e.g. existing file without sha)", async () => {


### PR DESCRIPTION
## 関連 Issue
closes #116

## 変更内容

`POST /api/projects/:name/assets/:type` のサイズ分岐を Worker 側で自動化。

| サイズ | 経路 |
|---|---|
| `< 5 MiB` | 既存 Contents API（変更なし）|
| `>= 5 MiB && <= 100 MiB` | **Git Data API (blob/tree/commit/ref)** ← 新規 |
| `> 100 MiB` | 413（LFS は別 Issue）|

### 設計

- 同じエンドポイントで size により内部分岐するため、フロント側の API 層は無変更で大容量アセットを置けるようになる。
- Git Data API のステップは `worker/src/git-data.ts` に分離:
  1. `branch` 省略時は `GET /repos` で `default_branch` を解決
  2. `GET /git/ref/heads/{branch}` → 親 commit SHA
  3. `GET /git/commits/{sha}` → base tree SHA
  4. `POST /git/blobs` `{ content, encoding: "base64" }`
  5. `POST /git/trees` `{ base_tree, tree: [{ path, mode: "100644", type: "blob", sha }] }`
  6. `POST /git/commits` `{ message, tree, parents: [...] }`
  7. `PATCH /git/refs/heads/{branch}` `{ sha }`
- 楽観ロック (`body.sha` 指定時): `GET /contents/{path}?ref={branch}` で現在 sha を取って比較。不一致は **409**（Contents API 経路の挙動と整合）。
- レスポンス形式は既存互換: `{ path, sha, commit_sha, size }` で `201`。

### テスト

- 既存 vitest 42 件すべて通過
- Git Data API 経路で 5 件追加: 5 MiB 成功 / `default_branch` 解決 / sha 一致時成功 / sha 不一致時 409 / 100 MiB 超 413
- 既存「5 MiB で 413」2 件は挙動変更により削除し「100 MiB 超で LFS 案内付き 413」1 件に置換

### 動作確認

- `npx tsc --noEmit` パス
- `npx vitest run` 42/42 パス