### PR TITLE
feat: #139 オートモード

### DIFF
--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -53,6 +53,8 @@ function NovelPlayer({
       if (assetBaseUrl) {
         renderer.setAssetBaseUrl(assetBaseUrl)
       }
+      // renderer が手動操作で autoMode を OFF にしたとき React state を同期 (#139)
+      renderer.setOnAutoModeChange((on) => setAutoMode(on))
       // init 完了直後に現在の settings を反映 (#138)
       renderer.applySettings(settings)
       if (scenes && scenes.length > 0) {

--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -26,6 +26,8 @@ function NovelPlayer({
   // debounce で吸収する (review #155 should-2)
   const [settings, setSettings] = useState<Settings>(() => loadSettings())
   const [settingsOpen, setSettingsOpen] = useState(false)
+  // オートモード ON/OFF (#139)
+  const [autoMode, setAutoMode] = useState(false)
   const debouncedSave = useMemo(() => makeDebouncedSaveSettings(300), [])
 
   // 有効な AspectRatio に正規化
@@ -109,6 +111,15 @@ function NovelPlayer({
     }
   }, [events, scenes])
 
+  // オートモード変更を renderer に反映 (#139)
+  useEffect(() => {
+    rendererRef.current?.setAutoMode(autoMode)
+  }, [autoMode])
+
+  const handleAutoToggle = () => {
+    setAutoMode((v) => !v)
+  }
+
   return (
     <div className="relative w-full h-full flex items-center justify-center bg-gradient-to-br from-slate-800 to-slate-900">
       <div
@@ -121,6 +132,20 @@ function NovelPlayer({
           maxHeight: '100%',
         }}
       />
+      {/* オートモードボタン (#139) */}
+      <button
+        type="button"
+        onClick={handleAutoToggle}
+        aria-label={autoMode ? 'オートモードをオフにする' : 'オートモードをオンにする'}
+        title="オートモード (A)"
+        className={`absolute top-3 right-14 w-9 h-9 flex items-center justify-center rounded-full text-sm font-bold transition-colors ${
+          autoMode
+            ? 'bg-blue-500/80 hover:bg-blue-500 text-white'
+            : 'bg-black/50 hover:bg-black/70 text-white/80 hover:text-white'
+        }`}
+      >
+        A
+      </button>
       <button
         type="button"
         onClick={() => setSettingsOpen(true)}

--- a/frontend/src/game/DialogBox.ts
+++ b/frontend/src/game/DialogBox.ts
@@ -79,6 +79,11 @@ export class DialogBox extends Container {
   private msPerChar: number
   /** 続きインジケーターを「表示したい」かどうか。実表示は typewriter 完了後に解禁 */
   private indicatorWanted: boolean = false
+  /**
+   * typewriter 表示完了時に1度だけ呼ばれるコールバック。
+   * setDialog() ごとに上書きされる。オートモード (#139) で使用。
+   */
+  private onTypingDone: (() => void) | null = null
 
   private ticker: Ticker
 
@@ -164,7 +169,14 @@ export class DialogBox extends Container {
         if (next.displayedCharCount !== this.typewriter.displayedCharCount) {
           this.dialogText.text = visibleText(next)
         }
+        const justFinished = isTypingActive(this.typewriter) && !isTypingActive(next)
         this.typewriter = next
+        // タイピング完了した瞬間にコールバックを1度だけ呼ぶ
+        if (justFinished && this.onTypingDone) {
+          const cb = this.onTypingDone
+          this.onTypingDone = null
+          cb()
+        }
       }
 
       // インジケーターは「表示したい」かつ「typewriter 完了」のときのみ可視
@@ -215,8 +227,10 @@ export class DialogBox extends Container {
    *
    * 枠なしモード（borderless=true）では name を無視して nameBox を非表示にする。
    * setBorderless(false) で枠ありに戻したあとも、nameBox の復元はこのメソッドの呼び出し時に行う。
+   *
+   * @param onTypingDone タイピング完了時に1度だけ呼ばれるコールバック（オートモード用）
    */
-  setDialog(name: string | null, text: string): void {
+  setDialog(name: string | null, text: string, onTypingDone?: (() => void) | null): void {
     // 話者名（枠なしモードでは常に非表示）
     if (name && !this.borderless) {
       this.nameText.text = name
@@ -236,6 +250,13 @@ export class DialogBox extends Container {
     const lines = wordwrap(text, maxTextWidth, font)
     this.typewriter = startTypewriter(lines.join('\n'))
     this.dialogText.text = ''
+    // タイピング完了コールバックをセット（空テキストはタイプライターが動かないので即呼び出し）
+    this.onTypingDone = onTypingDone ?? null
+    if (!isTypingActive(this.typewriter) && this.onTypingDone) {
+      const cb = this.onTypingDone
+      this.onTypingDone = null
+      cb()
+    }
   }
 
   /**
@@ -254,6 +275,8 @@ export class DialogBox extends Container {
     if (!isTypingActive(this.typewriter)) return
     this.typewriter = typewriterSkip(this.typewriter)
     this.dialogText.text = visibleText(this.typewriter)
+    // スキップ時はオートモードコールバックを破棄（手動操作なので自動進行しない）
+    this.onTypingDone = null
   }
 
   /**

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -345,6 +345,7 @@ export class NovelRenderer {
 
   /**
    * 設定（テキスト速度・音量）をリアルタイムに反映する。
+   * voiceVolume は #144 voice 実装後に対応予定。
    */
   applySettings(settings: {
     msPerChar: number
@@ -372,7 +373,8 @@ export class NovelRenderer {
       clearTimeout(this.autoTimer)
       this.autoTimer = null
     }
-    // React state との同期
+    // React state との同期。コールバック内で setAutoMode が再度呼ばれても
+    // 同値 no-op（上の早期 return）で無限ループを防いでいる。
     this.onAutoModeChange?.(on)
   }
 
@@ -598,6 +600,10 @@ export class NovelRenderer {
   /**
    * typewriter 表示中なら全文表示にスキップ、完了済みなら次イベントへ進む (#137)。
    * advance() / クリック / Enter / Space / ArrowRight 共通の入力ハンドラから呼ぶ。
+   *
+   * 呼び出し元は必ず先に setAutoMode(false) してから本メソッドを呼ぶこと。
+   * skipTypewriter() 内は onTypingDone を破棄するが、この時点では autoMode がすでに
+   * false になっているため、次の render() でコールバックがセットされず自動進行しない。
    */
   private advanceOrSkipTypewriter(): void {
     if (this.dialogBox.isTyping()) {

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -139,6 +139,13 @@ export class NovelRenderer {
   /** 論理画面高さ（aspectRatio から決定） */
   private screenHeight: number
 
+  /** オートモード ON/OFF (#139) */
+  private autoMode: boolean = false
+  /** オートモード待機タイマー（destroy 時・手動操作時にキャンセル） */
+  private autoTimer: ReturnType<typeof setTimeout> | null = null
+  /** オートモード待機時間 ms（settings.autoWaitMs から更新） */
+  private autoWaitMs: number = 2000
+
   constructor(config?: { dialogBorderless?: boolean; aspectRatio?: AspectRatio }) {
     this.app = new Application()
     this.bgGraphics = new Graphics()
@@ -332,12 +339,36 @@ export class NovelRenderer {
 
   /**
    * 設定（テキスト速度・音量）をリアルタイムに反映する。
-   * Issue #138。autoWaitMs / voiceVolume はここでは使わない（将来用）。
    */
-  applySettings(settings: { msPerChar: number; bgmVolume: number; seVolume: number }): void {
+  applySettings(settings: {
+    msPerChar: number
+    bgmVolume: number
+    seVolume: number
+    autoWaitMs?: number
+  }): void {
     this.dialogBox.setMsPerChar(settings.msPerChar)
     this.audioManager.setBgmVolume(settings.bgmVolume)
     this.audioManager.setSeVolume(settings.seVolume)
+    if (settings.autoWaitMs !== undefined) {
+      this.autoWaitMs = settings.autoWaitMs
+    }
+  }
+
+  /**
+   * オートモードの ON/OFF を切り替える (#139)。
+   * OFF にした場合は待機中のオートタイマーをキャンセルする。
+   */
+  setAutoMode(on: boolean): void {
+    this.autoMode = on
+    if (!on && this.autoTimer) {
+      clearTimeout(this.autoTimer)
+      this.autoTimer = null
+    }
+  }
+
+  /** オートモードの現在状態を取得する */
+  isAutoMode(): boolean {
+    return this.autoMode
   }
 
   /**
@@ -355,6 +386,10 @@ export class NovelRenderer {
     if (this.waitTimer) {
       clearTimeout(this.waitTimer)
       this.waitTimer = null
+    }
+    if (this.autoTimer) {
+      clearTimeout(this.autoTimer)
+      this.autoTimer = null
     }
     this.audioManager.destroy()
     this.characterLayer.clear()
@@ -564,6 +599,8 @@ export class NovelRenderer {
       return
     }
     if (this.saveLoadOverlay.visible) return
+    // 手動クリック/タップでオートモードをキャンセル (#139)
+    this.setAutoMode(false)
     this.advanceOrSkipTypewriter()
   }
 
@@ -617,9 +654,12 @@ export class NovelRenderer {
       case ' ':
       case 'Enter':
         e.preventDefault()
+        // 手動キー操作でオートモードをキャンセル (#139)
+        this.setAutoMode(false)
         this.advanceOrSkipTypewriter()
         break
       case 'ArrowRight':
+        this.setAutoMode(false)
         this.advanceOrSkipTypewriter()
         break
       case 'ArrowLeft':
@@ -936,7 +976,9 @@ export class NovelRenderer {
 
     // 空行 = 改ページ（テキストクリア後に次行へ自動進行はしない。空表示する）
     const name = textEvt.type === 'dialog' ? textEvt.character : null
-    this.dialogBox.setDialog(name, line)
+    // オートモード時はタイピング完了後に autoWaitMs 待機してから自動進行 (#139)
+    const onTypingDone = this.autoMode ? () => this.scheduleAutoAdvance() : null
+    this.dialogBox.setDialog(name, line, onTypingDone)
 
     // 最後のテキスト行かつ最後のイベントならインジケーター非表示
     const isLastText = this.textIndex >= textEvt.text.length - 1
@@ -945,6 +987,24 @@ export class NovelRenderer {
 
     this.updateCounter()
     this.updateSeekBar()
+  }
+
+  /**
+   * オートモード: autoWaitMs 後に advance() を呼ぶタイマーをセット (#139)。
+   * 選択肢待ち・Wait 待ち中は発動しない。
+   */
+  private scheduleAutoAdvance(): void {
+    if (!this.autoMode) return
+    if (this.waitingForChoice || this.waitingForWait) return
+    if (this.autoTimer) {
+      clearTimeout(this.autoTimer)
+    }
+    this.autoTimer = setTimeout(() => {
+      this.autoTimer = null
+      if (this.autoMode && !this.waitingForChoice && !this.waitingForWait) {
+        this.advance()
+      }
+    }, this.autoWaitMs)
   }
 
   private updateCounter(): void {

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -144,7 +144,9 @@ export class NovelRenderer {
   /** オートモード待機タイマー（destroy 時・手動操作時にキャンセル） */
   private autoTimer: ReturnType<typeof setTimeout> | null = null
   /** オートモード待機時間 ms（settings.autoWaitMs から更新） */
-  private autoWaitMs: number = 2000
+  private autoWaitMs: number = 2500
+  /** autoMode 変更時の React 側同期コールバック */
+  private onAutoModeChange: ((on: boolean) => void) | null = null
 
   constructor(config?: { dialogBorderless?: boolean; aspectRatio?: AspectRatio }) {
     this.app = new Application()
@@ -294,6 +296,10 @@ export class NovelRenderer {
       clearTimeout(this.waitTimer)
       this.waitTimer = null
     }
+    if (this.autoTimer) {
+      clearTimeout(this.autoTimer)
+      this.autoTimer = null
+    }
     this.choiceOverlay.hide()
     this.audioManager.stopBgm(0)
     this.clearBackground()
@@ -357,13 +363,22 @@ export class NovelRenderer {
   /**
    * オートモードの ON/OFF を切り替える (#139)。
    * OFF にした場合は待機中のオートタイマーをキャンセルする。
+   * React 側から呼ぶ場合は setAutoMode、renderer 内部から呼ぶ場合も同じメソッドを使う。
    */
   setAutoMode(on: boolean): void {
+    if (this.autoMode === on) return
     this.autoMode = on
     if (!on && this.autoTimer) {
       clearTimeout(this.autoTimer)
       this.autoTimer = null
     }
+    // React state との同期
+    this.onAutoModeChange?.(on)
+  }
+
+  /** オートモード変更コールバックを登録する（NovelPlayer が setAutoMode(false) を検知するため） */
+  setOnAutoModeChange(cb: (on: boolean) => void): void {
+    this.onAutoModeChange = cb
   }
 
   /** オートモードの現在状態を取得する */
@@ -663,6 +678,7 @@ export class NovelRenderer {
         this.advanceOrSkipTypewriter()
         break
       case 'ArrowLeft':
+        this.setAutoMode(false)
         this.goBack()
         break
       case 's':


### PR DESCRIPTION
## 関連 Issue
closes #139

## 変更内容

### DialogBox
- `onTypingDone` コールバックフィールド追加
- `setDialog(name, text, onTypingDone?)` でコールバックを受け取り、タイピング完了時に1度だけ呼ぶ
- `skipTypewriter()` 時はコールバックを破棄（手動スキップなので自動進行しない）
- 空テキストはタイプライターが動かないため `setDialog()` 内で即時呼び出し

### NovelRenderer
- `autoMode / autoTimer / autoWaitMs` フィールド追加
- `setAutoMode(on)` / `isAutoMode()` パブリック API 追加
- `scheduleAutoAdvance()`: `autoWaitMs` 後に `advance()` を発火（選択肢・Wait 中は発動しない）
- `render()` でオートモード時は `onTypingDone` に `scheduleAutoAdvance` をセット
- クリック / Space / Enter / ArrowRight の手動操作でオートモードを OFF にキャンセル
- `applySettings()` に `autoWaitMs?` 引数を追加
- `destroy()` で `autoTimer` をキャンセル

### NovelPlayer
- `autoMode` state 追加
- A ボタン追加：ON 時は青背景、OFF 時は半透明黒でトグル表示
- `autoMode` 変更を `renderer.setAutoMode()` に反映

## テスト
- フロントエンド: 340 件 pass