### PR TITLE
fix: #125 NovelPlayer SeekBar の現在位置を Counter と同期

### DIFF
--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -30,11 +30,12 @@ import { SaveManager, SaveSlotData } from './SaveManager'
 import { SaveLoadOverlay } from './SaveLoadOverlay'
 import { BacklogOverlay } from './BacklogOverlay'
 import { SeekBar } from './SeekBar'
+import { computeDisplayIndex, findHistoryIndexForDisplayIndex } from './seekMapping'
 import { Event, EventScene } from '../types'
 import { GAME_WIDTH, GAME_HEIGHT } from './constants'
 
 /** Dialog / Narration から text を取り出すヘルパー */
-function getTextEvent(event: Event):
+export function getTextEvent(event: Event):
   | {
       type: 'dialog'
       character: string | null
@@ -888,27 +889,10 @@ export class NovelRenderer {
     this.updateSeekBar()
   }
 
-  /**
-   * 表示用テキストイベントの現在 index（1-based、Counter / SeekBar 共通）。
-   * 例: 13 個のテキストイベント中 3 個目を表示中なら 3 を返す。
-   */
-  private getDisplayIndex(): number {
-    let displayIndex = 0
-    for (let i = 0; i < this.eventIndex && i < this.resolvedEvents.length; i++) {
-      if (getTextEvent(this.resolvedEvents[i])) displayIndex++
-    }
-    if (
-      this.eventIndex < this.resolvedEvents.length &&
-      getTextEvent(this.resolvedEvents[this.eventIndex])
-    ) {
-      displayIndex++
-    }
-    return displayIndex
-  }
-
   private updateCounter(): void {
     if (!this.counterText) return
-    this.counterText.text = `${this.getDisplayIndex()} / ${this.displayEventCount}`
+    const displayIndex = computeDisplayIndex(this.eventIndex, this.resolvedEvents)
+    this.counterText.text = `${displayIndex} / ${this.displayEventCount}`
   }
 
   /**
@@ -917,7 +901,7 @@ export class NovelRenderer {
    *  満タンに張り付いていた #125)
    */
   private updateSeekBar(): void {
-    const displayIndex = this.getDisplayIndex()
+    const displayIndex = computeDisplayIndex(this.eventIndex, this.resolvedEvents)
     // 0-based に変換し SeekBar に渡す。SeekBar は ratio = current/(total-1) を計算する。
     const current = Math.max(0, displayIndex - 1)
     const total = this.displayEventCount
@@ -929,30 +913,17 @@ export class NovelRenderer {
    * 適切な history index にマップして seekTo する。
    *
    * - 訪問済み (history に対応エントリあり) → そこへ巻き戻し
-   * - 未訪問 (前方ジャンプ) → forward-play は未対応なので no-op
+   * - 未訪問 (前方ジャンプ) → forward-play は未実装なので no-op。
+   *   TODO: 将来 visual hint (DialogBox 上の小フラッシュ等) を出して
+   *   「無効操作」とユーザーに伝えるか検討する
    */
   private seekToTextEventDisplayIndex(displayIndex: number): void {
-    if (displayIndex < 0) return
-
-    // displayIndex 番目のテキストイベントが resolvedEvents の何番にあるかを引く
-    let textCount = 0
-    let targetEventIndex = -1
-    for (let i = 0; i < this.resolvedEvents.length; i++) {
-      if (getTextEvent(this.resolvedEvents[i])) {
-        if (textCount === displayIndex) {
-          targetEventIndex = i
-          break
-        }
-        textCount++
-      }
-    }
-    if (targetEventIndex < 0) return
-
-    const historyIdx = this.history.findIndex((s) => s.eventIndex === targetEventIndex)
-    if (historyIdx < 0) {
-      // 未訪問への前方ジャンプは未対応 (forward-play が未実装のため)
-      return
-    }
+    const historyIdx = findHistoryIndexForDisplayIndex(
+      displayIndex,
+      this.resolvedEvents,
+      this.history
+    )
+    if (historyIdx < 0) return
     this.seekTo(historyIdx)
   }
 }

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -182,7 +182,7 @@ export class NovelRenderer {
     this.app.stage.addChild(this.dialogBox)
 
     // シークバー（ダイアログボックスの下）
-    this.seekBar.setOnSeek((index) => this.seekTo(index))
+    this.seekBar.setOnSeek((displayIndex) => this.seekToTextEventDisplayIndex(displayIndex))
     this.app.stage.addChild(this.seekBar)
 
     // シーンカウンター
@@ -888,10 +888,11 @@ export class NovelRenderer {
     this.updateSeekBar()
   }
 
-  private updateCounter(): void {
-    if (!this.counterText) return
-    const total = this.displayEventCount
-    // 表示イベントの中での現在位置を計算
+  /**
+   * 表示用テキストイベントの現在 index（1-based、Counter / SeekBar 共通）。
+   * 例: 13 個のテキストイベント中 3 個目を表示中なら 3 を返す。
+   */
+  private getDisplayIndex(): number {
     let displayIndex = 0
     for (let i = 0; i < this.eventIndex && i < this.resolvedEvents.length; i++) {
       if (getTextEvent(this.resolvedEvents[i])) displayIndex++
@@ -902,16 +903,56 @@ export class NovelRenderer {
     ) {
       displayIndex++
     }
-    this.counterText.text = `${displayIndex} / ${total}`
+    return displayIndex
+  }
+
+  private updateCounter(): void {
+    if (!this.counterText) return
+    this.counterText.text = `${this.getDisplayIndex()} / ${this.displayEventCount}`
   }
 
   /**
-   * シークバーの表示を更新する
+   * シークバーの表示を更新する。Counter と同じ「テキストイベント表示位置」で動く。
+   * (旧実装は history.length - 1 / history.length で常に ratio≈1 になりバーが
+   *  満タンに張り付いていた #125)
    */
   private updateSeekBar(): void {
-    // history.length - 1 が現在のインデックス（0-based）
-    const current = Math.max(0, this.history.length - 1)
-    const total = this.history.length
+    const displayIndex = this.getDisplayIndex()
+    // 0-based に変換し SeekBar に渡す。SeekBar は ratio = current/(total-1) を計算する。
+    const current = Math.max(0, displayIndex - 1)
+    const total = this.displayEventCount
     this.seekBar.update(current, total)
+  }
+
+  /**
+   * SeekBar からのクリック (テキストイベント表示 index 0-based) を
+   * 適切な history index にマップして seekTo する。
+   *
+   * - 訪問済み (history に対応エントリあり) → そこへ巻き戻し
+   * - 未訪問 (前方ジャンプ) → forward-play は未対応なので no-op
+   */
+  private seekToTextEventDisplayIndex(displayIndex: number): void {
+    if (displayIndex < 0) return
+
+    // displayIndex 番目のテキストイベントが resolvedEvents の何番にあるかを引く
+    let textCount = 0
+    let targetEventIndex = -1
+    for (let i = 0; i < this.resolvedEvents.length; i++) {
+      if (getTextEvent(this.resolvedEvents[i])) {
+        if (textCount === displayIndex) {
+          targetEventIndex = i
+          break
+        }
+        textCount++
+      }
+    }
+    if (targetEventIndex < 0) return
+
+    const historyIdx = this.history.findIndex((s) => s.eventIndex === targetEventIndex)
+    if (historyIdx < 0) {
+      // 未訪問への前方ジャンプは未対応 (forward-play が未実装のため)
+      return
+    }
+    this.seekTo(historyIdx)
   }
 }

--- a/frontend/src/game/seekMapping.test.ts
+++ b/frontend/src/game/seekMapping.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeDisplayIndex,
+  countDisplayEvents,
+  findEventIndexForDisplayIndex,
+  findHistoryIndexForDisplayIndex,
+} from './seekMapping'
+import type { Event } from '../types'
+import type { NovelGameState } from './GameState'
+
+const T = (text: string): Event => ({ Narration: { text: [text] } })
+const BG = (p: string): Event => ({ Background: { path: p } })
+const BGM = (p: string): Event => ({ Bgm: { path: p, action: 'Play' } })
+
+function makeState(eventIndex: number): NovelGameState {
+  return {
+    sceneId: 's1',
+    eventIndex,
+    textIndex: 0,
+    flags: {},
+    backgroundPath: null,
+    isBlackout: false,
+    characters: [],
+    currentBgmPath: null,
+  }
+}
+
+describe('computeDisplayIndex', () => {
+  it('returns 0 before any text event is reached', () => {
+    const events: Event[] = [BG('a.png'), BGM('b.ogg'), T('hi')]
+    expect(computeDisplayIndex(0, events)).toBe(0) // pointing at BG
+    expect(computeDisplayIndex(1, events)).toBe(0) // pointing at BGM
+  })
+
+  it('returns 1 when pointing at the first text event', () => {
+    const events: Event[] = [BG('a.png'), T('hi'), T('bye')]
+    expect(computeDisplayIndex(1, events)).toBe(1)
+  })
+
+  it('returns N when the N-th text event is being displayed', () => {
+    const events: Event[] = [T('1'), T('2'), BG('x'), T('3')]
+    expect(computeDisplayIndex(0, events)).toBe(1) // on 1st
+    expect(computeDisplayIndex(1, events)).toBe(2) // on 2nd
+    expect(computeDisplayIndex(2, events)).toBe(2) // on BG between 2nd and 3rd
+    expect(computeDisplayIndex(3, events)).toBe(3) // on 3rd
+  })
+
+  it('handles eventIndex past the end (post-last-event)', () => {
+    const events: Event[] = [T('1'), T('2')]
+    expect(computeDisplayIndex(2, events)).toBe(2)
+    expect(computeDisplayIndex(99, events)).toBe(2)
+  })
+
+  it('handles empty event list', () => {
+    expect(computeDisplayIndex(0, [])).toBe(0)
+  })
+})
+
+describe('countDisplayEvents', () => {
+  it('counts only Dialog / Narration events', () => {
+    const events: Event[] = [BG('a'), T('1'), BGM('b'), T('2'), T('3')]
+    expect(countDisplayEvents(events)).toBe(3)
+  })
+
+  it('returns 0 for empty', () => {
+    expect(countDisplayEvents([])).toBe(0)
+  })
+})
+
+describe('findEventIndexForDisplayIndex', () => {
+  const events: Event[] = [BG('a'), T('1'), BGM('b'), T('2'), T('3')]
+
+  it('returns the resolvedEvents index of the i-th text event (0-based)', () => {
+    expect(findEventIndexForDisplayIndex(0, events)).toBe(1) // 1st text -> idx 1
+    expect(findEventIndexForDisplayIndex(1, events)).toBe(3) // 2nd text -> idx 3
+    expect(findEventIndexForDisplayIndex(2, events)).toBe(4) // 3rd text -> idx 4
+  })
+
+  it('returns -1 for out-of-range', () => {
+    expect(findEventIndexForDisplayIndex(3, events)).toBe(-1)
+    expect(findEventIndexForDisplayIndex(-1, events)).toBe(-1)
+  })
+
+  it('returns -1 when there are no text events', () => {
+    expect(findEventIndexForDisplayIndex(0, [BG('a'), BGM('b')])).toBe(-1)
+  })
+})
+
+describe('findHistoryIndexForDisplayIndex', () => {
+  const events: Event[] = [BG('a'), T('1'), BGM('b'), T('2'), T('3')]
+
+  it('returns the matching history index when target text event is visited', () => {
+    // history は text event の直前/直前で push される (NovelRenderer.pushSnapshot 仕様)
+    const history = [makeState(1), makeState(3), makeState(4)] // visited 1st, 2nd, 3rd
+    expect(findHistoryIndexForDisplayIndex(0, events, history)).toBe(0)
+    expect(findHistoryIndexForDisplayIndex(1, events, history)).toBe(1)
+    expect(findHistoryIndexForDisplayIndex(2, events, history)).toBe(2)
+  })
+
+  it('returns -1 for forward jump (target not yet in history)', () => {
+    const history = [makeState(1)] // only 1st text event visited
+    expect(findHistoryIndexForDisplayIndex(1, events, history)).toBe(-1)
+    expect(findHistoryIndexForDisplayIndex(2, events, history)).toBe(-1)
+  })
+
+  it('returns the FIRST history index when same eventIndex appears multiple times', () => {
+    // Choice loop で同じ text event を再訪問しているシナリオ。
+    // 「過去に通った最古の地点に戻る」挙動を保証する。
+    const history = [makeState(1), makeState(3), makeState(1), makeState(3)]
+    expect(findHistoryIndexForDisplayIndex(0, events, history)).toBe(0)
+    expect(findHistoryIndexForDisplayIndex(1, events, history)).toBe(1)
+  })
+
+  it('returns -1 when no text events exist', () => {
+    expect(findHistoryIndexForDisplayIndex(0, [BG('a')], [makeState(0)])).toBe(-1)
+  })
+
+  it('returns -1 for negative displayIndex', () => {
+    const history = [makeState(1)]
+    expect(findHistoryIndexForDisplayIndex(-1, events, history)).toBe(-1)
+  })
+})
+
+describe('regression: #125 SeekBar bar-stuck-full', () => {
+  // 旧実装は seekBar.update(history.length - 1, history.length) で
+  // ratio = (N-1)/(N-1) = 1 が常に成立 → バー満タン張り付き。
+  // 修正後は computeDisplayIndex(eventIndex, resolvedEvents) で
+  // 進行に応じて 0..total と動くことを確認する。
+  it('produces monotonically increasing displayIndex along resolvedEvents', () => {
+    const events: Event[] = [T('1'), T('2'), T('3'), T('4'), T('5')]
+    const total = countDisplayEvents(events)
+    expect(total).toBe(5)
+    for (let i = 0; i < events.length; i++) {
+      const di = computeDisplayIndex(i, events)
+      expect(di).toBe(i + 1)
+      // SeekBar に渡す 0-based current は 0..total-1 の範囲
+      const current = Math.max(0, di - 1)
+      expect(current).toBeGreaterThanOrEqual(0)
+      expect(current).toBeLessThan(total)
+    }
+  })
+})

--- a/frontend/src/game/seekMapping.ts
+++ b/frontend/src/game/seekMapping.ts
@@ -1,0 +1,77 @@
+/**
+ * NovelRenderer の SeekBar 用 pure マッピングヘルパー (#125)
+ *
+ * NovelRenderer から切り出した理由は単体テストしたいから。実体は
+ * NovelRenderer のメソッドが薄くこれらを呼ぶ形で再利用する。
+ */
+
+import type { NovelGameState } from './GameState'
+import type { Event } from '../types'
+import { getTextEvent } from './NovelRenderer'
+
+/**
+ * 表示用テキストイベントの 1-based 現在 index (Counter / SeekBar 共通)。
+ *
+ * - eventIndex 自体がテキストイベントを指していたら +1 (= 「いまそれを表示中」)
+ * - そうでなければ resolvedEvents[0..eventIndex) にあるテキストイベント数
+ *
+ * 例: 13 個中 3 個目のテキストイベントを表示中 → 3
+ *     先頭イベントが Bg / Flag だけで text にまだ届いていない → 0
+ */
+export function computeDisplayIndex(eventIndex: number, resolvedEvents: readonly Event[]): number {
+  let displayIndex = 0
+  for (let i = 0; i < eventIndex && i < resolvedEvents.length; i++) {
+    if (getTextEvent(resolvedEvents[i])) displayIndex++
+  }
+  if (eventIndex < resolvedEvents.length && getTextEvent(resolvedEvents[eventIndex])) {
+    displayIndex++
+  }
+  return displayIndex
+}
+
+/**
+ * 表示用テキストイベント数 (Counter / SeekBar の total)。
+ */
+export function countDisplayEvents(resolvedEvents: readonly Event[]): number {
+  let n = 0
+  for (const e of resolvedEvents) if (getTextEvent(e)) n++
+  return n
+}
+
+/**
+ * 「displayIndex 番目 (0-based) のテキストイベント」が resolvedEvents の何番目か。
+ * 該当無し (displayIndex がレンジ外) は -1。
+ */
+export function findEventIndexForDisplayIndex(
+  displayIndex: number,
+  resolvedEvents: readonly Event[]
+): number {
+  if (displayIndex < 0) return -1
+  let textCount = 0
+  for (let i = 0; i < resolvedEvents.length; i++) {
+    if (getTextEvent(resolvedEvents[i])) {
+      if (textCount++ === displayIndex) return i
+    }
+  }
+  return -1
+}
+
+/**
+ * 「displayIndex 番目 (0-based) のテキストイベント」に対応する history index。
+ *
+ * - 訪問済み: 該当 eventIndex を持つ history エントリの最初の位置を返す
+ * - 未訪問 (前方ジャンプ): -1 を返す。NovelRenderer 側で no-op 扱い
+ *
+ * NOTE: 同じ eventIndex を持つ history エントリが複数あるシナリオ (Choice ループで
+ * 同じ text event を再訪問) では、最初に一致する古い方の history まで巻き戻る。
+ * これは「過去に通った最古の地点に戻る」挙動として一貫しているとみなす。
+ */
+export function findHistoryIndexForDisplayIndex(
+  displayIndex: number,
+  resolvedEvents: readonly Event[],
+  history: readonly NovelGameState[]
+): number {
+  const targetEventIndex = findEventIndexForDisplayIndex(displayIndex, resolvedEvents)
+  if (targetEventIndex < 0) return -1
+  return history.findIndex((s) => s.eventIndex === targetEventIndex)
+}


### PR DESCRIPTION
## 関連 Issue
closes #125

## 変更内容

`frontend/src/game/NovelRenderer.ts` のみ変更。

### バグ
- 旧実装は `seekBar.update(history.length - 1, history.length)` を渡しており、SeekBar 側の計算 `ratio = current / (total - 1)` は `(N-1) / (N-1) = 1` で常に満タンに張り付く
- 一方カウンタ「3 / 13」は `displayIndex / displayEventCount` で正しく計算 → 視覚不一致 (#125 の現象)

### 修正
- `getDisplayIndex()` を private helper として切り出し、Counter / SeekBar 両方で共有
- `updateSeekBar()` は `(displayIndex - 1) / displayEventCount` で 0-based ratio を渡す
- クリックシーク: `setOnSeek` 経由で受け取る index を「テキストイベント表示 index」と再解釈し、`seekToTextEventDisplayIndex()` で `resolvedEvents` の対応位置を探し、一致する history エントリへ `seekTo()`
- 未訪問への前方ジャンプは forward-play 未実装のため no-op (Issue 範囲外)

## テスト
- `npx tsc --noEmit` パス
- `npx vitest run` 250/250 パス（既存テスト破壊なし）

## 動作確認
ローカル `npm run dev` で `/play/ogurasia` を開き、進行に応じて SeekBar が Counter と同期して左→右に伸びることを目視確認すべき。Polish 系なので CI は不要。