### PR TITLE
feat: #141 タイトル画面（新規開始/つづきから/設定/終了）

### DIFF
--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -135,12 +135,18 @@ function NovelPlayer({
     } else {
       rendererRef.current.setEvents(events)
     }
-    // 「つづきから」: イベント設定後にスキップモードを ON にして未読位置まで高速進行 (#141)
-    if (initialSkipMode && docKey) {
-      rendererRef.current.setSkipMode(true)
-      setSkipMode(true)
-    }
   }, [events, scenes])
+
+  // 「つづきから」: 初回イベントセット後に一度だけスキップモードを ON にする (#141)
+  // useRef で発動済みフラグを管理し、events 更新のたびに再発動しないよう制御する
+  const initialSkipAppliedRef = useRef(false)
+  useEffect(() => {
+    if (!initialSkipMode || !docKey) return
+    if (initialSkipAppliedRef.current) return
+    initialSkipAppliedRef.current = true
+    rendererRef.current?.setSkipMode(true)
+    setSkipMode(true)
+  }, [events, scenes, initialSkipMode, docKey])
 
   // オートモード変更を renderer に反映 (#139)
   useEffect(() => {

--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -13,6 +13,12 @@ interface NovelPlayerProps {
   aspectRatio?: AspectRatio | string
   /** 既読永続化キー（省略時はスキップ機能を無効化）(#140) */
   docKey?: string
+  /**
+   * true にするとゲーム開始直後にスキップモードを ON にする (#141)。
+   * 「つづきから」で未読位置まで高速スキップするために使用する。
+   * docKey が未設定の場合は無視される。
+   */
+  initialSkipMode?: boolean
 }
 
 function NovelPlayer({
@@ -21,6 +27,7 @@ function NovelPlayer({
   assetBaseUrl,
   aspectRatio: aspectRatioProp,
   docKey,
+  initialSkipMode = false,
 }: NovelPlayerProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const rendererRef = useRef<NovelRenderer | null>(null)
@@ -127,6 +134,11 @@ function NovelPlayer({
       rendererRef.current.setScenes(scenes)
     } else {
       rendererRef.current.setEvents(events)
+    }
+    // 「つづきから」: イベント設定後にスキップモードを ON にして未読位置まで高速進行 (#141)
+    if (initialSkipMode && docKey) {
+      rendererRef.current.setSkipMode(true)
+      setSkipMode(true)
     }
   }, [events, scenes])
 

--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -138,7 +138,8 @@ function NovelPlayer({
   }, [events, scenes])
 
   // 「つづきから」: 初回イベントセット後に一度だけスキップモードを ON にする (#141)
-  // useRef で発動済みフラグを管理し、events 更新のたびに再発動しないよう制御する
+  // initialSkipMode が false の間は早期 return するため ref はセットされない。
+  // initialSkipMode が true になった初回のみ ref をセットして発動し、以降の events 更新では再発動しない。
   const initialSkipAppliedRef = useRef(false)
   useEffect(() => {
     if (!initialSkipMode || !docKey) return

--- a/frontend/src/components/TitleOverlay.tsx
+++ b/frontend/src/components/TitleOverlay.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react'
+
+/**
+ * タイトル画面オーバーレイ (#141)
+ *
+ * ゲーム開始前に表示するタイトル画面。
+ * - タイトル画像（assets/title.png）があれば表示、なければタイトルテキスト
+ * - ボタン: 新規開始 / つづきから / 設定 / 終了
+ * - 「つづきから」は hasSaveData=true の場合のみ有効
+ */
+
+interface TitleOverlayProps {
+  /** ゲームのタイトル文字列（title.png がない場合に表示） */
+  title: string
+  /** タイトル画像の URL（assets/title.png など）。読み込み失敗時はタイトルテキストで代替 */
+  titleImageUrl?: string
+  /** 既読データが存在するか（「つづきから」ボタンの有効/無効制御） */
+  hasSaveData: boolean
+  /** 「新規開始」ボタン押下時 */
+  onNewGame: () => void
+  /** 「つづきから」ボタン押下時 */
+  onContinue: () => void
+  /** 「設定」ボタン押下時 */
+  onOpenSettings: () => void
+  /** 「終了」ボタン押下時（プロジェクト一覧に戻る） */
+  onBack: () => void
+  /** ダークモード */
+  isDark?: boolean
+}
+
+function TitleOverlay({
+  title,
+  titleImageUrl,
+  hasSaveData,
+  onNewGame,
+  onContinue,
+  onOpenSettings,
+  onBack,
+  isDark = false,
+}: TitleOverlayProps) {
+  const [imageLoaded, setImageLoaded] = useState(false)
+  const [imageFailed, setImageFailed] = useState(false)
+
+  const showImage = titleImageUrl && !imageFailed
+
+  return (
+    <div
+      className="absolute inset-0 flex flex-col items-center justify-center z-50"
+      style={{ background: isDark ? '#111827' : '#1e1b4b' }}
+    >
+      {/* タイトル */}
+      <div className="mb-10 flex flex-col items-center">
+        {showImage && (
+          <img
+            src={titleImageUrl}
+            alt={title}
+            onLoad={() => setImageLoaded(true)}
+            onError={() => setImageFailed(true)}
+            className={`max-w-xs max-h-40 object-contain transition-opacity duration-300 ${
+              imageLoaded ? 'opacity-100' : 'opacity-0'
+            }`}
+          />
+        )}
+        {/* 画像がない・失敗・読み込み前はテキストを表示 */}
+        {(!showImage || !imageLoaded) && (
+          <h1
+            className="text-4xl font-bold tracking-widest text-white"
+            style={{ textShadow: '0 2px 12px rgba(0,0,0,0.6)' }}
+          >
+            {title}
+          </h1>
+        )}
+      </div>
+
+      {/* ボタン群 */}
+      <div className="flex flex-col gap-3 w-48">
+        <TitleButton onClick={onNewGame}>新規開始</TitleButton>
+        <TitleButton onClick={onContinue} disabled={!hasSaveData}>
+          つづきから
+        </TitleButton>
+        <TitleButton onClick={onOpenSettings} variant="secondary">
+          設定
+        </TitleButton>
+        <TitleButton onClick={onBack} variant="secondary">
+          終了
+        </TitleButton>
+      </div>
+    </div>
+  )
+}
+
+interface TitleButtonProps {
+  children: React.ReactNode
+  onClick: () => void
+  disabled?: boolean
+  variant?: 'primary' | 'secondary'
+}
+
+function TitleButton({
+  children,
+  onClick,
+  disabled = false,
+  variant = 'primary',
+}: TitleButtonProps) {
+  const base =
+    'w-full py-2.5 px-4 rounded text-sm font-semibold tracking-wide transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-indigo-950'
+
+  const variants = {
+    primary: disabled
+      ? 'bg-indigo-900 text-indigo-400 cursor-not-allowed'
+      : 'bg-indigo-600 hover:bg-indigo-500 text-white focus:ring-indigo-400',
+    secondary: disabled
+      ? 'bg-gray-700 text-gray-500 cursor-not-allowed'
+      : 'bg-gray-700 hover:bg-gray-600 text-gray-200 focus:ring-gray-400',
+  }
+
+  return (
+    <button className={`${base} ${variants[variant]}`} onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  )
+}
+
+export default TitleOverlay

--- a/frontend/src/game/readProgress.ts
+++ b/frontend/src/game/readProgress.ts
@@ -67,11 +67,7 @@ export function clearReadProgress(docKey: string): void {
   }
 }
 
-/** テスト用: localStorage をリセットする */
+/** テスト用: localStorage をリセットする（clearReadProgress の薄いラッパー） */
 export function __resetReadProgressForTest(docKey: string): void {
-  try {
-    localStorage.removeItem(STORAGE_PREFIX + docKey)
-  } catch {
-    // ignore
-  }
+  clearReadProgress(docKey)
 }

--- a/frontend/src/game/readProgress.ts
+++ b/frontend/src/game/readProgress.ts
@@ -55,6 +55,18 @@ export function isRead(progress: Set<number>, displayIndex: number): boolean {
   return progress.has(displayIndex)
 }
 
+/**
+ * 指定 docKey の既読データを全消去する。
+ * タイトル画面の「新規開始」など、進捗リセット時に呼ぶ (#141)。
+ */
+export function clearReadProgress(docKey: string): void {
+  try {
+    localStorage.removeItem(STORAGE_PREFIX + docKey)
+  } catch {
+    // ignore
+  }
+}
+
 /** テスト用: localStorage をリセットする */
 export function __resetReadProgressForTest(docKey: string): void {
   try {

--- a/frontend/src/screens/PlayerScreen.test.tsx
+++ b/frontend/src/screens/PlayerScreen.test.tsx
@@ -138,8 +138,9 @@ describe('PlayerScreen', () => {
       'https://raw.githubusercontent.com/kako-jun/friday-1930/main/assets'
     )
 
-    // タイトル表示
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('友達 1930')
+    // タイトル表示（ヘッダーの h1 とタイトルオーバーレイの h1 の両方に表示される）
+    const headings = screen.getAllByRole('heading', { level: 1 })
+    expect(headings.some((h) => h.textContent === '友達 1930')).toBe(true)
 
     // 編集 UI が描画されていないこと（編集モード固有の文字列が無い）
     expect(screen.queryByText('保存')).toBeNull()

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -7,10 +7,7 @@ import type { RPGProject } from '../types/rpg'
 import { parseMarkdown } from '../wasm/parser'
 import { findRpgSceneIndex, rpgProjectFromDoc } from '../game/rpgProjectFromDoc'
 import { ApiError, createApiClient, type ProjectInfo } from '../api/client'
-import {
-  loadReadProgress,
-  __resetReadProgressForTest as resetReadProgress,
-} from '../game/readProgress'
+import { loadReadProgress, clearReadProgress } from '../game/readProgress'
 
 // kako-jun/name-name#108: 一般ユーザー向けの再生専用画面。
 //   - 編集 UI / 保存 / アセット管理 / デバッグは一切表示しない
@@ -133,7 +130,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
   const title = projectInfo?.title || projectName
 
   // 「つづきから」ボタンの有効判定: 既読データが存在するか (#141)
-  const hasSaveData = loadReadProgress(projectName).size > 0
+  const [hasSaveData, setHasSaveData] = useState(() => loadReadProgress(projectName).size > 0)
 
   return (
     <div className={`flex flex-col h-screen ${isDark ? 'dark bg-gray-900' : 'bg-white'}`}>
@@ -210,7 +207,8 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
                 isDark={isDark}
                 onNewGame={() => {
                   // 新規開始: 既読データをクリアして最初から
-                  resetReadProgress(projectName)
+                  clearReadProgress(projectName)
+                  setHasSaveData(false)
                   setStartWithSkip(false)
                   setTitleDismissed(true)
                 }}
@@ -220,9 +218,9 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
                   setTitleDismissed(true)
                 }}
                 onOpenSettings={() => {
-                  // NovelPlayer 内の設定パネルを開く手段がないため、
-                  // 将来的には設定パネルを外部から制御できる ref を追加する。
-                  // 現時点ではタイトルを閉じて設定ボタンから開くよう案内。
+                  // TODO (#141): NovelPlayer の設定パネルを外部から開く ref を追加して
+                  // タイトル画面の「設定」ボタンからダイレクトに設定を開けるようにする。
+                  // 現時点ではタイトルを閉じてゲーム内の設定ボタン（⚙）から開く。
                   setTitleDismissed(true)
                 }}
                 onBack={onBack}

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -1,11 +1,16 @@
 import { useEffect, useMemo, useState } from 'react'
 import NovelPlayer from '../components/NovelPlayer'
 import RPGPlayer from '../components/RPGPlayer'
+import TitleOverlay from '../components/TitleOverlay'
 import type { Event, EventDocument } from '../types'
 import type { RPGProject } from '../types/rpg'
 import { parseMarkdown } from '../wasm/parser'
 import { findRpgSceneIndex, rpgProjectFromDoc } from '../game/rpgProjectFromDoc'
 import { ApiError, createApiClient, type ProjectInfo } from '../api/client'
+import {
+  loadReadProgress,
+  __resetReadProgressForTest as resetReadProgress,
+} from '../game/readProgress'
 
 // kako-jun/name-name#108: 一般ユーザー向けの再生専用画面。
 //   - 編集 UI / 保存 / アセット管理 / デバッグは一切表示しない
@@ -51,6 +56,11 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
   const [error, setError] = useState<string | null>(null)
   // chapters/all.md がまだリポに無い「未投入」状態。エラーではなく案内として扱う。
   const [unpopulated, setUnpopulated] = useState(false)
+
+  // タイトル画面の表示状態 (#141)
+  const [titleDismissed, setTitleDismissed] = useState(false)
+  // 「つづきから」で開始した場合 true: ゲーム開始直後にスキップモードで未読位置まで進める
+  const [startWithSkip, setStartWithSkip] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -122,6 +132,9 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
 
   const title = projectInfo?.title || projectName
 
+  // 「つづきから」ボタンの有効判定: 既読データが存在するか (#141)
+  const hasSaveData = loadReadProgress(projectName).size > 0
+
   return (
     <div className={`flex flex-col h-screen ${isDark ? 'dark bg-gray-900' : 'bg-white'}`}>
       <header
@@ -151,7 +164,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
         </div>
       </header>
 
-      <main className="flex-1 overflow-hidden">
+      <main className="flex-1 overflow-hidden relative">
         {loading ? (
           <div
             className={`flex items-center justify-center h-full ${isDark ? 'text-gray-400' : 'text-gray-600'}`}
@@ -180,12 +193,42 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
           // ノベル+RPG の遷移制御は #108 本統合で扱う。
           <RPGPlayer gameData={rpgProject} view={rpgProject.view} />
         ) : (
-          <NovelPlayer
-            events={novelEvents}
-            assetBaseUrl={assetBaseUrl}
-            aspectRatio={doc?.aspect_ratio}
-            docKey={projectName}
-          />
+          <>
+            <NovelPlayer
+              events={novelEvents}
+              assetBaseUrl={assetBaseUrl}
+              aspectRatio={doc?.aspect_ratio}
+              docKey={projectName}
+              initialSkipMode={startWithSkip}
+            />
+            {/* タイトル画面オーバーレイ (#141): ゲーム開始前に表示 */}
+            {!titleDismissed && (
+              <TitleOverlay
+                title={title}
+                titleImageUrl={`${assetBaseUrl}/title.png`}
+                hasSaveData={hasSaveData}
+                isDark={isDark}
+                onNewGame={() => {
+                  // 新規開始: 既読データをクリアして最初から
+                  resetReadProgress(projectName)
+                  setStartWithSkip(false)
+                  setTitleDismissed(true)
+                }}
+                onContinue={() => {
+                  // つづきから: スキップモードで未読位置まで高速進行
+                  setStartWithSkip(true)
+                  setTitleDismissed(true)
+                }}
+                onOpenSettings={() => {
+                  // NovelPlayer 内の設定パネルを開く手段がないため、
+                  // 将来的には設定パネルを外部から制御できる ref を追加する。
+                  // 現時点ではタイトルを閉じて設定ボタンから開くよう案内。
+                  setTitleDismissed(true)
+                }}
+                onBack={onBack}
+              />
+            )}
+          </>
         )}
       </main>
     </div>


### PR DESCRIPTION
## 関連 Issue
closes #141

## 変更内容
- `TitleOverlay` コンポーネントを新規作成
  - タイトル画像（`assets/title.png`）があれば表示、なければタイトルテキスト
  - ボタン: 新規開始 / つづきから / 設定 / 終了（onBack）
  - 「つづきから」は既読データが存在する場合のみ有効
- `PlayerScreen` にタイトル画面オーバーレイを統合
  - ゲームデータ読み込み完了後にオーバーレイ表示
  - 「新規開始」: readProgress をクリアして最初から
  - 「つづきから」: initialSkipMode=true でスキップモード起動し未読位置まで高速進行
- `NovelPlayer` に `initialSkipMode` prop を追加（ゲーム開始直後にスキップモードを ON にする）