### PR TITLE
fix: #191 #192 エンカウント未発動（WASD移動）+ Raycast 床色フォールバック統一

### DIFF
--- a/frontend/src/game/RaycastRenderer.ts
+++ b/frontend/src/game/RaycastRenderer.ts
@@ -106,6 +106,13 @@ export class RaycastRenderer {
   /** 戦闘直後の連続エンカウント抑止カウンタ。残歩数だけ抽選をスキップする (#172) */
   private encounterCooldown: number = 0
   /**
+   * updateMovement でのタイルまたぎ検出用。
+   * 前フレームのタイル座標を保持し、整数グリッドが変化したときにエンカウント抽選を呼ぶ。
+   * -1 は未初期化（最初の load() 後の最初フレームで確定する）。
+   */
+  private prevTileX: number = -1
+  private prevTileY: number = -1
+  /**
    * resize 時のミニマップ再描画に使う NPC リスト（#149）。
    *
    * 責務: rebuildNpcObjects を呼ぶすべての経路でこの cache も同期更新する。
@@ -317,6 +324,8 @@ export class RaycastRenderer {
     this.masterParty = gameData.party ?? {}
     this.stepCounter = 0
     this.encounterCooldown = 0
+    this.prevTileX = -1
+    this.prevTileY = -1
 
     // Player: tile center
     this.playerX = gameData.player.x + 0.5
@@ -1050,6 +1059,22 @@ export class RaycastRenderer {
         this.playerVZ = 0
       }
     }
+
+    // タイルまたぎ検出 → エンカウント抽選 (#191)。
+    // snapStep（タッチ 1 歩）と同様に、タイルグリッドが変化した瞬間だけ抽選する。
+    // 毎フレーム呼ぶと極端に高頻度になるため、整数グリッド座標の変化で 1 回だけ発火させる。
+    const curTileX = Math.floor(this.playerX)
+    const curTileY = Math.floor(this.playerY)
+    if (this.prevTileX === -1) {
+      // 初期化: 最初のフレームではエンカウントを発生させない
+      this.prevTileX = curTileX
+      this.prevTileY = curTileY
+    } else if (curTileX !== this.prevTileX || curTileY !== this.prevTileY) {
+      this.prevTileX = curTileX
+      this.prevTileY = curTileY
+      this.stepCounter += 1
+      this.maybeRollEncounter()
+    }
   }
 
   private isPassable(x: number, y: number): boolean {
@@ -1159,12 +1184,12 @@ export class RaycastRenderer {
         const rowDist = denom > 0 ? cameraZ / denom : 0
         const sampleX = Math.floor(this.playerX + fx * rowDist)
         const sampleY = Math.floor(this.playerY + fy * rowDist)
-        let color = 0x555555
+        let color = 0x1a3a1a // マップ範囲外: TREE と同色でフォールバック
         if (sampleY >= 0 && sampleY < this.mapHeight && sampleX >= 0 && sampleX < this.mapWidth) {
           const tile = this.mapTiles[sampleY]?.[sampleX]
           if (tile === TileType.ROAD) color = 0x8b7355
           else if (tile === TileType.GRASS) color = 0x2d5016
-          else color = 0x444444 // TREE/WATER タイル下に立つことは無いがフォールバック
+          else color = 0x1a3a1a // TREE/WATER: TopDown の TILE_COLORS_HEX[TileType.TREE] と統一
         }
         if (color !== bandColor) {
           flushBand(y, bandColor)

--- a/frontend/src/game/RaycastRenderer.ts
+++ b/frontend/src/game/RaycastRenderer.ts
@@ -46,6 +46,8 @@ import { MinimapOverlay } from './MinimapOverlay'
 import { BattleScreen } from './BattleScreen'
 import { BattleEngine } from './battleEngine'
 import type { BattleEntity } from './spellDsl'
+import { rollEncounter } from './encounter'
+export { rollEncounter } from './encounter'
 
 interface NPCRuntime {
   data: UiNpcData
@@ -108,10 +110,11 @@ export class RaycastRenderer {
   /**
    * updateMovement でのタイルまたぎ検出用。
    * 前フレームのタイル座標を保持し、整数グリッドが変化したときにエンカウント抽選を呼ぶ。
-   * -1 は未初期化（最初の load() 後の最初フレームで確定する）。
+   * false は未初期化（最初の load() 後の最初フレームで初期化する）。
    */
-  private prevTileX: number = -1
-  private prevTileY: number = -1
+  private prevTileInitialized: boolean = false
+  private prevTileX: number = 0
+  private prevTileY: number = 0
   /**
    * resize 時のミニマップ再描画に使う NPC リスト（#149）。
    *
@@ -324,8 +327,9 @@ export class RaycastRenderer {
     this.masterParty = gameData.party ?? {}
     this.stepCounter = 0
     this.encounterCooldown = 0
-    this.prevTileX = -1
-    this.prevTileY = -1
+    this.prevTileInitialized = false
+    this.prevTileX = 0
+    this.prevTileY = 0
 
     // Player: tile center
     this.playerX = gameData.player.x + 0.5
@@ -659,6 +663,11 @@ export class RaycastRenderer {
     )
     // 1 歩進んだので確率エンカウント抽選 (#172)
     this.stepCounter += 1
+    // prevTileX/Y を更新して、同フレームの updateMovement タイルまたぎ検出と
+    // 二重エンカウントしないようにする (#191)
+    this.prevTileInitialized = true
+    this.prevTileX = Math.floor(this.playerX)
+    this.prevTileY = Math.floor(this.playerY)
     this.maybeRollEncounter()
   }
 
@@ -1065,8 +1074,9 @@ export class RaycastRenderer {
     // 毎フレーム呼ぶと極端に高頻度になるため、整数グリッド座標の変化で 1 回だけ発火させる。
     const curTileX = Math.floor(this.playerX)
     const curTileY = Math.floor(this.playerY)
-    if (this.prevTileX === -1) {
+    if (!this.prevTileInitialized) {
       // 初期化: 最初のフレームではエンカウントを発生させない
+      this.prevTileInitialized = true
       this.prevTileX = curTileX
       this.prevTileY = curTileY
     } else if (curTileX !== this.prevTileX || curTileY !== this.prevTileY) {
@@ -1628,56 +1638,6 @@ export class RaycastRenderer {
       npc.sprite.texture = sheet.textures[row][frame]
     }
   }
-}
-
-/**
- * DQ4 式エンカウント抽選の純関数実装 (#172)。
- *
- * - rate=0 / groups 空 / masters が解決不能で全滅 → null（不発）
- * - rate=1 で毎歩確実エンカウント（debug knob）
- * - rate=N で `rng() < 1/N` 抽選、当選したら groups から重み均等で 1 つ選び、
- *   `+` 連結を分解してマスターから BattleEntity を組み立てる
- *
- * RaycastRenderer.maybeRollEncounter から呼ばれる。テストでは `rng` に
- * 固定値関数を渡して挙動を assert する。
- */
-export function rollEncounter(input: {
-  rate: number
-  groups: ReadonlyArray<string>
-  masters: Record<string, import('../types').MonsterDef>
-  rng: () => number
-}): BattleEntity[] | null {
-  if (input.rate === 0) return null
-  if (input.groups.length === 0) return null
-  if (input.rng() >= 1 / input.rate) return null
-
-  const groupSpec = input.groups[Math.floor(input.rng() * input.groups.length)]
-  const monsterIds = groupSpec
-    .split('+')
-    .map((s) => s.trim())
-    .filter(Boolean)
-  const enemies: BattleEntity[] = []
-  for (const id of monsterIds) {
-    const def = input.masters[id]
-    if (!def) {
-      console.warn(`[name-name] encounter group references unknown monster '${id}'`)
-      continue
-    }
-    enemies.push({
-      id: def.id,
-      name: def.name,
-      hp: def.hp,
-      maxHp: def.hp,
-      mp: def.mp ?? 0,
-      maxMp: def.mp ?? 0,
-      atk: def.atk,
-      def: def.def,
-      agi: def.agi,
-      exp: def.exp,
-      gold: def.gold,
-    })
-  }
-  return enemies.length > 0 ? enemies : null
 }
 
 function directionToAngle(d: DirectionLabel): number {

--- a/frontend/src/game/TopDownRenderer.ts
+++ b/frontend/src/game/TopDownRenderer.ts
@@ -20,7 +20,7 @@ import {
 } from './npcSpriteSheet'
 import { attachTouchInput, type SwipeDirection } from './touchInput'
 import { TouchMenuOverlay, DQ4_COMMANDS, type Dq4CommandId } from './TouchMenuOverlay'
-import { rollEncounter } from './RaycastRenderer'
+import { rollEncounter } from './encounter'
 
 type Direction = 'up' | 'down' | 'left' | 'right'
 
@@ -484,7 +484,9 @@ export class TopDownRenderer {
     })
     if (enemies && enemies.length > 0) {
       // TopDown では戦闘画面を RaycastRenderer のように持っていないため、
-      // 現時点では console.info で記録するにとどめ、将来 BattleScreen 統合時に実装する
+      // 現時点では console.info で記録するにとどめ、将来 BattleScreen 統合時に実装する。
+      // TODO: BattleScreen 統合時は「エンカウント検出時」ではなく「戦闘終了（onClose）時」に
+      //       encounterCooldown = 3 をセットするよう変更すること（RaycastRenderer と同方式にする）
       console.info(
         '[TopDownRenderer] encounter!',
         enemies.map((e) => e.name)

--- a/frontend/src/game/TopDownRenderer.ts
+++ b/frontend/src/game/TopDownRenderer.ts
@@ -8,6 +8,7 @@
 
 import { Application, Container, Graphics, Sprite } from 'pixi.js'
 import { UiNpcData, RPGProject, TILE_COLORS_HEX, TileType } from '../types/rpg'
+import type { MonsterDef } from '../types'
 import { RpgDialogBox } from './RpgDialogBox'
 import {
   NPC_ANIM_PERIOD_MS,
@@ -19,6 +20,7 @@ import {
 } from './npcSpriteSheet'
 import { attachTouchInput, type SwipeDirection } from './touchInput'
 import { TouchMenuOverlay, DQ4_COMMANDS, type Dq4CommandId } from './TouchMenuOverlay'
+import { rollEncounter } from './RaycastRenderer'
 
 type Direction = 'up' | 'down' | 'left' | 'right'
 
@@ -73,6 +75,13 @@ export class TopDownRenderer {
   private screenHeight = 0
 
   private resizeRaf: number | null = null
+
+  /** 確率エンカウント (#191) */
+  private encounterRate: number = 0
+  private encounterGroups: string[] = []
+  private masterMonsters: Record<string, MonsterDef> = {}
+  /** 戦闘直後の連続エンカウント抑止カウンタ。残歩数だけ抽選をスキップする */
+  private encounterCooldown: number = 0
 
   private initialized = false
 
@@ -154,6 +163,12 @@ export class TopDownRenderer {
     this.playerGridX = gameData.player.x
     this.playerGridY = gameData.player.y
     this.playerDirection = gameData.player.direction
+
+    // エンカウント設定 (#191)
+    this.encounterRate = gameData.map.encounterRate ?? 0
+    this.encounterGroups = gameData.map.encounterGroups ?? []
+    this.masterMonsters = gameData.monsters ?? {}
+    this.encounterCooldown = 0
 
     this.drawMap()
     this.drawNPCs(gameData.npcs)
@@ -451,6 +466,31 @@ export class TopDownRenderer {
     this.playerGridX = nx
     this.playerGridY = ny
     this.isMoving = true
+
+    // 1 歩進んだので確率エンカウント抽選 (#191)
+    this.maybeRollEncounter()
+  }
+
+  private maybeRollEncounter(): void {
+    if (this.encounterCooldown > 0) {
+      this.encounterCooldown -= 1
+      return
+    }
+    const enemies = rollEncounter({
+      rate: this.encounterRate,
+      groups: this.encounterGroups,
+      masters: this.masterMonsters,
+      rng: Math.random,
+    })
+    if (enemies && enemies.length > 0) {
+      // TopDown では戦闘画面を RaycastRenderer のように持っていないため、
+      // 現時点では console.info で記録するにとどめ、将来 BattleScreen 統合時に実装する
+      console.info(
+        '[TopDownRenderer] encounter!',
+        enemies.map((e) => e.name)
+      )
+      this.encounterCooldown = 3
+    }
   }
 
   private canMoveTo(x: number, y: number): boolean {

--- a/frontend/src/game/encounter.ts
+++ b/frontend/src/game/encounter.ts
@@ -1,0 +1,53 @@
+/**
+ * DQ4 式エンカウント抽選の純関数実装 (#172)。
+ *
+ * - rate=0 / groups 空 / masters が解決不能で全滅 → null（不発）
+ * - rate=1 で毎歩確実エンカウント（debug knob）
+ * - rate=N で `rng() < 1/N` 抽選、当選したら groups から重み均等で 1 つ選び、
+ *   `+` 連結を分解してマスターから BattleEntity を組み立てる
+ *
+ * RaycastRenderer / TopDownRenderer の maybeRollEncounter から呼ばれる。
+ * テストでは `rng` に固定値関数を渡して挙動を assert する。
+ */
+
+import type { MonsterDef } from '../types'
+import type { BattleEntity } from './spellDsl'
+
+export function rollEncounter(input: {
+  rate: number
+  groups: ReadonlyArray<string>
+  masters: Record<string, MonsterDef>
+  rng: () => number
+}): BattleEntity[] | null {
+  if (input.rate === 0) return null
+  if (input.groups.length === 0) return null
+  if (input.rng() >= 1 / input.rate) return null
+
+  const groupSpec = input.groups[Math.floor(input.rng() * input.groups.length)]
+  const monsterIds = groupSpec
+    .split('+')
+    .map((s) => s.trim())
+    .filter(Boolean)
+  const enemies: BattleEntity[] = []
+  for (const id of monsterIds) {
+    const def = input.masters[id]
+    if (!def) {
+      console.warn(`[name-name] encounter group references unknown monster '${id}'`)
+      continue
+    }
+    enemies.push({
+      id: def.id,
+      name: def.name,
+      hp: def.hp,
+      maxHp: def.hp,
+      mp: def.mp ?? 0,
+      maxMp: def.mp ?? 0,
+      atk: def.atk,
+      def: def.def,
+      agi: def.agi,
+      exp: def.exp,
+      gold: def.gold,
+    })
+  }
+  return enemies.length > 0 ? enemies : null
+}


### PR DESCRIPTION
## 概要

2 つのバグを修正する。

## 修正 1: エンカウントが発生しない (#191)

### RaycastRenderer
`updateMovement`（WASD/矢印キー連続移動）でエンカウント抽選が呼ばれていなかった。
`snapStep`（タッチ 1 歩）にしか `maybeRollEncounter()` がなかったため、PC では一切エンカウントしない状態だった。

**修正**: `prevTileX/Y` フィールドを追加し、`updateMovement` の末尾でタイルグリッドが変化したときに `maybeRollEncounter()` を呼ぶよう追記。

### TopDownRenderer
エンカウント関連処理が全く未実装だった。

**修正**: `encounterRate` / `encounterGroups` / `masterMonsters` / `encounterCooldown` フィールドを追加、`load()` で初期化、`tryMove` 完了後に `maybeRollEncounter()` を呼ぶ。現時点では BattleScreen が未統合のため console.info のみ（RaycastRenderer と同様に BattleScreen 統合は次回 Issue で対応）。

## 修正 2: Raycast 床色フォールバックが TopDown と異なる (#192)

床 floor casting で TREE/WATER タイルとマップ範囲外のフォールバック色が `0x444444`（暗いグレー）だった。TopDown / MinimapOverlay は `TILE_COLORS_HEX[TileType.TREE]`（`0x1a3a1a`、暗い緑）を使うため視覚的不整合があった。

**修正**: フォールバックを `0x1a3a1a` に統一。

## テスト
- `npm run type-check`: clean
- `npm run lint`: clean
- `npm test`: 488 tests passed
- `cargo test`: 81 tests passed