### PR TITLE
feat: #142 クイックセーブ/ロード（F5/F8）

### DIFF
--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Event, EventScene } from '../types'
 import { NovelRenderer } from '../game/NovelRenderer'
 import { type Settings, loadSettings, makeDebouncedSaveSettings } from '../game/settings'
@@ -124,14 +124,14 @@ function NovelPlayer({
   }, [])
 
   // クイックセーブ/ロード 通知 toast を表示するヘルパー (#142)
-  function showToast(message: string) {
+  const showToast = useCallback((message: string) => {
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
     setToast(message)
     toastTimerRef.current = setTimeout(() => {
       setToast(null)
       toastTimerRef.current = null
     }, 2000)
-  }
+  }, [])
 
   // F5: クイックセーブ / F8: クイックロード (#142)
   useEffect(() => {
@@ -148,7 +148,7 @@ function NovelPlayer({
     }
     window.addEventListener('keydown', handleKey)
     return () => window.removeEventListener('keydown', handleKey)
-  }, [])
+  }, [showToast])
 
   // unmount 時に toast タイマーをクリア
   useEffect(() => {

--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -40,6 +40,9 @@ function NovelPlayer({
   const [autoMode, setAutoMode] = useState(false)
   // スキップモード ON/OFF (#140)
   const [skipMode, setSkipMode] = useState(false)
+  // クイックセーブ/ロード完了通知 toast (#142)
+  const [toast, setToast] = useState<string | null>(null)
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const debouncedSave = useMemo(() => makeDebouncedSaveSettings(300), [])
 
   // 有効な AspectRatio に正規化
@@ -118,6 +121,40 @@ function NovelPlayer({
     }
     window.addEventListener('keydown', handleKey)
     return () => window.removeEventListener('keydown', handleKey)
+  }, [])
+
+  // クイックセーブ/ロード 通知 toast を表示するヘルパー (#142)
+  function showToast(message: string) {
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
+    setToast(message)
+    toastTimerRef.current = setTimeout(() => {
+      setToast(null)
+      toastTimerRef.current = null
+    }, 2000)
+  }
+
+  // F5: クイックセーブ / F8: クイックロード (#142)
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'F5') {
+        e.preventDefault()
+        const ok = rendererRef.current?.quickSave() ?? false
+        showToast(ok ? 'クイックセーブしました' : 'この場面ではセーブできません')
+      } else if (e.key === 'F8') {
+        e.preventDefault()
+        const ok = rendererRef.current?.quickLoad() ?? false
+        showToast(ok ? 'クイックロードしました' : 'クイックセーブデータがありません')
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [])
+
+  // unmount 時に toast タイマーをクリア
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
+    }
   }, [])
 
   // assetBaseUrl が変わったらレンダラーに反映
@@ -223,6 +260,16 @@ function NovelPlayer({
         settings={settings}
         onChange={setSettings}
       />
+      {/* クイックセーブ/ロード通知 toast (#142) */}
+      {toast !== null && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="absolute bottom-10 left-1/2 -translate-x-1/2 px-4 py-2 rounded-full bg-black/70 text-white text-sm font-medium pointer-events-none select-none"
+        >
+          {toast}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -960,6 +960,56 @@ export class NovelRenderer {
     this.bgContainer.removeChildren()
   }
 
+  // --- クイックセーブ / クイックロード (#142) ---
+
+  /**
+   * 現在のゲーム状態をクイックセーブスロットに保存する。
+   * 選択肢・Wait 待機中は保存しない（不整合状態を避けるため）。
+   * 成功したら true、保存できない状態なら false を返す。
+   */
+  quickSave(): boolean {
+    if (this.waitingForChoice || this.waitingForWait) return false
+
+    const sceneName = this.currentSceneId
+      ? (this.allScenes.find((s) => s.id === this.currentSceneId)?.title ?? null)
+      : null
+
+    const snapshot = this.getSnapshot()
+    const data: SaveSlotData = {
+      slot: -1, // クイックセーブはスロット番号不使用
+      sceneId: snapshot.sceneId,
+      eventIndex: snapshot.eventIndex,
+      textIndex: snapshot.textIndex,
+      flags: snapshot.flags,
+      backgroundPath: snapshot.backgroundPath,
+      isBlackout: snapshot.isBlackout,
+      characters: snapshot.characters,
+      currentBgmPath: snapshot.currentBgmPath,
+      savedAt: new Date().toISOString(),
+      sceneName,
+    }
+    this.saveManager.quickSave(data)
+    return true
+  }
+
+  /**
+   * クイックセーブスロットからゲーム状態を復元する。
+   * データがない・復元できない場合は false を返す。
+   */
+  quickLoad(): boolean {
+    const data = this.saveManager.quickLoad()
+    if (!data) return false
+    this.loadFromSaveData(data)
+    return true
+  }
+
+  /**
+   * クイックセーブデータが存在するか返す。
+   */
+  hasQuickSave(): boolean {
+    return this.saveManager.hasQuickSave()
+  }
+
   /**
    * セーブメニューを表示する
    */

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -994,9 +994,11 @@ export class NovelRenderer {
 
   /**
    * クイックセーブスロットからゲーム状態を復元する。
+   * 選択肢・Wait 待機中はロードしない（不整合状態を避けるため）。
    * データがない・復元できない場合は false を返す。
    */
   quickLoad(): boolean {
+    if (this.waitingForChoice || this.waitingForWait) return false
     const data = this.saveManager.quickLoad()
     if (!data) return false
     this.loadFromSaveData(data)

--- a/frontend/src/game/SaveManager.test.ts
+++ b/frontend/src/game/SaveManager.test.ts
@@ -1,0 +1,66 @@
+/**
+ * SaveManager のクイックセーブ/ロードテスト (#142)
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { SaveManager, SaveSlotData } from './SaveManager'
+
+function makeSaveData(): SaveSlotData {
+  return {
+    slot: -1,
+    sceneId: 'scene-1',
+    eventIndex: 3,
+    textIndex: 1,
+    flags: { visited: true },
+    backgroundPath: '/bg/room.png',
+    isBlackout: false,
+    characters: [{ name: 'Alice', expression: 'happy', position: 'center' }],
+    currentBgmPath: '/bgm/main.mp3',
+    savedAt: new Date().toISOString(),
+    sceneName: 'シーン1',
+  }
+}
+
+describe('SaveManager - クイックセーブ', () => {
+  let manager: SaveManager
+
+  beforeEach(() => {
+    manager = new SaveManager()
+    // テスト前にクイックセーブを消す
+    localStorage.removeItem('name-name-save-quick')
+  })
+
+  it('hasQuickSave: データなしで false を返す', () => {
+    expect(manager.hasQuickSave()).toBe(false)
+  })
+
+  it('quickSave で保存し、hasQuickSave が true になる', () => {
+    manager.quickSave(makeSaveData())
+    expect(manager.hasQuickSave()).toBe(true)
+  })
+
+  it('quickLoad でデータが復元される', () => {
+    const data = makeSaveData()
+    manager.quickSave(data)
+    const loaded = manager.quickLoad()
+    expect(loaded).not.toBeNull()
+    expect(loaded?.sceneId).toBe('scene-1')
+    expect(loaded?.eventIndex).toBe(3)
+    expect(loaded?.textIndex).toBe(1)
+    expect(loaded?.flags).toEqual({ visited: true })
+  })
+
+  it('quickLoad: データなしで null を返す', () => {
+    expect(manager.quickLoad()).toBeNull()
+  })
+
+  it('quickSave は通常スロット（0〜2）に影響しない', () => {
+    manager.quickSave(makeSaveData())
+    expect(manager.listSlots()).toEqual([null, null, null])
+  })
+
+  it('通常 save は quickLoad に影響しない', () => {
+    const data = { ...makeSaveData(), slot: 0 }
+    manager.save(0, data)
+    expect(manager.quickLoad()).toBeNull()
+  })
+})

--- a/frontend/src/game/SaveManager.test.ts
+++ b/frontend/src/game/SaveManager.test.ts
@@ -25,8 +25,7 @@ describe('SaveManager - クイックセーブ', () => {
 
   beforeEach(() => {
     manager = new SaveManager()
-    // テスト前にクイックセーブを消す
-    localStorage.removeItem('name-name-save-quick')
+    manager.deleteQuickSave()
   })
 
   it('hasQuickSave: データなしで false を返す', () => {

--- a/frontend/src/game/SaveManager.ts
+++ b/frontend/src/game/SaveManager.ts
@@ -74,7 +74,9 @@ export class SaveManager {
   }
 
   /**
-   * 全スロットを JSON 文字列でエクスポートする
+   * 全スロットを JSON 文字列でエクスポートする。
+   * クイックセーブは一時的な作業メモとして扱うため、エクスポート対象に含めない。
+   * ブラウザ間の持ち運しが目的のため、意図的に除外している。
    */
   exportJSON(): string {
     const data: (SaveSlotData | null)[] = this.listSlots()
@@ -149,6 +151,17 @@ export class SaveManager {
       return localStorage.getItem(QUICK_SAVE_KEY) !== null
     } catch {
       return false
+    }
+  }
+
+  /**
+   * クイックセーブデータを消去する。
+   */
+  deleteQuickSave(): void {
+    try {
+      localStorage.removeItem(QUICK_SAVE_KEY)
+    } catch {
+      // ignore
     }
   }
 }

--- a/frontend/src/game/SaveManager.ts
+++ b/frontend/src/game/SaveManager.ts
@@ -3,12 +3,15 @@
  *
  * localStorage を使い、複数スロット（3つ）のセーブデータを管理する。
  * JSON エクスポート/インポートによるブラウザ間の持ち運びにも対応。
+ * クイックセーブ（#142）は専用キーで通常スロットとは独立して保存する。
  */
 
 import { FlagValue } from '../types'
 
 const SLOT_COUNT = 3
 const STORAGE_PREFIX = 'name-name-save-'
+/** クイックセーブ専用ストレージキー (#142) */
+const QUICK_SAVE_KEY = 'name-name-save-quick'
 
 export interface SaveSlotData {
   slot: number
@@ -105,6 +108,45 @@ export class SaveManager {
         }
       }
       return true
+    } catch {
+      return false
+    }
+  }
+
+  // --- クイックセーブ (#142) ---
+
+  /**
+   * クイックセーブスロットに保存する。
+   * 通常スロット（0〜2）とは独立したキーで保存するため、既存セーブと干渉しない。
+   */
+  quickSave(data: SaveSlotData): void {
+    try {
+      localStorage.setItem(QUICK_SAVE_KEY, JSON.stringify(data))
+    } catch {
+      // quota exceeded 等は無視
+    }
+  }
+
+  /**
+   * クイックセーブスロットからデータを読み込む。
+   * データがない場合は null を返す。
+   */
+  quickLoad(): SaveSlotData | null {
+    try {
+      const json = localStorage.getItem(QUICK_SAVE_KEY)
+      if (!json) return null
+      return JSON.parse(json) as SaveSlotData
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * クイックセーブデータが存在するか返す。
+   */
+  hasQuickSave(): boolean {
+    try {
+      return localStorage.getItem(QUICK_SAVE_KEY) !== null
     } catch {
       return false
     }

--- a/frontend/src/game/SaveManager.ts
+++ b/frontend/src/game/SaveManager.ts
@@ -76,7 +76,7 @@ export class SaveManager {
   /**
    * 全スロットを JSON 文字列でエクスポートする。
    * クイックセーブは一時的な作業メモとして扱うため、エクスポート対象に含めない。
-   * ブラウザ間の持ち運しが目的のため、意図的に除外している。
+   * ブラウザ間の持ち運びが目的のため、意図的に除外している。
    */
   exportJSON(): string {
     const data: (SaveSlotData | null)[] = this.listSlots()


### PR DESCRIPTION
## 関連 Issue
closes #142

## 変更内容
- `SaveManager` にクイックセーブ専用メソッドを追加
  - `quickSave(data)` — 専用キー `name-name-save-quick` に保存（通常スロットと独立）
  - `quickLoad()` — クイックセーブデータを読み込む
  - `hasQuickSave()` — データ存在確認
- `NovelRenderer` に公開メソッドを追加
  - `quickSave()` — 選択肢/Wait 待機中は保存不可（false を返す）
  - `quickLoad()` — クイックデータからゲーム状態を復元
  - `hasQuickSave()` — データ存在確認
- `NovelPlayer` に F5/F8 キーハンドラと toast 通知を追加
  - F5: クイックセーブ、F8: クイックロード
  - 成功/失敗に応じたメッセージを 2 秒間表示
- `SaveManager.test.ts` 新規追加（6件）