### PR TITLE
fix: retroactive review 対応 — wasm-bytes 同期 + settings save debounce

### DIFF
--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Event, EventScene } from '../types'
 import { NovelRenderer } from '../game/NovelRenderer'
-import { type Settings, loadSettings, saveSettings } from '../game/settings'
+import { type Settings, loadSettings, makeDebouncedSaveSettings } from '../game/settings'
 import SettingsOverlay from './SettingsOverlay'
 
 interface NovelPlayerProps {
@@ -14,9 +14,11 @@ function NovelPlayer({ events, scenes, assetBaseUrl }: NovelPlayerProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const rendererRef = useRef<NovelRenderer | null>(null)
 
-  // 設定 (Issue #138): localStorage と同期
+  // 設定 (Issue #138): localStorage と同期。スライダー drag による書き込み連打は
+  // debounce で吸収する (review #155 should-2)
   const [settings, setSettings] = useState<Settings>(() => loadSettings())
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const debouncedSave = useMemo(() => makeDebouncedSaveSettings(300), [])
 
   // ライフサイクル管理: init + destroy
   useEffect(() => {
@@ -54,8 +56,15 @@ function NovelPlayer({ events, scenes, assetBaseUrl }: NovelPlayerProps) {
   // 設定変更を renderer に反映 + localStorage に保存 (#138)
   useEffect(() => {
     rendererRef.current?.applySettings(settings)
-    saveSettings(settings)
-  }, [settings])
+    debouncedSave.save(settings)
+  }, [settings, debouncedSave])
+
+  // unmount 時に debounce 中の保存を flush する（取りこぼし防止）
+  useEffect(() => {
+    return () => {
+      debouncedSave.flush()
+    }
+  }, [debouncedSave])
 
   // 設定パネルの開閉ショートカット (#138): Ctrl/Cmd + , で開く
   useEffect(() => {

--- a/frontend/src/components/RPGPlayer.tsx
+++ b/frontend/src/components/RPGPlayer.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { TopDownRenderer } from '../game/TopDownRenderer'
 import { RaycastRenderer } from '../game/RaycastRenderer'
 import { sampleRpgData } from '../game/sampleRpgData'
 import { RPGProject } from '../types/rpg'
-import { type Settings, loadSettings, saveSettings } from '../game/settings'
+import { type Settings, loadSettings, makeDebouncedSaveSettings } from '../game/settings'
 import SettingsOverlay from './SettingsOverlay'
 
 type RendererLike = {
@@ -22,9 +22,10 @@ function RPGPlayer({ gameData, view = 'topdown' }: RPGPlayerProps) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const rendererRef = useRef<RendererLike | null>(null)
 
-  // 設定 (Issue #138)
+  // 設定 (Issue #138) — slider drag による書き込み連打は debounce で吸収 (review #155 should-2)
   const [settings, setSettings] = useState<Settings>(() => loadSettings())
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const debouncedSave = useMemo(() => makeDebouncedSaveSettings(300), [])
 
   useEffect(() => {
     const container = containerRef.current
@@ -59,11 +60,18 @@ function RPGPlayer({ gameData, view = 'topdown' }: RPGPlayerProps) {
     }
   }, [gameData, view])
 
-  // 設定変更を renderer に反映 + 永続化 (#138)
+  // 設定変更を renderer に反映 + 永続化 (#138) — debounced
   useEffect(() => {
     rendererRef.current?.applySettings?.(settings)
-    saveSettings(settings)
-  }, [settings])
+    debouncedSave.save(settings)
+  }, [settings, debouncedSave])
+
+  // unmount 時に debounce 中の保存を flush
+  useEffect(() => {
+    return () => {
+      debouncedSave.flush()
+    }
+  }, [debouncedSave])
 
   // Ctrl/Cmd + , で設定パネル開閉 (#138)
   useEffect(() => {

--- a/frontend/src/game/settings.test.ts
+++ b/frontend/src/game/settings.test.ts
@@ -5,6 +5,7 @@ import {
   __resetMemoryStoreForTest,
   clampSettings,
   loadSettings,
+  makeDebouncedSaveSettings,
   saveSettings,
 } from './settings'
 
@@ -136,5 +137,56 @@ describe('settings', () => {
     expect(setSpy).toHaveBeenCalled()
     expect(loadSettings()).toEqual(s)
     expect(getSpy).toHaveBeenCalled()
+  })
+})
+
+describe('makeDebouncedSaveSettings (review #155 should-2)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('連続呼び出しは debounce され、最後の値だけ保存される', () => {
+    const { save } = makeDebouncedSaveSettings(100)
+    const s1: Settings = { ...DEFAULT_SETTINGS, msPerChar: 10 }
+    const s2: Settings = { ...DEFAULT_SETTINGS, msPerChar: 50 }
+    const s3: Settings = { ...DEFAULT_SETTINGS, msPerChar: 99 }
+
+    save(s1)
+    save(s2)
+    save(s3)
+    // wait 経過前は保存されていない
+    expect(loadSettings().msPerChar).toBe(DEFAULT_SETTINGS.msPerChar)
+
+    vi.advanceTimersByTime(100)
+    expect(loadSettings().msPerChar).toBe(99)
+  })
+
+  it('flush で即時保存できる', () => {
+    const { save, flush } = makeDebouncedSaveSettings(500)
+    save({ ...DEFAULT_SETTINGS, bgmVolume: 0.42 })
+    expect(loadSettings().bgmVolume).toBe(DEFAULT_SETTINGS.bgmVolume)
+    flush()
+    expect(loadSettings().bgmVolume).toBe(0.42)
+  })
+
+  it('cancel で pending 保存を破棄できる', () => {
+    const { save, cancel } = makeDebouncedSaveSettings(100)
+    save({ ...DEFAULT_SETTINGS, seVolume: 0.11 })
+    cancel()
+    vi.advanceTimersByTime(500)
+    expect(loadSettings().seVolume).toBe(DEFAULT_SETTINGS.seVolume)
+  })
+
+  it('独立した debouncer は state を共有しない', () => {
+    const a = makeDebouncedSaveSettings(100)
+    const b = makeDebouncedSaveSettings(100)
+    a.save({ ...DEFAULT_SETTINGS, msPerChar: 10 })
+    b.save({ ...DEFAULT_SETTINGS, msPerChar: 20 })
+    vi.advanceTimersByTime(100)
+    // 後勝ち (どちらも localStorage に書くので、最後の write が残る)
+    expect(loadSettings().msPerChar).toBe(20)
   })
 })

--- a/frontend/src/game/settings.ts
+++ b/frontend/src/game/settings.ts
@@ -114,3 +114,51 @@ export function saveSettings(s: Settings): void {
 export function __resetMemoryStoreForTest(): void {
   memoryStore = null
 }
+
+/**
+ * saveSettings の debounced 版を作る (review #155 should-2)。
+ * スライダーを drag するたび localStorage 書き込みが発生するのを抑える。
+ *
+ * @param waitMs 連続呼び出しが止まってから何 ms 後に保存するか (デフォルト 300ms)
+ */
+export function makeDebouncedSaveSettings(waitMs: number = 300): {
+  save: (s: Settings) => void
+  flush: () => void
+  cancel: () => void
+} {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let pending: Settings | null = null
+
+  const flush = () => {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+    if (pending !== null) {
+      saveSettings(pending)
+      pending = null
+    }
+  }
+
+  const cancel = () => {
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
+    pending = null
+  }
+
+  const save = (s: Settings) => {
+    pending = s
+    if (timer !== null) clearTimeout(timer)
+    timer = setTimeout(() => {
+      timer = null
+      if (pending !== null) {
+        saveSettings(pending)
+        pending = null
+      }
+    }, waitMs)
+  }
+
+  return { save, flush, cancel }
+}


### PR DESCRIPTION
## 関連
- name-name#134 (PR #156) follow-up
- name-name#138 (PR #155) follow-up

## 背景
session 379 で #150/#138/#134 の 3 PR をセルフレビュー省略のままマージしてしまった件、retroactive レビューで発見された must / should を 1 PR にまとめて修正。

## 修正
### must (#134 系): wasm-bytes.generated.ts stale
- \`parser/pkg/name_name_parser_bg.wasm\` は 288274 bytes に更新済だが、\`frontend/src/wasm/wasm-bytes.generated.ts\` ヘッダは 189537 のまま、base64 も古い
- predev/prebuild が auto-sync するため CF Pages 本番デプロイは自動で正しい wasm を含むが、fresh checkout 直後に \`npm test\` 等を直接走らせると stale で動く
- \`sync-wasm.mjs\` を実行して 288274 bytes 版に同期し commit

### should (#138 系): settings save debounce 不在
- スライダー drag 中に毎フレーム \`saveSettings → localStorage.setItem\` が走る問題
- \`makeDebouncedSaveSettings(waitMs)\` を \`settings.ts\` に追加 (save / flush / cancel API)
- \`NovelPlayer\` / \`RPGPlayer\` で \`useMemo\` 経由で debouncer 作成、unmount で flush

## レビューで誤指摘と判定して dismiss したもの
- #156 must-3 (round-trip 日本語キー喪失): name-name の \`test_roundtrip\` は Document equality のみ見る。522/522 は別リポ retro-decode の話
- #154 should-2 (RpgDialogBox.destroy で super.destroy 未呼出): 実際は line 264 で呼んでいる

## テスト
- vitest: 323 → 327 件 pass (debounce 4 件追加)
- tsc clean