### PR TITLE
feat: #140 スキップモード + 既読フラグ永続化

### DIFF
--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -94,6 +94,13 @@ function NovelPlayer({
     }
   }, [debouncedSave])
 
+  // docKey が変化したときに renderer に反映 (#140): 同じコンポーネントが再利用される場合の考慮
+  useEffect(() => {
+    if (docKey) {
+      rendererRef.current?.setDocKey(docKey)
+    }
+  }, [docKey])
+
   // 設定パネルの開閉ショートカット (#138): Ctrl/Cmd + , で開く
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {

--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -11,6 +11,8 @@ interface NovelPlayerProps {
   assetBaseUrl?: string
   /** 画面比率。"16:9" / "4:3" / "9:16"。デフォルト "16:9" (#136) */
   aspectRatio?: AspectRatio | string
+  /** 既読永続化キー（省略時はスキップ機能を無効化）(#140) */
+  docKey?: string
 }
 
 function NovelPlayer({
@@ -18,6 +20,7 @@ function NovelPlayer({
   scenes,
   assetBaseUrl,
   aspectRatio: aspectRatioProp,
+  docKey,
 }: NovelPlayerProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const rendererRef = useRef<NovelRenderer | null>(null)
@@ -28,6 +31,8 @@ function NovelPlayer({
   const [settingsOpen, setSettingsOpen] = useState(false)
   // オートモード ON/OFF (#139)
   const [autoMode, setAutoMode] = useState(false)
+  // スキップモード ON/OFF (#140)
+  const [skipMode, setSkipMode] = useState(false)
   const debouncedSave = useMemo(() => makeDebouncedSaveSettings(300), [])
 
   // 有効な AspectRatio に正規化
@@ -55,6 +60,11 @@ function NovelPlayer({
       }
       // renderer が手動操作で autoMode を OFF にしたとき React state を同期 (#139)
       renderer.setOnAutoModeChange((on) => setAutoMode(on))
+      // renderer が未読到達で skipMode を OFF にしたとき React state を同期 (#140)
+      renderer.setOnSkipModeChange((on) => setSkipMode(on))
+      if (docKey) {
+        renderer.setDocKey(docKey)
+      }
       // init 完了直後に現在の settings を反映 (#138)
       renderer.applySettings(settings)
       if (scenes && scenes.length > 0) {
@@ -118,8 +128,17 @@ function NovelPlayer({
     rendererRef.current?.setAutoMode(autoMode)
   }, [autoMode])
 
+  // スキップモード変更を renderer に反映 (#140)
+  useEffect(() => {
+    rendererRef.current?.setSkipMode(skipMode)
+  }, [skipMode])
+
   const handleAutoToggle = () => {
     setAutoMode((v) => !v)
+  }
+
+  const handleSkipToggle = () => {
+    setSkipMode((v) => !v)
   }
 
   return (
@@ -134,6 +153,21 @@ function NovelPlayer({
           maxHeight: '100%',
         }}
       />
+      {/* スキップボタン (#140): docKey がある場合のみ有効 */}
+      <button
+        type="button"
+        onClick={handleSkipToggle}
+        disabled={!docKey}
+        aria-label={skipMode ? 'スキップモードをオフにする' : 'スキップモードをオンにする'}
+        title="スキップ（既読のみ）"
+        className={`absolute top-3 right-[6.25rem] w-9 h-9 flex items-center justify-center rounded-full text-sm font-bold transition-colors disabled:opacity-30 disabled:cursor-not-allowed ${
+          skipMode
+            ? 'bg-green-500/80 hover:bg-green-500 text-white'
+            : 'bg-black/50 hover:bg-black/70 text-white/80 hover:text-white'
+        }`}
+      >
+        S
+      </button>
       {/* オートモードボタン (#139) */}
       <button
         type="button"

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -823,6 +823,8 @@ export class NovelRenderer {
       return
     }
     if ('Choice' in event) {
+      // 選択肢に到達したらスキップモードを解除（手動選択が必要） (#140)
+      this.setSkipMode(false)
       this.waitingForChoice = true
       this.choiceOverlay.show(event.Choice.options, (jump: string) => {
         this.waitingForChoice = false
@@ -862,6 +864,8 @@ export class NovelRenderer {
     }
     if ('Wait' in event) {
       // 進行を停止し、指定ミリ秒後に再開（eventIndex のインクリメントはコールバック内で行う）
+      // Wait 中もスキップを停止する（Wait を無視するのは仕様違反） (#140)
+      this.setSkipMode(false)
       this.waitingForWait = true
       this.waitTimer = setTimeout(() => {
         this.waitTimer = null
@@ -1088,6 +1092,10 @@ export class NovelRenderer {
   /**
    * スキップモード: 既読行を高速スキップする (#140)。
    * タイプライターをスキップしてから advance() を setTimeout(0) で呼ぶ。
+   * Choice / Wait 到達時は processDirective() 内で setSkipMode(false) が呼ばれるため、
+   * タイマー発火時に skipMode が false になっており advance() は通常呼び出しになる。
+   * 同一イベントの複数 text 行は同じ displayIndex を持つため、
+   * 2 行目以降も「既読」として扱い全行をスキップする（意図的な設計）。
    */
   private scheduleSkipStep(): void {
     if (!this.skipMode) return
@@ -1097,7 +1105,8 @@ export class NovelRenderer {
     this.skipTimer = setTimeout(() => {
       this.skipTimer = null
       if (!this.skipMode) return
-      // タイプライター中なら全文スキップ（onTypingDone は null なので自動進行しない）
+      // タイプライター中なら全文スキップ（skipTypewriter は onTypingDone を破棄するため
+      // オートモードとの二重 advance は起きない）
       if (this.dialogBox.isTyping()) {
         this.dialogBox.skipTypewriter()
       }

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -33,6 +33,7 @@ import { SeekBar } from './SeekBar'
 import { computeDisplayIndex, findHistoryIndexForDisplayIndex } from './seekMapping'
 import { Event, EventScene } from '../types'
 import { ASPECT_RATIOS, type AspectRatio, parseAspectRatio } from './constants'
+import { isRead, loadReadProgress, markRead } from './readProgress'
 
 /** Dialog / Narration から text を取り出すヘルパー */
 export function getTextEvent(event: Event):
@@ -147,6 +148,17 @@ export class NovelRenderer {
   private autoWaitMs: number = 2500
   /** autoMode 変更時の React 側同期コールバック */
   private onAutoModeChange: ((on: boolean) => void) | null = null
+
+  /** スキップモード ON/OFF (#140) */
+  private skipMode: boolean = false
+  /** スキップ連続進行タイマー */
+  private skipTimer: ReturnType<typeof setTimeout> | null = null
+  /** 既読進捗（display index の Set）。docKey が設定されている場合に使用 */
+  private readProgress: Set<number> = new Set()
+  /** 既読永続化のキー（undefined の場合はスキップ機能無効） */
+  private docKey: string | undefined = undefined
+  /** skipMode 変更時の React 側同期コールバック */
+  private onSkipModeChange: ((on: boolean) => void) | null = null
 
   constructor(config?: { dialogBorderless?: boolean; aspectRatio?: AspectRatio }) {
     this.app = new Application()
@@ -300,6 +312,10 @@ export class NovelRenderer {
       clearTimeout(this.autoTimer)
       this.autoTimer = null
     }
+    if (this.skipTimer) {
+      clearTimeout(this.skipTimer)
+      this.skipTimer = null
+    }
     this.choiceOverlay.hide()
     this.audioManager.stopBgm(0)
     this.clearBackground()
@@ -389,6 +405,39 @@ export class NovelRenderer {
   }
 
   /**
+   * 既読永続化キーを設定する (#140)。
+   * 設定するとスキップモードが有効になり、既読進捗を localStorage から読み込む。
+   */
+  setDocKey(docKey: string): void {
+    this.docKey = docKey
+    this.readProgress = loadReadProgress(docKey)
+  }
+
+  /**
+   * スキップモードの ON/OFF を切り替える (#140)。
+   * OFF にした場合はスキップタイマーをキャンセルする。
+   */
+  setSkipMode(on: boolean): void {
+    if (this.skipMode === on) return
+    this.skipMode = on
+    if (!on && this.skipTimer) {
+      clearTimeout(this.skipTimer)
+      this.skipTimer = null
+    }
+    this.onSkipModeChange?.(on)
+  }
+
+  /** スキップモード変更コールバックを登録する */
+  setOnSkipModeChange(cb: (on: boolean) => void): void {
+    this.onSkipModeChange = cb
+  }
+
+  /** スキップモードの現在状態を取得する */
+  isSkipMode(): boolean {
+    return this.skipMode
+  }
+
+  /**
    * リソース解放
    */
   destroy(): void {
@@ -407,6 +456,10 @@ export class NovelRenderer {
     if (this.autoTimer) {
       clearTimeout(this.autoTimer)
       this.autoTimer = null
+    }
+    if (this.skipTimer) {
+      clearTimeout(this.skipTimer)
+      this.skipTimer = null
     }
     this.audioManager.destroy()
     this.characterLayer.clear()
@@ -620,8 +673,9 @@ export class NovelRenderer {
       return
     }
     if (this.saveLoadOverlay.visible) return
-    // 手動クリック/タップでオートモードをキャンセル (#139)
+    // 手動クリック/タップでオートモード・スキップモードをキャンセル (#139 #140)
     this.setAutoMode(false)
+    this.setSkipMode(false)
     this.advanceOrSkipTypewriter()
   }
 
@@ -675,16 +729,19 @@ export class NovelRenderer {
       case ' ':
       case 'Enter':
         e.preventDefault()
-        // 手動キー操作でオートモードをキャンセル (#139)
+        // 手動キー操作でオートモード・スキップモードをキャンセル (#139 #140)
         this.setAutoMode(false)
+        this.setSkipMode(false)
         this.advanceOrSkipTypewriter()
         break
       case 'ArrowRight':
         this.setAutoMode(false)
+        this.setSkipMode(false)
         this.advanceOrSkipTypewriter()
         break
       case 'ArrowLeft':
         this.setAutoMode(false)
+        this.setSkipMode(false)
         this.goBack()
         break
       case 's':
@@ -995,6 +1052,23 @@ export class NovelRenderer {
     }
 
     const line = textEvt.text[this.textIndex] ?? ''
+    const displayIndex = computeDisplayIndex(this.eventIndex, this.resolvedEvents)
+
+    // スキップモード処理 (#140): 既読チェックはマーク前に行う
+    if (this.skipMode && this.docKey) {
+      if (!isRead(this.readProgress, displayIndex)) {
+        // 未読到達 → スキップ終了（現在の行は表示して待機）
+        this.setSkipMode(false)
+      } else {
+        // 既読 → 即 advance をスケジュール
+        this.scheduleSkipStep()
+      }
+    }
+
+    // 既読マーク (#140): チェック後にマーク（次回以降は既読として扱う）
+    if (this.docKey) {
+      markRead(this.docKey, this.readProgress, displayIndex)
+    }
 
     // 空行 = 改ページ（テキストクリア後に次行へ自動進行はしない。空表示する）
     const name = textEvt.type === 'dialog' ? textEvt.character : null
@@ -1009,6 +1083,26 @@ export class NovelRenderer {
 
     this.updateCounter()
     this.updateSeekBar()
+  }
+
+  /**
+   * スキップモード: 既読行を高速スキップする (#140)。
+   * タイプライターをスキップしてから advance() を setTimeout(0) で呼ぶ。
+   */
+  private scheduleSkipStep(): void {
+    if (!this.skipMode) return
+    if (this.skipTimer) {
+      clearTimeout(this.skipTimer)
+    }
+    this.skipTimer = setTimeout(() => {
+      this.skipTimer = null
+      if (!this.skipMode) return
+      // タイプライター中なら全文スキップ（onTypingDone は null なので自動進行しない）
+      if (this.dialogBox.isTyping()) {
+        this.dialogBox.skipTypewriter()
+      }
+      this.advance()
+    }, 0)
   }
 
   /**

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -420,6 +420,10 @@ export class NovelRenderer {
   setSkipMode(on: boolean): void {
     if (this.skipMode === on) return
     this.skipMode = on
+    if (on) {
+      // スキップモードとオートモードは排他: スキップ ON 時にオートを解除 (#140)
+      this.setAutoMode(false)
+    }
     if (!on && this.skipTimer) {
       clearTimeout(this.skipTimer)
       this.skipTimer = null

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -574,6 +574,9 @@ export class NovelRenderer {
     if (historyIndex < 0 || historyIndex >= this.history.length) return
     if (this.waitingForChoice || this.waitingForWait) return
 
+    // シーク操作時はスキップモードを解除する (#140): ユーザーが特定箇所を見たくてシークしているため
+    this.setSkipMode(false)
+
     // 履歴を指定位置まで切り詰める（アンドゥスタック方式: 戻った地点から再進行すると新しい履歴が積まれる）
     this.history = this.history.slice(0, historyIndex + 1)
     const targetState = this.history[historyIndex]

--- a/frontend/src/game/readProgress.test.ts
+++ b/frontend/src/game/readProgress.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  __resetReadProgressForTest,
+  isRead,
+  loadReadProgress,
+  markRead,
+  saveReadProgress,
+} from './readProgress'
+
+const KEY = 'test-doc'
+
+beforeEach(() => {
+  __resetReadProgressForTest(KEY)
+})
+
+afterEach(() => {
+  __resetReadProgressForTest(KEY)
+})
+
+describe('loadReadProgress', () => {
+  it('保存がなければ空セットを返す', () => {
+    expect(loadReadProgress(KEY)).toEqual(new Set())
+  })
+
+  it('保存済みのインデックスを復元する', () => {
+    saveReadProgress(KEY, new Set([1, 2, 5]))
+    expect(loadReadProgress(KEY)).toEqual(new Set([1, 2, 5]))
+  })
+
+  it('不正な JSON は空セットにフォールバック', () => {
+    localStorage.setItem('name-name:read-progress:' + KEY, '{bad json')
+    expect(loadReadProgress(KEY)).toEqual(new Set())
+  })
+
+  it('配列以外の JSON は空セットにフォールバック', () => {
+    localStorage.setItem('name-name:read-progress:' + KEY, '42')
+    expect(loadReadProgress(KEY)).toEqual(new Set())
+  })
+
+  it('配列内の非数値要素はスキップする', () => {
+    localStorage.setItem('name-name:read-progress:' + KEY, '[1, "x", 3, null]')
+    expect(loadReadProgress(KEY)).toEqual(new Set([1, 3]))
+  })
+})
+
+describe('saveReadProgress / loadReadProgress ラウンドトリップ', () => {
+  it('save → load で値が保持される', () => {
+    const s = new Set([10, 20, 30])
+    saveReadProgress(KEY, s)
+    expect(loadReadProgress(KEY)).toEqual(s)
+  })
+})
+
+describe('markRead', () => {
+  it('未既読インデックスをマークして保存する', () => {
+    const progress = new Set<number>()
+    markRead(KEY, progress, 3)
+    expect(progress.has(3)).toBe(true)
+    expect(loadReadProgress(KEY).has(3)).toBe(true)
+  })
+
+  it('既読済みインデックスを重複マークしても問題ない', () => {
+    const progress = new Set<number>([3])
+    markRead(KEY, progress, 3)
+    expect(progress.size).toBe(1)
+  })
+})
+
+describe('isRead', () => {
+  it('既読インデックスは true を返す', () => {
+    expect(isRead(new Set([1, 2, 3]), 2)).toBe(true)
+  })
+
+  it('未読インデックスは false を返す', () => {
+    expect(isRead(new Set([1, 2, 3]), 5)).toBe(false)
+  })
+})

--- a/frontend/src/game/readProgress.ts
+++ b/frontend/src/game/readProgress.ts
@@ -1,0 +1,65 @@
+/**
+ * 既読 display index の localStorage 永続化ストア
+ *
+ * Issue #140: スキップモード + 既読フラグ永続化
+ *
+ * - キー: `name-name:read-progress:<docKey>`
+ * - 値: JSON 配列（既読の display index 一覧）
+ * - display index は computeDisplayIndex() が返す 1-based のテキストイベント番号
+ */
+
+const STORAGE_PREFIX = 'name-name:read-progress:'
+
+/**
+ * 指定 docKey の既読 display index セットを読み込む。
+ * localStorage が使えない場合は空セットを返す。
+ */
+export function loadReadProgress(docKey: string): Set<number> {
+  try {
+    const raw = localStorage.getItem(STORAGE_PREFIX + docKey)
+    if (!raw) return new Set()
+    const arr = JSON.parse(raw)
+    if (!Array.isArray(arr)) return new Set()
+    return new Set(arr.filter((v) => typeof v === 'number'))
+  } catch {
+    return new Set()
+  }
+}
+
+/**
+ * 指定 docKey の既読 display index セットを保存する。
+ * localStorage が使えない場合は無視する。
+ */
+export function saveReadProgress(docKey: string, progress: Set<number>): void {
+  try {
+    localStorage.setItem(STORAGE_PREFIX + docKey, JSON.stringify(Array.from(progress)))
+  } catch {
+    // quota exceeded 等は無視
+  }
+}
+
+/**
+ * 指定 docKey の display index を既読にマークし、保存する。
+ * progress セットを直接変更する（in-place mutation）。
+ */
+export function markRead(docKey: string, progress: Set<number>, displayIndex: number): void {
+  if (progress.has(displayIndex)) return
+  progress.add(displayIndex)
+  saveReadProgress(docKey, progress)
+}
+
+/**
+ * 指定 display index が既読かどうかを返す。
+ */
+export function isRead(progress: Set<number>, displayIndex: number): boolean {
+  return progress.has(displayIndex)
+}
+
+/** テスト用: localStorage をリセットする */
+export function __resetReadProgressForTest(docKey: string): void {
+  try {
+    localStorage.removeItem(STORAGE_PREFIX + docKey)
+  } catch {
+    // ignore
+  }
+}

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -184,6 +184,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
             events={novelEvents}
             assetBaseUrl={assetBaseUrl}
             aspectRatio={doc?.aspect_ratio}
+            docKey={projectName}
           />
         )}
       </main>


### PR DESCRIPTION
## 関連 Issue
closes #140

## 変更内容

### readProgress.ts（新規）
- `loadReadProgress / saveReadProgress / markRead / isRead` 追加
- キー: `name-name:read-progress:<docKey>`, 値: display index の JSON 配列
- ユニットテスト 10 件

### NovelRenderer
- `setDocKey(key)`: 既読進捗を localStorage から読み込む
- `setSkipMode(on)` / `setOnSkipModeChange(cb)` / `isSkipMode()` API 追加
- `render()`: 既読チェック（マーク前）→ 既読なら `scheduleSkipStep()`、未読なら自動 OFF
- 既読マークはチェック後（次回以降既読として扱う）
- `scheduleSkipStep()`: `setTimeout(0)` で `skipTypewriter()` → `advance()`
- 手動操作でスキップモードもキャンセル
- `destroy()` / `resetAndStartEvents()` で `skipTimer` をキャンセル

### NovelPlayer
- `docKey` prop 追加
- `skipMode` state + S ボタン（緑: ON / グレー: OFF）
- `docKey` 未設定時は S ボタンを `disabled`

### PlayerScreen
- `docKey={projectName}` を `NovelPlayer` に渡す

## テスト
- フロントエンド: 350 件 pass（+10 件新規）