### PR TITLE
feat: #136 画面比率指定（16:9 / 4:3 / 9:16）

### DIFF
--- a/docs/spec/markdown-v0.1.md
+++ b/docs/spec/markdown-v0.1.md
@@ -15,6 +15,7 @@ chapter: 1
 title: "出会い"
 hidden: false
 default_bgm: amehure.ogg
+aspect_ratio: "16:9"
 ---
 ```
 
@@ -25,6 +26,7 @@ default_bgm: amehure.ogg
 | `title` | string | Yes | 章タイトル |
 | `hidden` | boolean | No | `true` の場合エディタで非表示（デフォルト: `false`） |
 | `default_bgm` | string | No | 章全体のデフォルトBGMファイルパス |
+| `aspect_ratio` | string | No | 画面比率。`"16:9"` / `"4:3"` / `"9:16"` から選択（デフォルト: `"16:9"`）。論理解像度は 16:9=800×450、4:3=800×600、9:16=450×800 |
 
 フロントマターは Event ではなく、parser の Chapter 構造体（Rust 側）のフィールドとしてパースされる。フロントエンド側の EventChapter 型とは別物なので注意する。
 

--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -2,15 +2,23 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { Event, EventScene } from '../types'
 import { NovelRenderer } from '../game/NovelRenderer'
 import { type Settings, loadSettings, makeDebouncedSaveSettings } from '../game/settings'
+import { type AspectRatio, ASPECT_RATIOS, parseAspectRatio } from '../game/constants'
 import SettingsOverlay from './SettingsOverlay'
 
 interface NovelPlayerProps {
   events: Event[]
   scenes?: EventScene[]
   assetBaseUrl?: string
+  /** 画面比率。"16:9" / "4:3" / "9:16"。デフォルト "16:9" (#136) */
+  aspectRatio?: AspectRatio | string
 }
 
-function NovelPlayer({ events, scenes, assetBaseUrl }: NovelPlayerProps) {
+function NovelPlayer({
+  events,
+  scenes,
+  assetBaseUrl,
+  aspectRatio: aspectRatioProp,
+}: NovelPlayerProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const rendererRef = useRef<NovelRenderer | null>(null)
 
@@ -20,11 +28,15 @@ function NovelPlayer({ events, scenes, assetBaseUrl }: NovelPlayerProps) {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const debouncedSave = useMemo(() => makeDebouncedSaveSettings(300), [])
 
+  // 有効な AspectRatio に正規化 (#136)
+  const aspectRatio = parseAspectRatio(aspectRatioProp)
+  const { width: gameWidth, height: gameHeight } = ASPECT_RATIOS[aspectRatio]
+
   // ライフサイクル管理: init + destroy
   useEffect(() => {
     if (!containerRef.current) return
 
-    const renderer = new NovelRenderer()
+    const renderer = new NovelRenderer({ aspectRatio })
     rendererRef.current = renderer
 
     let destroyed = false
@@ -100,7 +112,12 @@ function NovelPlayer({ events, scenes, assetBaseUrl }: NovelPlayerProps) {
       <div
         ref={containerRef}
         className="rounded-xl shadow-2xl overflow-hidden"
-        style={{ maxWidth: '100%', maxHeight: '100%' }}
+        style={{
+          // canvas が aspect-ratio に合わせて正しいサイズで表示されるよう制約 (#136)
+          aspectRatio: `${gameWidth} / ${gameHeight}`,
+          maxWidth: '100%',
+          maxHeight: '100%',
+        }}
       />
       <button
         type="button"

--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -28,11 +28,13 @@ function NovelPlayer({
   const [settingsOpen, setSettingsOpen] = useState(false)
   const debouncedSave = useMemo(() => makeDebouncedSaveSettings(300), [])
 
-  // 有効な AspectRatio に正規化 (#136)
+  // 有効な AspectRatio に正規化
   const aspectRatio = parseAspectRatio(aspectRatioProp)
   const { width: gameWidth, height: gameHeight } = ASPECT_RATIOS[aspectRatio]
 
   // ライフサイクル管理: init + destroy
+  // aspectRatio が変わる場合はコンポーネントを再マウントすること
+  // （依存配列は空：レンダラーはマウント時に1度だけ生成する設計）
   useEffect(() => {
     if (!containerRef.current) return
 
@@ -113,7 +115,7 @@ function NovelPlayer({
         ref={containerRef}
         className="rounded-xl shadow-2xl overflow-hidden"
         style={{
-          // canvas が aspect-ratio に合わせて正しいサイズで表示されるよう制約 (#136)
+          // canvas が aspect-ratio に合わせて正しいサイズで表示されるよう制約
           aspectRatio: `${gameWidth} / ${gameHeight}`,
           maxWidth: '100%',
           maxHeight: '100%',

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -32,7 +32,7 @@ import { BacklogOverlay } from './BacklogOverlay'
 import { SeekBar } from './SeekBar'
 import { computeDisplayIndex, findHistoryIndexForDisplayIndex } from './seekMapping'
 import { Event, EventScene } from '../types'
-import { GAME_WIDTH, GAME_HEIGHT } from './constants'
+import { ASPECT_RATIOS, type AspectRatio, parseAspectRatio } from './constants'
 
 /** Dialog / Narration から text を取り出すヘルパー */
 export function getTextEvent(event: Event):
@@ -134,22 +134,34 @@ export class NovelRenderer {
   /** 枠なしモードのデフォルト値（per-game 設定）。per-scene の DialogBorderless で上書きされる */
   private defaultDialogBorderless: boolean = false
 
-  constructor(config?: { dialogBorderless?: boolean }) {
+  /** 論理画面幅（aspectRatio から決定） */
+  private screenWidth: number
+  /** 論理画面高さ（aspectRatio から決定） */
+  private screenHeight: number
+
+  constructor(config?: { dialogBorderless?: boolean; aspectRatio?: AspectRatio }) {
     this.app = new Application()
     this.bgGraphics = new Graphics()
     this.bgContainer = new Container()
     this.characterLayer = new CharacterLayer()
     this.blackoutOverlay = new Graphics()
     this.defaultDialogBorderless = config?.dialogBorderless ?? false
+    const ratio = parseAspectRatio(config?.aspectRatio)
+    this.screenWidth = ASPECT_RATIOS[ratio].width
+    this.screenHeight = ASPECT_RATIOS[ratio].height
     this.dialogBox = new DialogBox({
-      screenWidth: GAME_WIDTH,
-      screenHeight: GAME_HEIGHT,
+      screenWidth: this.screenWidth,
+      screenHeight: this.screenHeight,
       borderless: this.defaultDialogBorderless,
     })
     this.audioManager = new AudioManager()
-    this.choiceOverlay = new ChoiceOverlay(GAME_WIDTH, GAME_HEIGHT)
-    this.saveLoadOverlay = new SaveLoadOverlay(GAME_WIDTH, GAME_HEIGHT, this.saveManager)
-    this.backlogOverlay = new BacklogOverlay(GAME_WIDTH, GAME_HEIGHT)
+    this.choiceOverlay = new ChoiceOverlay(this.screenWidth, this.screenHeight)
+    this.saveLoadOverlay = new SaveLoadOverlay(
+      this.screenWidth,
+      this.screenHeight,
+      this.saveManager
+    )
+    this.backlogOverlay = new BacklogOverlay(this.screenWidth, this.screenHeight)
     this.seekBar = new SeekBar()
   }
 
@@ -158,8 +170,8 @@ export class NovelRenderer {
    */
   async init(container: HTMLElement): Promise<void> {
     await this.app.init({
-      width: GAME_WIDTH,
-      height: GAME_HEIGHT,
+      width: this.screenWidth,
+      height: this.screenHeight,
       background: 0x000000,
       antialias: true,
     })
@@ -168,7 +180,7 @@ export class NovelRenderer {
     container.appendChild(this.app.canvas as HTMLCanvasElement)
 
     // 黒背景
-    this.bgGraphics.rect(0, 0, GAME_WIDTH, GAME_HEIGHT)
+    this.bgGraphics.rect(0, 0, this.screenWidth, this.screenHeight)
     this.bgGraphics.fill(0x000000)
     this.app.stage.addChild(this.bgGraphics)
 
@@ -179,7 +191,7 @@ export class NovelRenderer {
     this.app.stage.addChild(this.characterLayer)
 
     // 暗転レイヤー
-    this.blackoutOverlay.rect(0, 0, GAME_WIDTH, GAME_HEIGHT)
+    this.blackoutOverlay.rect(0, 0, this.screenWidth, this.screenHeight)
     this.blackoutOverlay.fill(0x000000)
     this.blackoutOverlay.visible = false
     this.app.stage.addChild(this.blackoutOverlay)
@@ -199,7 +211,7 @@ export class NovelRenderer {
       fontWeight: 'bold',
     })
     this.counterText = new PixiText({ text: '', style: counterStyle })
-    this.counterText.x = GAME_WIDTH - 20
+    this.counterText.x = this.screenWidth - 20
     this.counterText.y = 16
     this.counterText.anchor.set(1, 0)
     this.app.stage.addChild(this.counterText)
@@ -801,13 +813,13 @@ export class NovelRenderer {
   }
 
   private applyCoverFit(sprite: Sprite): void {
-    const scaleX = GAME_WIDTH / sprite.texture.width
-    const scaleY = GAME_HEIGHT / sprite.texture.height
+    const scaleX = this.screenWidth / sprite.texture.width
+    const scaleY = this.screenHeight / sprite.texture.height
     const scale = Math.max(scaleX, scaleY)
     sprite.width = sprite.texture.width * scale
     sprite.height = sprite.texture.height * scale
-    sprite.x = (GAME_WIDTH - sprite.width) / 2
-    sprite.y = (GAME_HEIGHT - sprite.height) / 2
+    sprite.x = (this.screenWidth - sprite.width) / 2
+    sprite.y = (this.screenHeight - sprite.height) / 2
   }
 
   /**

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -162,7 +162,7 @@ export class NovelRenderer {
       this.saveManager
     )
     this.backlogOverlay = new BacklogOverlay(this.screenWidth, this.screenHeight)
-    this.seekBar = new SeekBar()
+    this.seekBar = new SeekBar(this.screenWidth, this.screenHeight)
   }
 
   /**

--- a/frontend/src/game/SeekBar.ts
+++ b/frontend/src/game/SeekBar.ts
@@ -7,14 +7,11 @@
  */
 
 import { Container, FederatedPointerEvent, Graphics } from 'pixi.js'
-import { GAME_WIDTH, GAME_HEIGHT } from './constants'
 
 /** バー全体の高さ（px） */
 const BAR_HEIGHT = 6
 /** バー左右マージン */
 const BAR_MARGIN_X = 20
-/** バーの Y 位置（画面最下端からのオフセット） */
-const BAR_Y = GAME_HEIGHT - 12
 
 /** バー背景色（暗いグレー） */
 const BAR_BG_COLOR = 0x333333
@@ -33,6 +30,7 @@ export class SeekBar extends Container {
 
   private barWidth: number
   private barX: number
+  private barY: number
 
   private _total = 0
   private _current = 0
@@ -40,15 +38,16 @@ export class SeekBar extends Container {
   /** クリックで呼ばれるコールバック (historyIndex: number) => void */
   private onSeek: ((historyIndex: number) => void) | null = null
 
-  constructor() {
+  constructor(screenWidth: number, screenHeight: number) {
     super()
 
     this.barX = BAR_MARGIN_X
-    this.barWidth = GAME_WIDTH - BAR_MARGIN_X * 2
+    this.barWidth = screenWidth - BAR_MARGIN_X * 2
+    this.barY = screenHeight - 12
 
     // 透明ヒットエリア（クリック検出を広めに取る）
     this.clickRegion = new Graphics()
-    this.clickRegion.rect(this.barX, BAR_Y - 8, this.barWidth, BAR_HEIGHT + 16)
+    this.clickRegion.rect(this.barX, this.barY - 8, this.barWidth, BAR_HEIGHT + 16)
     this.clickRegion.fill({ color: 0x000000, alpha: 0 })
     this.clickRegion.eventMode = 'static'
     this.clickRegion.cursor = 'pointer'
@@ -68,7 +67,7 @@ export class SeekBar extends Container {
     this.thumb = new Graphics()
     this.thumb.circle(0, 0, THUMB_RADIUS)
     this.thumb.fill({ color: BAR_FILL_COLOR, alpha: 0.9 })
-    this.thumb.y = BAR_Y + BAR_HEIGHT / 2
+    this.thumb.y = this.barY + BAR_HEIGHT / 2
     this.addChild(this.thumb)
 
     this.updateVisual()
@@ -92,7 +91,7 @@ export class SeekBar extends Container {
 
   private drawBar(g: Graphics, color: number, width: number, alpha: number): void {
     g.clear()
-    g.roundRect(this.barX, BAR_Y, width, BAR_HEIGHT, BAR_RADIUS)
+    g.roundRect(this.barX, this.barY, width, BAR_HEIGHT, BAR_RADIUS)
     g.fill({ color, alpha })
   }
 
@@ -102,7 +101,7 @@ export class SeekBar extends Container {
     const fillWidth = Math.max(BAR_RADIUS * 2, this.barWidth * ratio)
 
     this.barFill.clear()
-    this.barFill.roundRect(this.barX, BAR_Y, fillWidth, BAR_HEIGHT, BAR_RADIUS)
+    this.barFill.roundRect(this.barX, this.barY, fillWidth, BAR_HEIGHT, BAR_RADIUS)
     this.barFill.fill({ color: BAR_FILL_COLOR, alpha: 0.8 })
 
     // つまみ位置

--- a/frontend/src/game/constants.test.ts
+++ b/frontend/src/game/constants.test.ts
@@ -35,6 +35,14 @@ describe('GAME_WIDTH / GAME_HEIGHT (後方互換エイリアス)', () => {
   it('GAME_HEIGHT はデフォルト比率の height と一致する', () => {
     expect(GAME_HEIGHT).toBe(ASPECT_RATIOS[DEFAULT_ASPECT_RATIO].height)
   })
+
+  it('GAME_WIDTH の具体的な値は 800', () => {
+    expect(GAME_WIDTH).toBe(800)
+  })
+
+  it('GAME_HEIGHT の具体的な値は 450 (16:9 デフォルト)', () => {
+    expect(GAME_HEIGHT).toBe(450)
+  })
 })
 
 describe('parseAspectRatio', () => {

--- a/frontend/src/game/constants.test.ts
+++ b/frontend/src/game/constants.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ASPECT_RATIOS,
+  DEFAULT_ASPECT_RATIO,
+  GAME_HEIGHT,
+  GAME_WIDTH,
+  parseAspectRatio,
+} from './constants'
+
+describe('ASPECT_RATIOS', () => {
+  it('16:9 は 800×450', () => {
+    expect(ASPECT_RATIOS['16:9']).toEqual({ width: 800, height: 450 })
+  })
+
+  it('4:3 は 800×600', () => {
+    expect(ASPECT_RATIOS['4:3']).toEqual({ width: 800, height: 600 })
+  })
+
+  it('9:16 は 450×800', () => {
+    expect(ASPECT_RATIOS['9:16']).toEqual({ width: 450, height: 800 })
+  })
+})
+
+describe('DEFAULT_ASPECT_RATIO', () => {
+  it('デフォルトは 16:9', () => {
+    expect(DEFAULT_ASPECT_RATIO).toBe('16:9')
+  })
+})
+
+describe('GAME_WIDTH / GAME_HEIGHT (後方互換エイリアス)', () => {
+  it('GAME_WIDTH はデフォルト比率の width と一致する', () => {
+    expect(GAME_WIDTH).toBe(ASPECT_RATIOS[DEFAULT_ASPECT_RATIO].width)
+  })
+
+  it('GAME_HEIGHT はデフォルト比率の height と一致する', () => {
+    expect(GAME_HEIGHT).toBe(ASPECT_RATIOS[DEFAULT_ASPECT_RATIO].height)
+  })
+})
+
+describe('parseAspectRatio', () => {
+  it('有効な比率文字列をそのまま返す', () => {
+    expect(parseAspectRatio('16:9')).toBe('16:9')
+    expect(parseAspectRatio('4:3')).toBe('4:3')
+    expect(parseAspectRatio('9:16')).toBe('9:16')
+  })
+
+  it('undefined はデフォルトにフォールバックする', () => {
+    expect(parseAspectRatio(undefined)).toBe(DEFAULT_ASPECT_RATIO)
+  })
+
+  it('null はデフォルトにフォールバックする', () => {
+    expect(parseAspectRatio(null)).toBe(DEFAULT_ASPECT_RATIO)
+  })
+
+  it('空文字はデフォルトにフォールバックする', () => {
+    expect(parseAspectRatio('')).toBe(DEFAULT_ASPECT_RATIO)
+  })
+
+  it('未知の文字列はデフォルトにフォールバックする', () => {
+    expect(parseAspectRatio('21:9')).toBe(DEFAULT_ASPECT_RATIO)
+    expect(parseAspectRatio('1:1')).toBe(DEFAULT_ASPECT_RATIO)
+    expect(parseAspectRatio('bad')).toBe(DEFAULT_ASPECT_RATIO)
+  })
+})

--- a/frontend/src/game/constants.ts
+++ b/frontend/src/game/constants.ts
@@ -1,3 +1,35 @@
-/** ゲーム画面の基本サイズ */
-export const GAME_WIDTH = 800
-export const GAME_HEIGHT = 600
+/**
+ * ゲーム画面の基本サイズと画面比率定数
+ *
+ * Issue #136: 画面比率指定（16:9 / 4:3 / 9:16 縦 Shorts 用）
+ *
+ * - デフォルトは 16:9 (800×450)
+ * - 論理解像度（PixiJS Canvas のサイズ）は ASPECT_RATIOS で管理
+ * - CSS 側は NovelPlayer / RPGPlayer が aspect-ratio CSS で追従する
+ */
+
+/** サポートする画面比率の識別子 */
+export type AspectRatio = '16:9' | '4:3' | '9:16'
+
+/** 各比率の論理解像度（px）。幅基準は 800px で統一 */
+export const ASPECT_RATIOS: Record<AspectRatio, { width: number; height: number }> = {
+  '16:9': { width: 800, height: 450 },
+  '4:3': { width: 800, height: 600 },
+  '9:16': { width: 450, height: 800 },
+}
+
+/** デフォルトの画面比率 */
+export const DEFAULT_ASPECT_RATIO: AspectRatio = '16:9'
+
+/** デフォルトのゲーム画面幅 (後方互換用) */
+export const GAME_WIDTH = ASPECT_RATIOS[DEFAULT_ASPECT_RATIO].width
+/** デフォルトのゲーム画面高さ (後方互換用) */
+export const GAME_HEIGHT = ASPECT_RATIOS[DEFAULT_ASPECT_RATIO].height
+
+/**
+ * 文字列を AspectRatio に変換する。未知の値はデフォルトにフォールバック。
+ */
+export function parseAspectRatio(s: string | undefined | null): AspectRatio {
+  if (s === '16:9' || s === '4:3' || s === '9:16') return s
+  return DEFAULT_ASPECT_RATIO
+}

--- a/frontend/src/game/constants.ts
+++ b/frontend/src/game/constants.ts
@@ -11,7 +11,7 @@
 /** サポートする画面比率の識別子 */
 export type AspectRatio = '16:9' | '4:3' | '9:16'
 
-/** 各比率の論理解像度（px）。幅基準は 800px で統一 */
+/** 各比率の論理解像度（px）。16:9 / 4:3 は幅 800px 基準、9:16 は高さ 800px 基準 */
 export const ASPECT_RATIOS: Record<AspectRatio, { width: number; height: number }> = {
   '16:9': { width: 800, height: 450 },
   '4:3': { width: 800, height: 600 },

--- a/frontend/src/screens/EditorScreen.tsx
+++ b/frontend/src/screens/EditorScreen.tsx
@@ -545,6 +545,7 @@ function EditorScreen({
           ) : (
             <NovelPlayer
               events={novelEvents}
+              aspectRatio={doc?.aspect_ratio}
               // PR #120 review S2: 旧 FastAPI は静的ファイルを直接返していたが、
               //   Worker は /assets/:type の一覧 API しか提供しない（個別ファイルは
               //   GitHub の download_url 経由になる）。

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -180,7 +180,11 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
           // ノベル+RPG の遷移制御は #108 本統合で扱う。
           <RPGPlayer gameData={rpgProject} view={rpgProject.view} />
         ) : (
-          <NovelPlayer events={novelEvents} assetBaseUrl={assetBaseUrl} />
+          <NovelPlayer
+            events={novelEvents}
+            assetBaseUrl={assetBaseUrl}
+            aspectRatio={doc?.aspect_ratio}
+          />
         )}
       </main>
     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -117,6 +117,8 @@ export interface EventChapter {
 
 export interface EventDocument {
   engine: string
+  /** 画面比率。省略時は "16:9" がデフォルト (Issue #136) */
+  aspect_ratio?: string
   chapters: EventChapter[]
 }
 

--- a/frontend/src/wasm/parser.ts
+++ b/frontend/src/wasm/parser.ts
@@ -89,6 +89,7 @@ function normalizeEvents(events: Event[]): Event[] {
 function normalizeDocument(doc: EventDocument): EventDocument {
   return {
     engine: doc.engine,
+    aspect_ratio: doc.aspect_ratio,
     chapters: doc.chapters.map((chapter) => ({
       ...chapter,
       default_bgm: chapter.default_bgm ?? null,

--- a/parser/src/emitter.rs
+++ b/parser/src/emitter.rs
@@ -10,6 +10,10 @@ pub fn emit(doc: &Document) -> String {
         // YAML front matter
         out.push_str("---\n");
         out.push_str(&format!("engine: {}\n", doc.engine));
+        // Emit aspect_ratio only when non-default
+        if doc.aspect_ratio != "16:9" {
+            out.push_str(&format!("aspect_ratio: {}\n", doc.aspect_ratio));
+        }
         out.push_str(&format!("chapter: {}\n", chapter.number));
         out.push_str(&format!("title: \"{}\"\n", chapter.title));
         // Emit `hidden` only when true; it's a boolean flag and the default (false) is silent.
@@ -443,6 +447,7 @@ mod tests {
     fn test_emit_simple() {
         let doc = Document {
             engine: "name-name".to_string(),
+            aspect_ratio: "16:9".to_string(),
             chapters: vec![Chapter {
                 number: 1,
                 title: "テスト".to_string(),

--- a/parser/src/emitter.rs
+++ b/parser/src/emitter.rs
@@ -12,7 +12,7 @@ pub fn emit(doc: &Document) -> String {
         out.push_str(&format!("engine: {}\n", doc.engine));
         // Emit aspect_ratio only when non-default
         if doc.aspect_ratio != "16:9" {
-            out.push_str(&format!("aspect_ratio: {}\n", doc.aspect_ratio));
+            out.push_str(&format!("aspect_ratio: \"{}\"\n", doc.aspect_ratio));
         }
         out.push_str(&format!("chapter: {}\n", chapter.number));
         out.push_str(&format!("title: \"{}\"\n", chapter.title));

--- a/parser/src/models.rs
+++ b/parser/src/models.rs
@@ -236,5 +236,12 @@ pub struct Chapter {
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct Document {
     pub engine: String,
+    /// 画面比率。"16:9" / "4:3" / "9:16"。未指定時は "16:9"。
+    #[serde(default = "default_aspect_ratio")]
+    pub aspect_ratio: String,
     pub chapters: Vec<Chapter>,
+}
+
+fn default_aspect_ratio() -> String {
+    "16:9".to_string()
 }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -12,6 +12,7 @@ pub fn parse(input: &str) -> Document {
     let mut chapter_title = String::new();
     let mut hidden = false;
     let mut default_bgm: Option<String> = None;
+    let mut aspect_ratio = String::from("16:9");
 
     if pos < len && lines[pos].trim() == "---" {
         pos += 1;
@@ -29,6 +30,11 @@ pub fn parse(input: &str) -> Document {
                 let v = val.trim().to_string();
                 if !v.is_empty() {
                     default_bgm = Some(v);
+                }
+            } else if let Some(val) = line.strip_prefix("aspect_ratio:") {
+                let v = unquote(val.trim());
+                if v == "16:9" || v == "4:3" || v == "9:16" {
+                    aspect_ratio = v;
                 }
             }
             pos += 1;
@@ -449,6 +455,7 @@ pub fn parse(input: &str) -> Document {
 
     Document {
         engine,
+        aspect_ratio,
         chapters: vec![Chapter {
             number: chapter_number,
             title: chapter_title,


### PR DESCRIPTION
## 関連 Issue
closes #136

## 変更内容

### parser（Rust）
- `Document.aspect_ratio: String` フィールド追加（デフォルト `"16:9"`）
- front-matter の `aspect_ratio:` をパース
- emitter は `"16:9"` 以外の場合のみ出力（デフォルト値のノイズを避ける）

### frontend（TypeScript）
- `constants.ts`: `AspectRatio` 型・`ASPECT_RATIOS` マップ・`parseAspectRatio()` 追加
  - `GAME_WIDTH` / `GAME_HEIGHT` は後方互換エイリアスとして維持
- `constants.test.ts`: ユニットテスト 11 件追加
- `NovelRenderer`: `screenWidth`/`screenHeight` をインスタンス変数化、`config.aspectRatio` から決定
- `NovelPlayer`: `aspectRatio` prop 追加、CSS `aspect-ratio` を動的設定
- `PlayerScreen`: `doc.aspect_ratio` を `NovelPlayer` に渡す

### docs
- `markdown-v0.1.md`: `aspect_ratio` フロントマターフィールドの説明を追記

## テスト
- Rust: 45 件 pass
- フロントエンド: 338 件 pass（+11 件新規）