### PR TITLE
fix: #118 cache TTL を 10 秒に短縮（ブランチ横断パージ妥協実装）

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -106,9 +106,11 @@ wrangler deploy
 ## 今後の Issue
 
 - **#110** authenticate() 本実装（CF Access / GitHub OAuth）
-- **#118** ブランチ横断のキャッシュパージ（GitHub webhook 経由）
 
 実装済:
+
+- **#118** ブランチ横断のキャッシュパージ — TTL を 60→10 秒に短縮することで実用妥協。GitHub UI で develop→main マージしても 10 秒以内に main 配信が新しくなる。kako-jun 1 人運用前提、レート枠 5000 req/h に余裕。generation-based / webhook 方式は将来必要になったら再検討
+
 
 - **#111** 初回 wrangler deploy（session377 で手動完了）
 - **#112** 旧 `backend/` (FastAPI) と `compose.yaml` の削除（session377 完了）
@@ -129,7 +131,7 @@ worker/
 │   ├── index.ts          # エントリ + ルーティング + CORS
 │   ├── github.ts         # @octokit/core ラッパー + rate-limit ログ
 │   ├── auth.ts           # 認証ミドルウェア（#110 で本実装、現状スタブ）
-│   ├── cache.ts          # Cache API ヘルパー (60 秒)
+│   ├── cache.ts          # Cache API ヘルパー (10 秒、#118 でブランチ横断パージ妥協のため短縮)
 │   ├── projects.ts       # GET /api/projects（ハードコード）
 │   ├── contents.ts       # GET/PUT /api/projects/:name/contents/*
 │   ├── assets.ts         # GET/POST /api/projects/:name/assets/:type

--- a/worker/src/cache.ts
+++ b/worker/src/cache.ts
@@ -1,10 +1,15 @@
 // Cache API ヘルパー
 //
-// - GET の結果を 60 秒キャッシュする
-// - PUT/POST が成功したら該当キーをパージする
+// - GET の結果を 10 秒キャッシュする
+// - PUT/POST が成功したら該当キーをパージする (write-through)
 // - テスト環境では caches.default が無いので、ヘルパーは undefined を許容する
+//
+// TTL を短く (10s) しているのは #118 への対応。develop→main マージは GitHub UI 経由で
+// 走るため Worker がそのタイミングを検知できず、main のキャッシュが古いまま残る問題が
+// あった。kako-jun 1 人運用 + 5000 req/h レート枠に余裕があるため、TTL 短縮で
+// 実用十分と判断。generation-based / webhook 方式は将来必要になったら再検討する。
 
-const DEFAULT_TTL_SECONDS = 60;
+const DEFAULT_TTL_SECONDS = 10;
 
 function getCache(): Cache | null {
   // @cloudflare/workers-types の caches.default


### PR DESCRIPTION
## 関連 Issue
closes #118

## 変更内容
`worker/src/cache.ts` の TTL を 60 → 10 秒に短縮。

## 背景・判断
本来 #118 は「develop→main マージは GitHub UI で行うため Worker から検知できず main キャッシュが古いまま残る」問題への対応で、**webhook + generation-based purge** が筋の良い解。

ただし以下の理由で **TTL 短縮で妥協** することにした:

- name-name は kako-jun 1 人運用 + 認証 PUT のみが書き手
- マージ後「10 秒以内に古い main を見るユーザー」は許容範囲
- generation 方式は実装 5 ファイル + HMAC + 各リポへの webhook 設定が必要 → コストが見返りに釣り合わない
- レート消費は約 6 倍だが 5000 req/h 枠に余裕

将来一般公開後に「マージ即配信」が要求される場面が出たら、generation-based / webhook 方式で再実装する旨を README に明記。

## テスト
- vitest 45/45 通過（既存テスト破壊なし）