### PR TITLE
feat: #150 RPG NPC 会話の typewriter 表示 (RpgDialogBox に #137 helper 適用)

### DIFF
--- a/frontend/src/game/RaycastRenderer.ts
+++ b/frontend/src/game/RaycastRenderer.ts
@@ -432,7 +432,12 @@ export class RaycastRenderer {
     if (this.dialogBox?.isShowing) {
       if (e.key === ' ' || e.key === 'Enter') {
         e.preventDefault()
-        this.dialogBox.hide()
+        // typewriter 表示中なら全文表示にスキップ、完了済みなら閉じる (#150)
+        if (this.dialogBox.isTyping()) {
+          this.dialogBox.skipTypewriter()
+        } else {
+          this.dialogBox.hide()
+        }
       }
       return
     }

--- a/frontend/src/game/RpgDialogBox.test.ts
+++ b/frontend/src/game/RpgDialogBox.test.ts
@@ -24,7 +24,12 @@ import {
 interface RpgDialogBoxInternals {
   portraitFrame: { visible: boolean } | null
   nameText: { x: number } | null
-  messageText: { x: number; style: { wordWrapWidth: number } } | null
+  messageText: {
+    x: number
+    text: string
+    visible: boolean
+    style: { wordWrapWidth: number }
+  } | null
   portraitSprite: { visible: boolean; texture: unknown } | null
   currentPortraitToken: number
 }
@@ -124,6 +129,71 @@ describe('RpgDialogBox portrait (Issue #73 Phase 1)', () => {
     box.show('村人', 'yo', 'villager.png')
     expect(i.currentPortraitToken).toBeGreaterThan(tokenAfterRedraw)
 
+    box.destroy()
+  })
+})
+
+describe('RpgDialogBox typewriter (Issue #150)', () => {
+  it('show 直後は messageText.text が空 (typewriter 開始時点)', () => {
+    const box = new RpgDialogBox(SCREEN_WIDTH, SCREEN_HEIGHT)
+    box.show('長老', 'こんにちは')
+    const i = asInternals(box)
+    expect(i.messageText!.text).toBe('')
+    expect(i.messageText!.visible).toBe(true)
+    expect(box.isTyping()).toBe(true)
+    box.destroy()
+  })
+
+  it('skipTypewriter で全文が即座に表示される', () => {
+    const box = new RpgDialogBox(SCREEN_WIDTH, SCREEN_HEIGHT)
+    box.show('長老', 'こんにちは、若者よ。')
+    box.skipTypewriter()
+    const i = asInternals(box)
+    expect(i.messageText!.text).toBe('こんにちは、若者よ。')
+    expect(box.isTyping()).toBe(false)
+    box.destroy()
+  })
+
+  it('hide で typewriter 状態がリセットされる', () => {
+    const box = new RpgDialogBox(SCREEN_WIDTH, SCREEN_HEIGHT)
+    box.show('長老', 'long message')
+    expect(box.isTyping()).toBe(true)
+    box.hide()
+    expect(box.isTyping()).toBe(false)
+    box.destroy()
+  })
+
+  it('setMsPerChar(0) で表示中なら即座に skip される', () => {
+    const box = new RpgDialogBox(SCREEN_WIDTH, SCREEN_HEIGHT)
+    box.show('長老', 'message')
+    expect(box.isTyping()).toBe(true)
+    box.setMsPerChar(0)
+    const i = asInternals(box)
+    expect(i.messageText!.text).toBe('message')
+    expect(box.isTyping()).toBe(false)
+    box.destroy()
+  })
+
+  it('skip 連打しても安定 (二回目は no-op)', () => {
+    const box = new RpgDialogBox(SCREEN_WIDTH, SCREEN_HEIGHT)
+    box.show('長老', 'msg')
+    box.skipTypewriter()
+    box.skipTypewriter()
+    box.skipTypewriter()
+    const i = asInternals(box)
+    expect(i.messageText!.text).toBe('msg')
+    expect(box.isTyping()).toBe(false)
+    box.destroy()
+  })
+
+  it('別 NPC を再度 show すると typewriter が新規開始する', () => {
+    const box = new RpgDialogBox(SCREEN_WIDTH, SCREEN_HEIGHT)
+    box.show('長老', 'first')
+    box.skipTypewriter()
+    box.show('村人', 'second')
+    const i = asInternals(box)
+    expect(i.messageText!.text).toBe('') // 新規 typewriter 開始時点なので空
+    expect(box.isTyping()).toBe(true)
     box.destroy()
   })
 })

--- a/frontend/src/game/RpgDialogBox.ts
+++ b/frontend/src/game/RpgDialogBox.ts
@@ -10,7 +10,28 @@
  * ノベル用 DialogBox（話者名別枠 + ▼インジケーター + 禁則ワードラップ）とは見た目が別系統のため独立クラスとして分離している。
  */
 
-import { Assets, Container, Graphics, Sprite, Text as PixiText, TextStyle, Texture } from 'pixi.js'
+import {
+  Assets,
+  Container,
+  Graphics,
+  Sprite,
+  Text as PixiText,
+  TextStyle,
+  Texture,
+  Ticker,
+} from 'pixi.js'
+import {
+  type TypewriterState,
+  isTypingActive,
+  makeInitialTypewriterState,
+  skipTypewriter as typewriterSkip,
+  startTypewriter,
+  tickTypewriter,
+  visibleText,
+} from './typewriter'
+
+/** typewriter のデフォルト速度（ms/char）。設定画面 #138 で上書き可能になる前提 */
+const DEFAULT_RPG_MS_PER_CHAR = 30
 
 /**
  * レイアウト定数（モジュール export）。
@@ -97,11 +118,30 @@ export class RpgDialogBox extends Container {
   private screenHeight: number
   private showing = false
 
+  /** typewriter 状態 (#150 / #137 と共通 helper) */
+  private typewriter: TypewriterState = makeInitialTypewriterState()
+  /** typewriter: 1 文字あたり ms */
+  private msPerChar: number = DEFAULT_RPG_MS_PER_CHAR
+  /** typewriter 進行 + show 中のみ動かす ticker */
+  private ticker: Ticker
+
   constructor(screenWidth: number, screenHeight: number) {
     super()
     this.screenWidth = screenWidth
     this.screenHeight = screenHeight
     this.build()
+
+    // typewriter ticker: show 中のみ tick を消費する。constructor では走らせず、
+    // show() で start、hide() / destroy() で stop する。
+    this.ticker = new Ticker()
+    this.ticker.add(() => {
+      if (!isTypingActive(this.typewriter)) return
+      const next = tickTypewriter(this.typewriter, this.ticker.deltaMS, this.msPerChar)
+      if (next.displayedCharCount !== this.typewriter.displayedCharCount && this.messageText) {
+        this.messageText.text = visibleText(next)
+      }
+      this.typewriter = next
+    })
   }
 
   get isShowing(): boolean {
@@ -127,9 +167,12 @@ export class RpgDialogBox extends Container {
       this.nameText.visible = true
     }
     if (this.messageText) {
-      this.messageText.text = message
+      // typewriter: 全文を保持し、displayedCharCount を 0 から進めていく
+      this.typewriter = startTypewriter(message)
+      this.messageText.text = ''
       this.messageText.visible = true
     }
+    if (!this.ticker.started) this.ticker.start()
 
     this.applyPortraitLayout()
     if (this.currentPortrait) {
@@ -148,6 +191,37 @@ export class RpgDialogBox extends Container {
     if (this.nameText) this.nameText.visible = false
     if (this.messageText) this.messageText.visible = false
     this.hidePortrait()
+    // typewriter 状態クリア + ticker 停止 (CPU 節約)
+    this.typewriter = makeInitialTypewriterState()
+    if (this.ticker.started) this.ticker.stop()
+  }
+
+  /**
+   * typewriter 表示中なら全文を即時表示し完了させる (#150)。
+   * 表示完了済み or hide 中なら何もしない。
+   */
+  skipTypewriter(): void {
+    if (!isTypingActive(this.typewriter)) return
+    this.typewriter = typewriterSkip(this.typewriter)
+    if (this.messageText) this.messageText.text = visibleText(this.typewriter)
+  }
+
+  /**
+   * typewriter が進行中（まだ全文表示されていない）か。
+   */
+  isTyping(): boolean {
+    return isTypingActive(this.typewriter)
+  }
+
+  /**
+   * typewriter 速度を設定する (#138 設定画面から呼ぶ前提)。
+   * @param msPerChar 1 文字あたり ms。0 以下は瞬間表示扱い。
+   */
+  setMsPerChar(msPerChar: number): void {
+    this.msPerChar = Math.max(0, msPerChar)
+    if (this.msPerChar === 0) {
+      this.skipTypewriter()
+    }
   }
 
   redraw(screenWidth: number, screenHeight: number): void {
@@ -163,7 +237,8 @@ export class RpgDialogBox extends Container {
         this.nameText.visible = true
       }
       if (this.messageText) {
-        this.messageText.text = this.currentMessage
+        // redraw 時は typewriter の現在状態を保ったまま再描画する
+        this.messageText.text = visibleText(this.typewriter)
         this.messageText.visible = true
       }
       this.applyPortraitLayout()
@@ -176,6 +251,9 @@ export class RpgDialogBox extends Container {
   }
 
   override destroy(): void {
+    // typewriter ticker を完全に停止・破棄してリーク防止
+    if (this.ticker.started) this.ticker.stop()
+    this.ticker.destroy()
     // super.destroy({ children: true }) が自身と全子要素を破棄する
     this.bg = null
     this.nameText = null

--- a/frontend/src/game/TopDownRenderer.ts
+++ b/frontend/src/game/TopDownRenderer.ts
@@ -335,7 +335,12 @@ export class TopDownRenderer {
     if (this.dialogBox?.isShowing) {
       if (e.key === ' ' || e.key === 'Enter') {
         e.preventDefault()
-        this.dialogBox.hide()
+        // typewriter 表示中なら全文表示にスキップ、完了済みなら閉じる (#150)
+        if (this.dialogBox.isTyping()) {
+          this.dialogBox.skipTypewriter()
+        } else {
+          this.dialogBox.hide()
+        }
       }
       return
     }


### PR DESCRIPTION
## 関連 Issue
closes #150

## 概要
PR #153 (#137) で導入した typewriter pure helper を RpgDialogBox にも適用。RPG パートの NPC 会話も 1 文字ずつ表示される。

## 変更ファイル
- \`frontend/src/game/RpgDialogBox.ts\`: typewriter 統合、\`skipTypewriter\` / \`isTyping\` / \`setMsPerChar\` API 追加、専用 Ticker
- \`frontend/src/game/RaycastRenderer.ts\`: dialog 中の Enter/Space 分岐に skip→hide 段階対応
- \`frontend/src/game/TopDownRenderer.ts\`: 同上
- \`frontend/src/game/RpgDialogBox.test.ts\`: typewriter 統合テスト 6 件追加

## 設計ポイント
- typewriter ロジックは PR #153 で切り出した pure helper をそのまま流用 (DRY)
- RpgDialogBox 内部に専用 Ticker、show 中のみ start し hide で stop (CPU 節約)
- destroy で ticker.destroy() してリーク防止
- redraw 時は typewriter 現在状態を保ったまま再描画 (途中で resize しても表示位置維持)
- Enter/Space 押下: typewriter 中 → skip / 完了済み → hide

## テスト
- \`npx tsc --noEmit\` パス
- \`npx vitest run\` 293 → 299 件 pass (RpgDialogBox typewriter 6 件追加)

## 効果
- ノベル (#137) と RPG (#150) で同じ typewriter 体験
- どちらも \`setMsPerChar\` API を持つので、設定画面 (#138) からの速度連携が綺麗に組める