### PR TITLE
feat: #137 1文字ずつ表示 (typewriter) + クリックスキップ

### DIFF
--- a/frontend/src/game/DialogBox.ts
+++ b/frontend/src/game/DialogBox.ts
@@ -9,6 +9,15 @@
 
 import { Container, Graphics, Text, TextStyle, Ticker } from 'pixi.js'
 import { wordwrap } from './wordwrap'
+import {
+  type TypewriterState,
+  isTypingActive,
+  makeInitialTypewriterState,
+  skipTypewriter as typewriterSkip,
+  startTypewriter,
+  tickTypewriter,
+  visibleText,
+} from './typewriter'
 
 export interface DialogBoxConfig {
   /** ゲーム画面幅 */
@@ -27,7 +36,12 @@ export interface DialogBoxConfig {
   fontSize?: number
   /** フォントファミリー（デフォルト: Noto Sans JP, sans-serif） */
   fontFamily?: string
+  /** typewriter 表示の 1 文字あたり ms（デフォルト: 30ms/char） */
+  msPerChar?: number
 }
+
+/** typewriter のデフォルト速度（ms/char）。設定画面 #138 で上書き可能になる前提 */
+const DEFAULT_MS_PER_CHAR = 30
 
 export class DialogBox extends Container {
   private bg: Graphics
@@ -46,6 +60,13 @@ export class DialogBox extends Container {
   private fontSize: number
   private fontFamily: string
 
+  /** typewriter 状態 (#137) */
+  private typewriter: TypewriterState = makeInitialTypewriterState()
+  /** typewriter: 1 文字あたり ms */
+  private msPerChar: number
+  /** 続きインジケーターを「表示したい」かどうか。実表示は typewriter 完了後に解禁 */
+  private indicatorWanted: boolean = false
+
   private ticker: Ticker
 
   constructor(config: DialogBoxConfig) {
@@ -60,11 +81,13 @@ export class DialogBox extends Container {
       padding = 20,
       fontSize = 22,
       fontFamily = "'Noto Sans JP', sans-serif",
+      msPerChar = DEFAULT_MS_PER_CHAR,
     } = config
 
     this.padding = padding
     this.fontSize = fontSize
     this.fontFamily = fontFamily
+    this.msPerChar = msPerChar
     this.boxW = screenWidth - marginX * 2
     this.boxH = boxHeight
     this.boxX = marginX
@@ -116,11 +139,24 @@ export class DialogBox extends Container {
     this.indicator.y = this.indicatorBaseY
     this.addChild(this.indicator)
 
-    // --- バウンスアニメーション ---
+    // --- ticker: バウンスアニメーション + typewriter 進行 ---
     this.ticker = new Ticker()
     this.ticker.add(() => {
+      // インジケーターのバウンス（typewriter 中は表示されないが計算は無害なので継続）
       this.indicatorTime = (this.indicatorTime + this.ticker.deltaMS / 1000) % ((2 * Math.PI) / 3)
       this.indicator.y = this.indicatorBaseY + Math.sin(this.indicatorTime * 3) * 4
+
+      // typewriter: 文字を 1 文字ずつ進める
+      if (isTypingActive(this.typewriter)) {
+        const next = tickTypewriter(this.typewriter, this.ticker.deltaMS, this.msPerChar)
+        if (next.displayedCharCount !== this.typewriter.displayedCharCount) {
+          this.dialogText.text = visibleText(next)
+        }
+        this.typewriter = next
+      }
+
+      // インジケーターは「表示したい」かつ「typewriter 完了」のときのみ可視
+      this.indicator.visible = this.indicatorWanted && !isTypingActive(this.typewriter)
     })
     this.ticker.start()
   }
@@ -168,25 +204,58 @@ export class DialogBox extends Container {
       this.nameText.visible = false
     }
 
-    // テキスト（ワードラップ適用）
+    // テキスト（ワードラップ適用）+ typewriter 開始
     const font = `${this.fontSize}px ${this.fontFamily}`
     const maxTextWidth = this.boxW - this.padding * 2
     const lines = wordwrap(text, maxTextWidth, font)
-    this.dialogText.text = lines.join('\n')
+    this.typewriter = startTypewriter(lines.join('\n'))
+    this.dialogText.text = ''
   }
 
   /**
    * テキストのみクリアする
    */
   clearText(): void {
+    this.typewriter = makeInitialTypewriterState()
     this.dialogText.text = ''
   }
 
   /**
-   * 続きインジケーターの表示/非表示
+   * typewriter 表示中なら全文を即時表示し完了させる。
+   * 表示完了済みなら何もしない。
+   */
+  skipTypewriter(): void {
+    if (!isTypingActive(this.typewriter)) return
+    this.typewriter = typewriterSkip(this.typewriter)
+    this.dialogText.text = visibleText(this.typewriter)
+  }
+
+  /**
+   * typewriter が進行中（まだ全文表示されていない）か。
+   */
+  isTyping(): boolean {
+    return isTypingActive(this.typewriter)
+  }
+
+  /**
+   * typewriter 速度を設定する (#138 設定画面から呼ぶ前提)。
+   * @param msPerChar 1 文字あたり ms。0 以下は瞬間表示扱い。
+   */
+  setMsPerChar(msPerChar: number): void {
+    this.msPerChar = Math.max(0, msPerChar)
+    if (this.msPerChar === 0) {
+      this.skipTypewriter()
+    }
+  }
+
+  /**
+   * 続きインジケーターの表示要望を保存する。
+   * 実際の表示は typewriter 完了後に ticker 内で反映される。
    */
   setIndicatorVisible(visible: boolean): void {
-    this.indicator.visible = visible
+    this.indicatorWanted = visible
+    // typewriter 中なら抑止、完了済みなら即時反映
+    this.indicator.visible = visible && !isTypingActive(this.typewriter)
   }
 
   /**

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -523,6 +523,11 @@ export class NovelRenderer {
       return
     }
     if (this.saveLoadOverlay.visible) return
+    // typewriter 表示中なら全文表示にスキップ。完了済みなら次へ進む (#137)。
+    if (this.dialogBox.isTyping()) {
+      this.dialogBox.skipTypewriter()
+      return
+    }
     this.advance()
   }
 
@@ -576,10 +581,19 @@ export class NovelRenderer {
       case ' ':
       case 'Enter':
         e.preventDefault()
-        this.advance()
+        // typewriter 中なら全文表示にスキップ、完了済みなら進行 (#137)
+        if (this.dialogBox.isTyping()) {
+          this.dialogBox.skipTypewriter()
+        } else {
+          this.advance()
+        }
         break
       case 'ArrowRight':
-        this.advance()
+        if (this.dialogBox.isTyping()) {
+          this.dialogBox.skipTypewriter()
+        } else {
+          this.advance()
+        }
         break
       case 'ArrowLeft':
         this.goBack()

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -516,6 +516,18 @@ export class NovelRenderer {
     // Flag は Condition の外にあるため、Flag の位置は再展開で変動しない
   }
 
+  /**
+   * typewriter 表示中なら全文表示にスキップ、完了済みなら次イベントへ進む (#137)。
+   * advance() / クリック / Enter / Space / ArrowRight 共通の入力ハンドラから呼ぶ。
+   */
+  private advanceOrSkipTypewriter(): void {
+    if (this.dialogBox.isTyping()) {
+      this.dialogBox.skipTypewriter()
+      return
+    }
+    this.advance()
+  }
+
   private handleAdvance = (): void => {
     this.audioManager.ensureContext()
     if (this.backlogOverlay.visible) {
@@ -523,12 +535,7 @@ export class NovelRenderer {
       return
     }
     if (this.saveLoadOverlay.visible) return
-    // typewriter 表示中なら全文表示にスキップ。完了済みなら次へ進む (#137)。
-    if (this.dialogBox.isTyping()) {
-      this.dialogBox.skipTypewriter()
-      return
-    }
-    this.advance()
+    this.advanceOrSkipTypewriter()
   }
 
   private handleWheel = (e: WheelEvent): void => {
@@ -581,19 +588,10 @@ export class NovelRenderer {
       case ' ':
       case 'Enter':
         e.preventDefault()
-        // typewriter 中なら全文表示にスキップ、完了済みなら進行 (#137)
-        if (this.dialogBox.isTyping()) {
-          this.dialogBox.skipTypewriter()
-        } else {
-          this.advance()
-        }
+        this.advanceOrSkipTypewriter()
         break
       case 'ArrowRight':
-        if (this.dialogBox.isTyping()) {
-          this.dialogBox.skipTypewriter()
-        } else {
-          this.advance()
-        }
+        this.advanceOrSkipTypewriter()
         break
       case 'ArrowLeft':
         this.goBack()

--- a/frontend/src/game/typewriter.test.ts
+++ b/frontend/src/game/typewriter.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isTypingActive,
+  makeInitialTypewriterState,
+  skipTypewriter,
+  startTypewriter,
+  tickTypewriter,
+  visibleText,
+} from './typewriter'
+
+describe('typewriter pure helpers', () => {
+  describe('makeInitialTypewriterState / startTypewriter', () => {
+    it('initial state は空文字 + count 0', () => {
+      const s = makeInitialTypewriterState()
+      expect(s.fullText).toBe('')
+      expect(s.displayedCharCount).toBe(0)
+      expect(isTypingActive(s)).toBe(false)
+    })
+
+    it('startTypewriter で count を 0 に戻す', () => {
+      const s = startTypewriter('こんにちは')
+      expect(s.fullText).toBe('こんにちは')
+      expect(s.displayedCharCount).toBe(0)
+      expect(s.acc).toBe(0)
+      expect(isTypingActive(s)).toBe(true)
+    })
+  })
+
+  describe('tickTypewriter', () => {
+    it('msPerChar=30 で deltaMS=15 なら進まない (acc に貯まる)', () => {
+      const s0 = startTypewriter('ABCDE')
+      const s1 = tickTypewriter(s0, 15, 30)
+      expect(s1.displayedCharCount).toBe(0)
+      expect(s1.acc).toBe(15)
+    })
+
+    it('acc が msPerChar を超えたら 1 文字進む', () => {
+      const s0 = { fullText: 'ABCDE', displayedCharCount: 0, acc: 15 }
+      const s1 = tickTypewriter(s0, 20, 30)
+      expect(s1.displayedCharCount).toBe(1)
+      expect(s1.acc).toBe(5) // 35 - 30 = 5 繰り越し
+    })
+
+    it('1 フレームで複数文字進む（重い tick）', () => {
+      const s0 = startTypewriter('ABCDE')
+      const s1 = tickTypewriter(s0, 100, 30) // 100/30 = 3 文字
+      expect(s1.displayedCharCount).toBe(3)
+      expect(s1.acc).toBe(10)
+    })
+
+    it('fullText.length を超えない', () => {
+      const s0 = startTypewriter('ABC')
+      const s1 = tickTypewriter(s0, 10000, 30)
+      expect(s1.displayedCharCount).toBe(3)
+      expect(isTypingActive(s1)).toBe(false)
+    })
+
+    it('msPerChar=0 で即座に最後まで進む', () => {
+      const s0 = startTypewriter('こんにちは')
+      const s1 = tickTypewriter(s0, 1, 0)
+      expect(s1.displayedCharCount).toBe(5)
+      expect(s1.acc).toBe(0)
+    })
+
+    it('msPerChar=負 でも即時完了', () => {
+      const s0 = startTypewriter('ABCDE')
+      const s1 = tickTypewriter(s0, 1, -10)
+      expect(s1.displayedCharCount).toBe(5)
+    })
+
+    it('既に完了済みなら state を変えない', () => {
+      const s0 = { fullText: 'ABC', displayedCharCount: 3, acc: 7 }
+      const s1 = tickTypewriter(s0, 100, 30)
+      expect(s1).toBe(s0) // 同一参照（早期 return）
+    })
+
+    it('deltaMS が負でも壊れない', () => {
+      const s0 = startTypewriter('ABCDE')
+      const s1 = tickTypewriter(s0, -100, 30)
+      expect(s1.displayedCharCount).toBe(0)
+      expect(s1.acc).toBe(0)
+    })
+  })
+
+  describe('skipTypewriter', () => {
+    it('表示中なら最後まで飛ばす', () => {
+      const s0 = startTypewriter('こんにちは')
+      const s1 = skipTypewriter(s0)
+      expect(s1.displayedCharCount).toBe(5)
+      expect(isTypingActive(s1)).toBe(false)
+    })
+
+    it('完了済みなら何もしない', () => {
+      const s0 = { fullText: 'ABC', displayedCharCount: 3, acc: 0 }
+      const s1 = skipTypewriter(s0)
+      expect(s1).toBe(s0)
+    })
+
+    it('空文字でも壊れない', () => {
+      const s0 = startTypewriter('')
+      const s1 = skipTypewriter(s0)
+      expect(s1.displayedCharCount).toBe(0)
+    })
+  })
+
+  describe('visibleText', () => {
+    it('displayedCharCount までの substring を返す', () => {
+      const s = { fullText: 'こんにちは', displayedCharCount: 3, acc: 0 }
+      expect(visibleText(s)).toBe('こんに')
+    })
+
+    it('改行 (\\n) も 1 文字としてカウント', () => {
+      const s = { fullText: 'AB\nCD', displayedCharCount: 3, acc: 0 }
+      expect(visibleText(s)).toBe('AB\n')
+    })
+  })
+
+  describe('regression #137 「カノソ方式 = 一瞬表示」廃止', () => {
+    it('30ms/char で 5 文字なら累計 150ms で完了', () => {
+      let s = startTypewriter('ABCDE')
+      // 5 frames of 30ms each
+      for (let i = 0; i < 5; i++) {
+        s = tickTypewriter(s, 30, 30)
+      }
+      expect(s.displayedCharCount).toBe(5)
+      expect(visibleText(s)).toBe('ABCDE')
+    })
+  })
+})

--- a/frontend/src/game/typewriter.test.ts
+++ b/frontend/src/game/typewriter.test.ts
@@ -74,11 +74,31 @@ describe('typewriter pure helpers', () => {
       expect(s1).toBe(s0) // 同一参照（早期 return）
     })
 
-    it('deltaMS が負でも壊れない', () => {
-      const s0 = startTypewriter('ABCDE')
+    it('deltaMS が負でも壊れない (acc を維持)', () => {
+      const s0 = { fullText: 'ABCDE', displayedCharCount: 1, acc: 12 }
       const s1 = tickTypewriter(s0, -100, 30)
+      expect(s1.displayedCharCount).toBe(1)
+      expect(s1.acc).toBe(12) // 元の acc を捨てない
+    })
+
+    it('deltaMS が NaN でも壊れない', () => {
+      const s0 = startTypewriter('ABC')
+      const s1 = tickTypewriter(s0, NaN, 30)
       expect(s1.displayedCharCount).toBe(0)
       expect(s1.acc).toBe(0)
+    })
+
+    it('msPerChar が NaN なら即時完了 (>0 でない値は完了扱い)', () => {
+      const s0 = startTypewriter('ABCDE')
+      const s1 = tickTypewriter(s0, 1, NaN)
+      expect(s1.displayedCharCount).toBe(5)
+    })
+
+    it('msPerChar 超大値 + 通常 deltaMS なら 1 文字も進まない', () => {
+      const s0 = startTypewriter('ABC')
+      const s1 = tickTypewriter(s0, 16, 1_000_000)
+      expect(s1.displayedCharCount).toBe(0)
+      expect(s1.acc).toBe(16)
     })
   })
 
@@ -90,10 +110,19 @@ describe('typewriter pure helpers', () => {
       expect(isTypingActive(s1)).toBe(false)
     })
 
-    it('完了済みなら何もしない', () => {
+    it('完了済みなら何もしない (同一参照)', () => {
       const s0 = { fullText: 'ABC', displayedCharCount: 3, acc: 0 }
       const s1 = skipTypewriter(s0)
       expect(s1).toBe(s0)
+    })
+
+    it('skip 連打しても state は安定 (2 回目以降は同一参照)', () => {
+      const s0 = startTypewriter('ABCDE')
+      const s1 = skipTypewriter(s0)
+      const s2 = skipTypewriter(s1)
+      const s3 = skipTypewriter(s2)
+      expect(s2).toBe(s1)
+      expect(s3).toBe(s1)
     })
 
     it('空文字でも壊れない', () => {

--- a/frontend/src/game/typewriter.ts
+++ b/frontend/src/game/typewriter.ts
@@ -1,0 +1,72 @@
+/**
+ * 1 文字ずつ表示する typewriter の pure 計算ヘルパー (#137)
+ *
+ * DialogBox / RpgDialogBox で同じロジックを使えるよう、PixiJS 依存無しで切り出す。
+ * 単体テストもこの helper に集約する。
+ */
+
+export interface TypewriterState {
+  /** ワードラップ済みの完全テキスト。改行は \n。空文字なら typewriter は何もしない */
+  fullText: string
+  /** 現在表示中の文字数 (0..fullText.length) */
+  displayedCharCount: number
+  /** deltaMS の累積（端数を次フレームに繰り越すため） */
+  acc: number
+}
+
+export function makeInitialTypewriterState(): TypewriterState {
+  return { fullText: '', displayedCharCount: 0, acc: 0 }
+}
+
+/**
+ * 新しいテキストで typewriter を開始する。
+ * displayedCharCount を 0 に戻し、acc もリセット。
+ */
+export function startTypewriter(fullText: string): TypewriterState {
+  return { fullText, displayedCharCount: 0, acc: 0 }
+}
+
+/**
+ * 1 フレーム分進める。msPerChar=0 のときは即座に最後まで進む。
+ *
+ * @returns 新しい state（immutable）
+ */
+export function tickTypewriter(
+  state: TypewriterState,
+  deltaMS: number,
+  msPerChar: number
+): TypewriterState {
+  if (state.displayedCharCount >= state.fullText.length) return state
+  if (msPerChar <= 0) {
+    return {
+      fullText: state.fullText,
+      displayedCharCount: state.fullText.length,
+      acc: 0,
+    }
+  }
+  const acc = state.acc + Math.max(0, deltaMS)
+  if (acc < msPerChar) {
+    return { fullText: state.fullText, displayedCharCount: state.displayedCharCount, acc }
+  }
+  const charsToAdd = Math.floor(acc / msPerChar)
+  const newAcc = acc - charsToAdd * msPerChar
+  const newCount = Math.min(state.fullText.length, state.displayedCharCount + charsToAdd)
+  return { fullText: state.fullText, displayedCharCount: newCount, acc: newAcc }
+}
+
+/**
+ * 全文を即時表示する（typewriter スキップ）。
+ */
+export function skipTypewriter(state: TypewriterState): TypewriterState {
+  if (state.displayedCharCount >= state.fullText.length) return state
+  return { fullText: state.fullText, displayedCharCount: state.fullText.length, acc: 0 }
+}
+
+export function isTypingActive(state: TypewriterState): boolean {
+  return state.displayedCharCount < state.fullText.length
+}
+
+/** 現在表示すべき文字列を返す（描画用）。 */
+export function visibleText(state: TypewriterState): string {
+  return state.fullText.substring(0, state.displayedCharCount)
+}

--- a/frontend/src/game/typewriter.ts
+++ b/frontend/src/game/typewriter.ts
@@ -27,7 +27,10 @@ export function startTypewriter(fullText: string): TypewriterState {
 }
 
 /**
- * 1 フレーム分進める。msPerChar=0 のときは即座に最後まで進む。
+ * 1 フレーム分進める。msPerChar<=0 (0 / 負 / NaN扱い) のときは即座に最後まで進む。
+ *
+ * - 既完了 state は同一参照で早期 return
+ * - 負の deltaMS は 0 にクランプ (時刻巻き戻り耐性)
  *
  * @returns 新しい state（immutable）
  */
@@ -37,14 +40,17 @@ export function tickTypewriter(
   msPerChar: number
 ): TypewriterState {
   if (state.displayedCharCount >= state.fullText.length) return state
-  if (msPerChar <= 0) {
+  if (!(msPerChar > 0)) {
+    // 0 / 負 / NaN は即時完了
     return {
       fullText: state.fullText,
       displayedCharCount: state.fullText.length,
       acc: 0,
     }
   }
-  const acc = state.acc + Math.max(0, deltaMS)
+  // 負の deltaMS / NaN はフレーム進行 0 とみなす (acc は元の値を維持)
+  const safeDelta = deltaMS > 0 ? deltaMS : 0
+  const acc = state.acc + safeDelta
   if (acc < msPerChar) {
     return { fullText: state.fullText, displayedCharCount: state.displayedCharCount, acc }
   }


### PR DESCRIPTION
## 関連 Issue
closes #137

## 概要
NovelRenderer 冒頭コメントの「カノソ方式 = 一瞬表示」を廃止。ノベルゲームとして基本の 1 文字ずつ表示 + タイピング中スキップ を実装。

## 変更ファイル
- 新規: \`frontend/src/game/typewriter.ts\` (pure helper)
- 新規: \`frontend/src/game/typewriter.test.ts\` (18 件)
- 修正: \`frontend/src/game/DialogBox.ts\` (typewriter 取り込み + skipTypewriter / isTyping / setMsPerChar API)
- 修正: \`frontend/src/game/NovelRenderer.ts\` (advance / Enter / Space / ArrowRight で typewriter 中なら skip)

## 設計ポイント
- typewriter ロジックは PixiJS 依存無しの pure helper として切り出し → 単体テスト可能 + #150 RpgDialogBox 側にも流用可
- DialogBox は内部 ticker で 1 フレームごと tickTypewriter を呼ぶ
- インジケーター (▼) は typewriter 中は非表示、完了で表示
- msPerChar デフォルト 30ms/char、設定画面 (#138) から \`setMsPerChar\` で動的変更前提
- msPerChar=0 / 負値で即時完了に倒す（一瞬表示モードへ後退できる）

## テスト
- typewriter.test.ts: tick / skip / visibleText / msPerChar=0 / 負値 / 改行カウント / 既完了不変 / 30ms×5frame=完了
- vitest 全件 271 → 289 pass、tsc clean

## 後続
- #138 設定画面で msPerChar をユーザー可変に
- #150 RpgDialogBox に同 helper を取り込み RPG 側 NPC 会話も typewriter 化