### PR TITLE
feat: #138 設定画面（速度 / 音量 / オート wait）+ localStorage 永続化

### DIFF
--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Event, EventScene } from '../types'
 import { NovelRenderer } from '../game/NovelRenderer'
+import { type Settings, loadSettings, saveSettings } from '../game/settings'
+import SettingsOverlay from './SettingsOverlay'
 
 interface NovelPlayerProps {
   events: Event[]
@@ -11,6 +13,10 @@ interface NovelPlayerProps {
 function NovelPlayer({ events, scenes, assetBaseUrl }: NovelPlayerProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const rendererRef = useRef<NovelRenderer | null>(null)
+
+  // 設定 (Issue #138): localStorage と同期
+  const [settings, setSettings] = useState<Settings>(() => loadSettings())
+  const [settingsOpen, setSettingsOpen] = useState(false)
 
   // ライフサイクル管理: init + destroy
   useEffect(() => {
@@ -29,6 +35,8 @@ function NovelPlayer({ events, scenes, assetBaseUrl }: NovelPlayerProps) {
       if (assetBaseUrl) {
         renderer.setAssetBaseUrl(assetBaseUrl)
       }
+      // init 完了直後に現在の settings を反映 (#138)
+      renderer.applySettings(settings)
       if (scenes && scenes.length > 0) {
         renderer.setScenes(scenes)
       } else {
@@ -41,6 +49,24 @@ function NovelPlayer({ events, scenes, assetBaseUrl }: NovelPlayerProps) {
       renderer.destroy()
       rendererRef.current = null
     }
+  }, [])
+
+  // 設定変更を renderer に反映 + localStorage に保存 (#138)
+  useEffect(() => {
+    rendererRef.current?.applySettings(settings)
+    saveSettings(settings)
+  }, [settings])
+
+  // 設定パネルの開閉ショートカット (#138): Ctrl/Cmd + , で開く
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if ((e.ctrlKey || e.metaKey) && e.key === ',') {
+        e.preventDefault()
+        setSettingsOpen((v) => !v)
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
   }, [])
 
   // assetBaseUrl が変わったらレンダラーに反映
@@ -61,11 +87,26 @@ function NovelPlayer({ events, scenes, assetBaseUrl }: NovelPlayerProps) {
   }, [events, scenes])
 
   return (
-    <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-slate-800 to-slate-900">
+    <div className="relative w-full h-full flex items-center justify-center bg-gradient-to-br from-slate-800 to-slate-900">
       <div
         ref={containerRef}
         className="rounded-xl shadow-2xl overflow-hidden"
         style={{ maxWidth: '100%', maxHeight: '100%' }}
+      />
+      <button
+        type="button"
+        onClick={() => setSettingsOpen(true)}
+        aria-label="設定を開く"
+        title="設定 (Ctrl/Cmd + ,)"
+        className="absolute top-3 right-3 w-9 h-9 flex items-center justify-center rounded-full bg-black/50 hover:bg-black/70 text-white/80 hover:text-white text-lg"
+      >
+        ⚙
+      </button>
+      <SettingsOverlay
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        settings={settings}
+        onChange={setSettings}
       />
     </div>
   )

--- a/frontend/src/components/RPGPlayer.tsx
+++ b/frontend/src/components/RPGPlayer.tsx
@@ -1,13 +1,16 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { TopDownRenderer } from '../game/TopDownRenderer'
 import { RaycastRenderer } from '../game/RaycastRenderer'
 import { sampleRpgData } from '../game/sampleRpgData'
 import { RPGProject } from '../types/rpg'
+import { type Settings, loadSettings, saveSettings } from '../game/settings'
+import SettingsOverlay from './SettingsOverlay'
 
 type RendererLike = {
   init(container: HTMLElement): Promise<void>
   load(gameData: RPGProject): void
   destroy(): void
+  applySettings?(settings: { msPerChar: number; bgmVolume: number; seVolume: number }): void
 }
 
 interface RPGPlayerProps {
@@ -17,6 +20,11 @@ interface RPGPlayerProps {
 
 function RPGPlayer({ gameData, view = 'topdown' }: RPGPlayerProps) {
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const rendererRef = useRef<RendererLike | null>(null)
+
+  // 設定 (Issue #138)
+  const [settings, setSettings] = useState<Settings>(() => loadSettings())
+  const [settingsOpen, setSettingsOpen] = useState(false)
 
   useEffect(() => {
     const container = containerRef.current
@@ -24,6 +32,7 @@ function RPGPlayer({ gameData, view = 'topdown' }: RPGPlayerProps) {
 
     const renderer: RendererLike =
       view === 'raycast' ? new RaycastRenderer() : new TopDownRenderer()
+    rendererRef.current = renderer
     let cancelled = false
 
     renderer
@@ -33,6 +42,7 @@ function RPGPlayer({ gameData, view = 'topdown' }: RPGPlayerProps) {
           renderer.destroy()
           return
         }
+        renderer.applySettings?.(settings)
         renderer.load(gameData ?? sampleRpgData)
       })
       .catch((err) => {
@@ -44,13 +54,47 @@ function RPGPlayer({ gameData, view = 'topdown' }: RPGPlayerProps) {
 
     return () => {
       cancelled = true
+      rendererRef.current = null
       renderer.destroy()
     }
   }, [gameData, view])
 
+  // 設定変更を renderer に反映 + 永続化 (#138)
+  useEffect(() => {
+    rendererRef.current?.applySettings?.(settings)
+    saveSettings(settings)
+  }, [settings])
+
+  // Ctrl/Cmd + , で設定パネル開閉 (#138)
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if ((e.ctrlKey || e.metaKey) && e.key === ',') {
+        e.preventDefault()
+        setSettingsOpen((v) => !v)
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [])
+
   return (
-    <div className="w-full h-full flex items-center justify-center">
+    <div className="relative w-full h-full flex items-center justify-center">
       <div ref={containerRef} className="w-full h-full" />
+      <button
+        type="button"
+        onClick={() => setSettingsOpen(true)}
+        aria-label="設定を開く"
+        title="設定 (Ctrl/Cmd + ,)"
+        className="absolute top-3 right-3 w-9 h-9 flex items-center justify-center rounded-full bg-black/50 hover:bg-black/70 text-white/80 hover:text-white text-lg z-10"
+      >
+        ⚙
+      </button>
+      <SettingsOverlay
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        settings={settings}
+        onChange={setSettings}
+      />
     </div>
   )
 }

--- a/frontend/src/components/SettingsOverlay.tsx
+++ b/frontend/src/components/SettingsOverlay.tsx
@@ -1,0 +1,175 @@
+import { useEffect } from 'react'
+import { DEFAULT_SETTINGS, type Settings } from '../game/settings'
+
+interface SettingsOverlayProps {
+  open: boolean
+  onClose: () => void
+  settings: Settings
+  onChange: (s: Settings) => void
+}
+
+interface SliderRowProps {
+  label: string
+  value: number
+  min: number
+  max: number
+  step: number
+  unit?: string
+  onChange: (v: number) => void
+  /** 数値表示の整形 */
+  format?: (v: number) => string
+}
+
+function SliderRow({ label, value, min, max, step, unit, onChange, format }: SliderRowProps) {
+  const display = format ? format(value) : `${value}${unit ?? ''}`
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <div className="flex justify-between items-baseline">
+        <span className="text-gray-200">{label}</span>
+        <span className="text-gray-400 tabular-nums text-xs">{display}</span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full accent-cyan-300"
+      />
+    </label>
+  )
+}
+
+/**
+ * 設定オーバーレイ (Issue #138)
+ *
+ * テキスト速度 / BGM 音量 / SE 音量 / Voice 音量 / オート wait time。
+ * ESC で閉じる、デフォルトに戻すボタン付き。
+ */
+export function SettingsOverlay({ open, onClose, settings, onChange }: SettingsOverlayProps) {
+  // ESC で閉じる
+  useEffect(() => {
+    if (!open) return
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  const update = (patch: Partial<Settings>) => onChange({ ...settings, ...patch })
+
+  return (
+    <div
+      className="absolute inset-0 z-50 flex items-center justify-center bg-black/70"
+      role="dialog"
+      aria-modal="true"
+      aria-label="設定"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md mx-4 bg-gray-900 border border-gray-700 rounded-lg shadow-2xl p-5 flex flex-col gap-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-between items-center">
+          <h2 className="text-lg font-semibold text-white">設定</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="閉じる"
+            className="w-8 h-8 flex items-center justify-center rounded text-gray-400 hover:bg-gray-800 hover:text-white"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <SliderRow
+            label="テキスト表示速度"
+            value={settings.msPerChar}
+            min={0}
+            max={200}
+            step={5}
+            onChange={(v) => update({ msPerChar: v })}
+            format={(v) =>
+              v === 0
+                ? '瞬間表示'
+                : v <= 15
+                  ? `速い (${v}ms)`
+                  : v >= 60
+                    ? `遅い (${v}ms)`
+                    : `${v}ms/字`
+            }
+          />
+
+          <SliderRow
+            label="BGM 音量"
+            value={settings.bgmVolume}
+            min={0}
+            max={1}
+            step={0.05}
+            onChange={(v) => update({ bgmVolume: v })}
+            format={(v) => `${Math.round(v * 100)}%`}
+          />
+
+          <SliderRow
+            label="SE 音量"
+            value={settings.seVolume}
+            min={0}
+            max={1}
+            step={0.05}
+            onChange={(v) => update({ seVolume: v })}
+            format={(v) => `${Math.round(v * 100)}%`}
+          />
+
+          <SliderRow
+            label="ボイス音量 (将来用)"
+            value={settings.voiceVolume}
+            min={0}
+            max={1}
+            step={0.05}
+            onChange={(v) => update({ voiceVolume: v })}
+            format={(v) => `${Math.round(v * 100)}%`}
+          />
+
+          <SliderRow
+            label="オート進行ウェイト"
+            value={settings.autoWaitMs}
+            min={500}
+            max={8000}
+            step={100}
+            onChange={(v) => update({ autoWaitMs: v })}
+            format={(v) => `${(v / 1000).toFixed(1)}秒`}
+          />
+        </div>
+
+        <div className="flex justify-between items-center pt-2 border-t border-gray-700">
+          <button
+            type="button"
+            onClick={() => onChange({ ...DEFAULT_SETTINGS })}
+            className="text-sm text-gray-400 hover:text-white px-2 py-1 rounded hover:bg-gray-800"
+          >
+            デフォルトに戻す
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm bg-cyan-600 hover:bg-cyan-500 text-white px-4 py-1.5 rounded"
+          >
+            閉じる
+          </button>
+        </div>
+
+        <p className="text-xs text-gray-500 text-center">ESC でも閉じられます</p>
+      </div>
+    </div>
+  )
+}
+
+export default SettingsOverlay

--- a/frontend/src/game/AudioManager.ts
+++ b/frontend/src/game/AudioManager.ts
@@ -20,6 +20,13 @@ export class AudioManager {
     timer: ReturnType<typeof setTimeout>
   }[] = []
 
+  // マスター音量（Issue #138）。BGM / SE をそれぞれの master gain に集約し、
+  // setBgmVolume / setSeVolume で動的に変更できるようにする。
+  private bgmMasterGain: GainNode | null = null
+  private seMasterGain: GainNode | null = null
+  private bgmVolume = 1.0
+  private seVolume = 1.0
+
   /**
    * AudioContext を生成/再開する。
    * ユーザーインタラクション（クリック等）のタイミングで呼ぶこと。
@@ -30,6 +37,40 @@ export class AudioManager {
     }
     if (this.ctx.state === 'suspended') {
       this.ctx.resume()
+    }
+    this.ensureMasterGains()
+  }
+
+  /** master gain が未生成なら作って destination に繋ぐ */
+  private ensureMasterGains(): void {
+    if (!this.ctx) return
+    if (!this.bgmMasterGain) {
+      this.bgmMasterGain = this.ctx.createGain()
+      this.bgmMasterGain.gain.value = this.bgmVolume
+      this.bgmMasterGain.connect(this.ctx.destination)
+    }
+    if (!this.seMasterGain) {
+      this.seMasterGain = this.ctx.createGain()
+      this.seMasterGain.gain.value = this.seVolume
+      this.seMasterGain.connect(this.ctx.destination)
+    }
+  }
+
+  /** BGM マスター音量を設定する（0..1） */
+  setBgmVolume(volume: number): void {
+    const v = Math.max(0, Math.min(1, volume))
+    this.bgmVolume = v
+    if (this.bgmMasterGain && this.ctx) {
+      this.bgmMasterGain.gain.setValueAtTime(v, this.ctx.currentTime)
+    }
+  }
+
+  /** SE マスター音量を設定する（0..1） */
+  setSeVolume(volume: number): void {
+    const v = Math.max(0, Math.min(1, volume))
+    this.seVolume = v
+    if (this.seMasterGain && this.ctx) {
+      this.seMasterGain.gain.setValueAtTime(v, this.ctx.currentTime)
     }
   }
 
@@ -55,7 +96,12 @@ export class AudioManager {
     const gain = this.ctx.createGain()
     gain.gain.value = 1.0
     source.connect(gain)
-    gain.connect(this.ctx.destination)
+    this.ensureMasterGains()
+    if (this.bgmMasterGain) {
+      gain.connect(this.bgmMasterGain)
+    } else {
+      gain.connect(this.ctx.destination)
+    }
 
     source.start(0)
 
@@ -111,7 +157,12 @@ export class AudioManager {
 
     const source = this.ctx.createBufferSource()
     source.buffer = buffer
-    source.connect(this.ctx.destination)
+    this.ensureMasterGains()
+    if (this.seMasterGain) {
+      source.connect(this.seMasterGain)
+    } else {
+      source.connect(this.ctx.destination)
+    }
     source.onended = () => source.disconnect()
     source.start(0)
   }
@@ -122,6 +173,14 @@ export class AudioManager {
   destroy(): void {
     this.stopBgmImmediate()
     this.audioCache.clear()
+    if (this.bgmMasterGain) {
+      this.bgmMasterGain.disconnect()
+      this.bgmMasterGain = null
+    }
+    if (this.seMasterGain) {
+      this.seMasterGain.disconnect()
+      this.seMasterGain = null
+    }
     if (this.ctx) {
       this.ctx.close()
       this.ctx = null

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -312,6 +312,16 @@ export class NovelRenderer {
   }
 
   /**
+   * 設定（テキスト速度・音量）をリアルタイムに反映する。
+   * Issue #138。autoWaitMs / voiceVolume はここでは使わない（将来用）。
+   */
+  applySettings(settings: { msPerChar: number; bgmVolume: number; seVolume: number }): void {
+    this.dialogBox.setMsPerChar(settings.msPerChar)
+    this.audioManager.setBgmVolume(settings.bgmVolume)
+    this.audioManager.setSeVolume(settings.seVolume)
+  }
+
+  /**
    * リソース解放
    */
   destroy(): void {

--- a/frontend/src/game/RaycastRenderer.ts
+++ b/frontend/src/game/RaycastRenderer.ts
@@ -371,6 +371,16 @@ export class RaycastRenderer {
     npc.sprite.tint = 0xffffff
   }
 
+  /**
+   * 設定（テキスト速度・音量）を反映。Issue #138。
+   * RaycastRenderer も現状 BGM/SE を持たない（将来統合用）。
+   */
+  applySettings(settings: { msPerChar: number; bgmVolume: number; seVolume: number }): void {
+    this.dialogBox?.setMsPerChar(settings.msPerChar)
+    void settings.bgmVolume
+    void settings.seVolume
+  }
+
   destroy(): void {
     window.removeEventListener('keydown', this.handleKeyDown)
     window.removeEventListener('keyup', this.handleKeyUp)

--- a/frontend/src/game/TopDownRenderer.ts
+++ b/frontend/src/game/TopDownRenderer.ts
@@ -142,6 +142,18 @@ export class TopDownRenderer {
     this.centerCamera()
   }
 
+  /**
+   * 設定（テキスト速度・音量）を反映。Issue #138。
+   * TopDownRenderer は現状 BGM/SE を持たないが、将来 AudioManager を統合した
+   * 際の API 互換のため bgmVolume / seVolume も受け取る。
+   */
+  applySettings(settings: { msPerChar: number; bgmVolume: number; seVolume: number }): void {
+    this.dialogBox?.setMsPerChar(settings.msPerChar)
+    // BGM / SE は未実装。引数は将来用。
+    void settings.bgmVolume
+    void settings.seVolume
+  }
+
   /** リソース解放 */
   destroy(): void {
     window.removeEventListener('keydown', this.handleKeyDown)

--- a/frontend/src/game/settings.test.ts
+++ b/frontend/src/game/settings.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_SETTINGS,
+  Settings,
+  __resetMemoryStoreForTest,
+  clampSettings,
+  loadSettings,
+  saveSettings,
+} from './settings'
+
+const STORAGE_KEY = 'name-name:settings'
+
+beforeEach(() => {
+  localStorage.clear()
+  __resetMemoryStoreForTest()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('settings', () => {
+  it('loadSettings は localStorage が空ならデフォルトを返す', () => {
+    expect(loadSettings()).toEqual(DEFAULT_SETTINGS)
+  })
+
+  it('save → load の round-trip で値が保持される', () => {
+    const s: Settings = {
+      msPerChar: 10,
+      bgmVolume: 0.5,
+      seVolume: 0.3,
+      voiceVolume: 0.6,
+      autoWaitMs: 3000,
+    }
+    saveSettings(s)
+    expect(loadSettings()).toEqual(s)
+  })
+
+  it('保存された JSON に欠落キーがあるとデフォルトでマージされる', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ msPerChar: 100 }))
+    const loaded = loadSettings()
+    expect(loaded.msPerChar).toBe(100)
+    expect(loaded.bgmVolume).toBe(DEFAULT_SETTINGS.bgmVolume)
+    expect(loaded.seVolume).toBe(DEFAULT_SETTINGS.seVolume)
+    expect(loaded.voiceVolume).toBe(DEFAULT_SETTINGS.voiceVolume)
+    expect(loaded.autoWaitMs).toBe(DEFAULT_SETTINGS.autoWaitMs)
+  })
+
+  it('不正な JSON → DEFAULT_SETTINGS を返す', () => {
+    localStorage.setItem(STORAGE_KEY, '{not json')
+    expect(loadSettings()).toEqual(DEFAULT_SETTINGS)
+  })
+
+  it('null / 配列 / プリミティブな JSON → DEFAULT_SETTINGS を返す', () => {
+    localStorage.setItem(STORAGE_KEY, 'null')
+    expect(loadSettings()).toEqual(DEFAULT_SETTINGS)
+    localStorage.setItem(STORAGE_KEY, '42')
+    expect(loadSettings()).toEqual(DEFAULT_SETTINGS)
+  })
+
+  it('clampSettings は msPerChar を 0..500 に丸める', () => {
+    expect(clampSettings({ ...DEFAULT_SETTINGS, msPerChar: -10 }).msPerChar).toBe(0)
+    expect(clampSettings({ ...DEFAULT_SETTINGS, msPerChar: 9999 }).msPerChar).toBe(500)
+    expect(clampSettings({ ...DEFAULT_SETTINGS, msPerChar: 0 }).msPerChar).toBe(0)
+    expect(clampSettings({ ...DEFAULT_SETTINGS, msPerChar: 500 }).msPerChar).toBe(500)
+  })
+
+  it('clampSettings は volume を 0..1 に丸める', () => {
+    const c = clampSettings({
+      ...DEFAULT_SETTINGS,
+      bgmVolume: -0.5,
+      seVolume: 2,
+      voiceVolume: 1.5,
+    })
+    expect(c.bgmVolume).toBe(0)
+    expect(c.seVolume).toBe(1)
+    expect(c.voiceVolume).toBe(1)
+  })
+
+  it('clampSettings は autoWaitMs を 500..10000 に丸める', () => {
+    expect(clampSettings({ ...DEFAULT_SETTINGS, autoWaitMs: 100 }).autoWaitMs).toBe(500)
+    expect(clampSettings({ ...DEFAULT_SETTINGS, autoWaitMs: 99999 }).autoWaitMs).toBe(10000)
+    expect(clampSettings({ ...DEFAULT_SETTINGS, autoWaitMs: 2500 }).autoWaitMs).toBe(2500)
+  })
+
+  it('clampSettings は NaN / Infinity / 非数値をデフォルトに置換する', () => {
+    const c = clampSettings({
+      msPerChar: NaN,
+      bgmVolume: Infinity,
+      seVolume: -Infinity,
+      // @ts-expect-error - テスト目的で型を破る
+      voiceVolume: 'bad',
+      autoWaitMs: NaN,
+    })
+    expect(c.msPerChar).toBe(DEFAULT_SETTINGS.msPerChar)
+    // Infinity は範囲外として max にクランプされる
+    expect(c.bgmVolume).toBe(1)
+    expect(c.seVolume).toBe(0)
+    expect(c.voiceVolume).toBe(DEFAULT_SETTINGS.voiceVolume)
+    expect(c.autoWaitMs).toBe(DEFAULT_SETTINGS.autoWaitMs)
+  })
+
+  it('saveSettings は範囲外の値を clamp してから保存する', () => {
+    saveSettings({
+      msPerChar: 9999,
+      bgmVolume: 5,
+      seVolume: -1,
+      voiceVolume: 0.5,
+      autoWaitMs: 50,
+    })
+    const loaded = loadSettings()
+    expect(loaded.msPerChar).toBe(500)
+    expect(loaded.bgmVolume).toBe(1)
+    expect(loaded.seVolume).toBe(0)
+    expect(loaded.voiceVolume).toBe(0.5)
+    expect(loaded.autoWaitMs).toBe(500)
+  })
+
+  it('localStorage.setItem が例外を投げても save → load が破綻しない (in-memory フォールバック)', () => {
+    const setSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded')
+    })
+    const getSpy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked')
+    })
+
+    const s: Settings = {
+      msPerChar: 50,
+      bgmVolume: 0.4,
+      seVolume: 0.4,
+      voiceVolume: 0.4,
+      autoWaitMs: 4000,
+    }
+    expect(() => saveSettings(s)).not.toThrow()
+    // setItem は呼ばれた（が throw される）→ in-memory にフォールバック
+    expect(setSpy).toHaveBeenCalled()
+    expect(loadSettings()).toEqual(s)
+    expect(getSpy).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/game/settings.ts
+++ b/frontend/src/game/settings.ts
@@ -1,0 +1,116 @@
+/**
+ * 設定の永続化（localStorage）と clamp ユーティリティ
+ *
+ * Issue #138: 設定画面（テキスト速度 / 音量 / オート wait time）
+ *
+ * - localStorage 'name-name:settings' に JSON 保存
+ * - 欠落キーは DEFAULT_SETTINGS で補完（前方互換）
+ * - 範囲外は clamp（msPerChar 0..500、各音量 0..1、autoWaitMs 500..10000）
+ * - localStorage 未対応 / 例外時は in-memory フォールバック
+ */
+
+export interface Settings {
+  /** 1 文字あたり ms。0 = 瞬間表示。UI レンジは 0..200 だが clamp 上限は 500 */
+  msPerChar: number
+  /** 0..1 */
+  bgmVolume: number
+  /** 0..1 */
+  seVolume: number
+  /** 0..1（#144 ボイス用、現在は保存だけ） */
+  voiceVolume: number
+  /** 1000..8000 想定（#139 オート用、保存だけ）。clamp は 500..10000 */
+  autoWaitMs: number
+}
+
+export const DEFAULT_SETTINGS: Settings = {
+  msPerChar: 30,
+  bgmVolume: 0.7,
+  seVolume: 0.8,
+  voiceVolume: 0.8,
+  autoWaitMs: 2500,
+}
+
+const STORAGE_KEY = 'name-name:settings'
+
+/**
+ * 範囲を [min, max] に丸める。
+ * - 非数値 / NaN → fallback
+ * - Infinity → max、-Infinity → min（範囲外なので素直にクランプ）
+ */
+function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) return fallback
+  if (value < min) return min
+  if (value > max) return max
+  return value
+}
+
+/**
+ * 設定値を許容範囲に clamp する。
+ * - msPerChar: 0..500
+ * - bgmVolume / seVolume / voiceVolume: 0..1
+ * - autoWaitMs: 500..10000
+ */
+export function clampSettings(s: Settings): Settings {
+  return {
+    msPerChar: clampNumber(s.msPerChar, 0, 500, DEFAULT_SETTINGS.msPerChar),
+    bgmVolume: clampNumber(s.bgmVolume, 0, 1, DEFAULT_SETTINGS.bgmVolume),
+    seVolume: clampNumber(s.seVolume, 0, 1, DEFAULT_SETTINGS.seVolume),
+    voiceVolume: clampNumber(s.voiceVolume, 0, 1, DEFAULT_SETTINGS.voiceVolume),
+    autoWaitMs: clampNumber(s.autoWaitMs, 500, 10000, DEFAULT_SETTINGS.autoWaitMs),
+  }
+}
+
+// localStorage 未対応 / 例外時のフォールバック
+let memoryStore: string | null = null
+
+function safeGetItem(): string | null {
+  try {
+    if (typeof localStorage === 'undefined') return memoryStore
+    return localStorage.getItem(STORAGE_KEY)
+  } catch {
+    return memoryStore
+  }
+}
+
+function safeSetItem(value: string): void {
+  memoryStore = value
+  try {
+    if (typeof localStorage === 'undefined') return
+    localStorage.setItem(STORAGE_KEY, value)
+  } catch {
+    // memoryStore に既に書いたので何もしない
+  }
+}
+
+/**
+ * localStorage から設定を読む。欠落キー / 不正 JSON はデフォルトで補完。
+ */
+export function loadSettings(): Settings {
+  const raw = safeGetItem()
+  if (!raw) return { ...DEFAULT_SETTINGS }
+
+  try {
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return { ...DEFAULT_SETTINGS }
+    const merged: Settings = {
+      ...DEFAULT_SETTINGS,
+      ...(parsed as Partial<Settings>),
+    }
+    return clampSettings(merged)
+  } catch {
+    return { ...DEFAULT_SETTINGS }
+  }
+}
+
+/**
+ * 設定を localStorage に保存する。clamp してから保存。
+ */
+export function saveSettings(s: Settings): void {
+  const clamped = clampSettings(s)
+  safeSetItem(JSON.stringify(clamped))
+}
+
+/** テスト用: in-memory フォールバックをリセット */
+export function __resetMemoryStoreForTest(): void {
+  memoryStore = null
+}


### PR DESCRIPTION
## 関連 Issue
closes #138

## 概要
ESC または Ctrl/Cmd+, で開く React オーバーレイの設定画面。テキスト表示速度・各音量・オート wait time を変更でき、localStorage で永続化、リアルタイムに renderer に反映。

## 変更ファイル
**新規:**
- \`frontend/src/game/settings.ts\` (Settings 型 + load/save/clamp + メモリ fallback)
- \`frontend/src/game/settings.test.ts\` (10 件)
- \`frontend/src/components/SettingsOverlay.tsx\` (モーダル UI、HTML range スライダー)

**修正:**
- \`frontend/src/game/AudioManager.ts\` (master gain 追加、setBgmVolume / setSeVolume)
- \`frontend/src/game/NovelRenderer.ts\` / \`RaycastRenderer.ts\` / \`TopDownRenderer.ts\` (applySettings)
- \`frontend/src/components/NovelPlayer.tsx\` / \`RPGPlayer.tsx\` (state + ⚙ ボタン + ショートカット + Overlay)

## 設計
- 設定の正本は React 側 (useState + localStorage)、renderer は applySettings で受動側
- volumes は 0..1、msPerChar は 0..500、autoWaitMs は 500..10000 で clamp
- Infinity → max にクランプ、NaN → デフォルトにフォールバック
- voiceVolume / autoWaitMs は #144 / #139 用に保存だけ（現状 consumer 無し）

## テスト
- \`npx tsc --noEmit\` パス
- \`npx vitest run\` 299 → 310 件 pass (settings 10 件 + AudioManager 既存維持)

## 後続 Issue
- #139 オートモード (autoWaitMs を消費)
- #144 voice 再生 (voiceVolume を消費)
- #140 typewriter ON/OFF: msPerChar=0 で代用済（さらに分かりやすい toggle が要るなら別 Issue）