### PR TITLE
feat: #197 EventRunner 新設・TopDownRenderer に inputLocked + NPC 歩行アニメを追加

### DIFF
--- a/frontend/src/game/TopDownRenderer.ts
+++ b/frontend/src/game/TopDownRenderer.ts
@@ -557,19 +557,19 @@ export class TopDownRenderer {
     const npc = this.npcs.find((n) => n.x === tx && n.y === ty)
     if (npc) {
       if (npc.data.scene) {
+        if (!this.eventRunner) return
         const event = this.gameData?.rpgEvents?.find((e) => e.name === npc.data.scene)
-        if (event) {
-          // once=true のトリガーは発火済みなら skip
-          if (event.once) {
-            const key = `name-name-event-done_npc_${npc.data.name}`
-            if (localStorage.getItem(key)) return
-            localStorage.setItem(key, '1')
-          }
-          this.inputLocked = true
-          this.eventRunner?.run(event.commands, () => {
-            this.inputLocked = false
-          })
+        if (!event) return
+        if (event.once) {
+          const key = `name-name-event-done-npc-${npc.data.name}`
+          if (localStorage.getItem(key)) return
+          // run が確実に呼ばれる直前に書き込む
+          localStorage.setItem(key, '1')
         }
+        this.inputLocked = true
+        this.eventRunner.run(event.commands, () => {
+          this.inputLocked = false
+        })
         return
       }
       this.dialogBox?.show(
@@ -589,6 +589,7 @@ export class TopDownRenderer {
    */
   private handleSwipe = (direction: SwipeDirection): void => {
     if (!this.initialized) return
+    if (this.inputLocked && this.eventRunner?.isRunning) return
     if (this.dialogBox?.isShowing) {
       // ダイアログ中のスワイプはダイアログ操作と分離。誤爆防止のため何もしない。
       return

--- a/frontend/src/game/TopDownRenderer.ts
+++ b/frontend/src/game/TopDownRenderer.ts
@@ -22,6 +22,7 @@ import {
 import { attachTouchInput, type SwipeDirection } from './touchInput'
 import { TouchMenuOverlay, DQ4_COMMANDS, type Dq4CommandId } from './TouchMenuOverlay'
 import { rollEncounter } from './encounter'
+import { EventRunner, type NpcMover } from './eventRunner'
 
 type Direction = 'up' | 'down' | 'left' | 'right'
 
@@ -47,6 +48,8 @@ export class TopDownRenderer {
   private world: Container
   private dialogBox: DialogBox | null = null
   private menuOverlay: TouchMenuOverlay | null = null
+  private eventRunner: EventRunner | null = null
+  private inputLocked = false
   private detachTouchInput: (() => void) | null = null
   /** isMoving 中に来たスワイプを 1 件だけキューする。連続スワイプの取りこぼし防止 (#178) */
   private pendingSwipe: Direction | null = null
@@ -85,6 +88,7 @@ export class TopDownRenderer {
   private encounterCooldown: number = 0
 
   private initialized = false
+  private gameData: RPGProject | null = null
 
   constructor() {
     this.app = new Application()
@@ -125,6 +129,12 @@ export class TopDownRenderer {
     })
     this.app.stage.addChild(this.dialogBox)
 
+    // EventRunner: NPC イベントのコマンドキューを順に実行する (#197)
+    const npcMover: NpcMover = {
+      moveNpcTo: (name, x, y, speed) => this.moveNpcTo(name, x, y, speed),
+    }
+    this.eventRunner = new EventRunner(this.dialogBox, npcMover)
+
     // ミニマップは raycast 専用 (#149)。topdown は元々全体俯瞰で見えているので不要。
 
     // タッチメニュー: DQ4 ファミコン版相当の左上 8 コマンドウィンドウ (#178 → #171)
@@ -155,6 +165,8 @@ export class TopDownRenderer {
     this.isMoving = false
     this.moveStart = 0
     this.dialogBox?.hide()
+    this.inputLocked = false
+    this.gameData = gameData
 
     this.mapTiles = gameData.map.tiles
     this.tileSize = gameData.map.tileSize
@@ -221,6 +233,8 @@ export class TopDownRenderer {
       const renderer = this.app.renderer
       this.app.destroy(true, { children: true })
       clearDemoSheetCache(renderer)
+      this.eventRunner?.destroy()
+      this.eventRunner = null
       this.dialogBox = null
       this.menuOverlay = null
       this.initialized = false
@@ -399,13 +413,20 @@ export class TopDownRenderer {
     if (this.dialogBox?.isShowing) {
       if (e.key === ' ' || e.key === 'Enter') {
         e.preventDefault()
-        // typewriter 表示中なら全文表示にスキップ、完了済みなら閉じる (#150)
-        if (this.dialogBox.isTyping()) {
+        if (this.inputLocked && this.eventRunner?.isRunning) {
+          this.eventRunner.advance()
+        } else if (this.dialogBox.isTyping()) {
+          // typewriter 表示中なら全文表示にスキップ、完了済みなら閉じる (#150)
           this.dialogBox.skipTypewriter()
         } else {
           this.dialogBox.hide()
         }
       }
+      return
+    }
+
+    // イベントランナー実行中は移動・メニューをブロック (#197)
+    if (this.inputLocked && this.eventRunner?.isRunning) {
       return
     }
 
@@ -533,6 +554,16 @@ export class TopDownRenderer {
     }
     const npc = this.npcs.find((n) => n.x === tx && n.y === ty)
     if (npc) {
+      if (npc.data.scene) {
+        const event = this.gameData?.rpgEvents?.find((e) => e.name === npc.data.scene)
+        if (event) {
+          this.inputLocked = true
+          this.eventRunner?.run(event.commands, () => {
+            this.inputLocked = false
+          })
+        }
+        return
+      }
       this.dialogBox?.show(
         npc.data.name,
         stripExpressionDirectives(npc.data.message),
@@ -578,7 +609,9 @@ export class TopDownRenderer {
   private handleTap = (): void => {
     if (!this.initialized) return
     if (this.dialogBox?.isShowing) {
-      if (this.dialogBox.isTyping()) {
+      if (this.inputLocked && this.eventRunner?.isRunning) {
+        this.eventRunner.advance()
+      } else if (this.dialogBox.isTyping()) {
         this.dialogBox.skipTypewriter()
       } else {
         this.dialogBox.hide()
@@ -731,5 +764,63 @@ export class TopDownRenderer {
 
   private gridToPixelY(gy: number): number {
     return gy * this.tileSize + this.tileSize / 2
+  }
+
+  /** NPC をグリッド単位でアニメ移動させる。完了したら resolve する Promise を返す (#197) */
+  private moveNpcTo(name: string, tx: number, ty: number, speed: number): Promise<void> {
+    return new Promise((resolve) => {
+      const npc = this.npcs.find((n) => n.data.name === name)
+      if (!npc) {
+        resolve()
+        return
+      }
+      const TILE = this.tileSize
+      const pxPerMs = (TILE * speed) / 1000
+
+      const moveNextTile = (): void => {
+        if (npc.x === tx && npc.y === ty) {
+          resolve()
+          return
+        }
+        const dx = Math.sign(tx - npc.x)
+        const dy = Math.sign(ty - npc.y)
+        const fromX = npc.container.x
+        const fromY = npc.container.y
+        npc.x += dx
+        npc.y += dy
+        const toX = this.gridToPixelX(npc.x)
+        const toY = this.gridToPixelY(npc.y)
+
+        // 向き更新
+        if (dx === 1) npc.direction = 'right'
+        else if (dx === -1) npc.direction = 'left'
+        else if (dy === 1) npc.direction = 'down'
+        else if (dy === -1) npc.direction = 'up'
+
+        const dist = TILE
+        const duration = dist / pxPerMs
+        const start = performance.now()
+
+        const tick = (): void => {
+          if (!this.initialized) {
+            resolve()
+            return
+          }
+          const elapsed = performance.now() - start
+          const t = Math.min(elapsed / duration, 1)
+          npc.container.x = fromX + (toX - fromX) * t
+          npc.container.y = fromY + (toY - fromY) * t
+          if (t < 1) {
+            requestAnimationFrame(tick)
+          } else {
+            npc.container.x = toX
+            npc.container.y = toY
+            moveNextTile()
+          }
+        }
+        requestAnimationFrame(tick)
+      }
+      moveNextTile()
+    })
   }
 }

--- a/frontend/src/game/TopDownRenderer.ts
+++ b/frontend/src/game/TopDownRenderer.ts
@@ -233,6 +233,7 @@ export class TopDownRenderer {
       const renderer = this.app.renderer
       this.app.destroy(true, { children: true })
       clearDemoSheetCache(renderer)
+      this.inputLocked = false
       this.eventRunner?.destroy()
       this.eventRunner = null
       this.dialogBox = null
@@ -536,6 +537,7 @@ export class TopDownRenderer {
   }
 
   private tryTalk(): void {
+    if (this.inputLocked) return
     let tx = this.playerGridX
     let ty = this.playerGridY
     switch (this.playerDirection) {
@@ -557,6 +559,12 @@ export class TopDownRenderer {
       if (npc.data.scene) {
         const event = this.gameData?.rpgEvents?.find((e) => e.name === npc.data.scene)
         if (event) {
+          // once=true のトリガーは発火済みなら skip
+          if (event.once) {
+            const key = `name-name-event-done_npc_${npc.data.name}`
+            if (localStorage.getItem(key)) return
+            localStorage.setItem(key, '1')
+          }
           this.inputLocked = true
           this.eventRunner?.run(event.commands, () => {
             this.inputLocked = false
@@ -802,7 +810,7 @@ export class TopDownRenderer {
         const start = performance.now()
 
         const tick = (): void => {
-          if (!this.initialized) {
+          if (!this.initialized || npc.container.destroyed) {
             resolve()
             return
           }

--- a/frontend/src/game/TopDownRenderer.ts
+++ b/frontend/src/game/TopDownRenderer.ts
@@ -560,7 +560,9 @@ export class TopDownRenderer {
         if (!this.eventRunner) return
         const event = this.gameData?.rpgEvents?.find((e) => e.name === npc.data.scene)
         if (!event) return
-        if (event.once) {
+        const trigger = this.gameData?.triggers?.find((t) => t.scene === npc.data.scene)
+        const isOnce = trigger?.once ?? false
+        if (isOnce) {
           const key = `name-name-event-done-npc-${npc.data.name}`
           if (localStorage.getItem(key)) return
           // run が確実に呼ばれる直前に書き込む

--- a/frontend/src/game/eventRunner.test.ts
+++ b/frontend/src/game/eventRunner.test.ts
@@ -1,0 +1,100 @@
+/**
+ * EventRunner のユニットテスト (#197)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventRunner } from './eventRunner'
+import type { NpcMover } from './eventRunner'
+import type { DialogBox } from './DialogBox'
+import type { EventCommand } from '../types'
+
+// DialogBox のモック
+function makeDialogBox(): DialogBox {
+  return {
+    isTyping: vi.fn(() => false),
+    skipTypewriter: vi.fn(),
+    isShowing: false,
+    show: vi.fn(),
+    hide: vi.fn(),
+  } as unknown as DialogBox
+}
+
+// NpcMover のモック
+function makeNpcMover(): NpcMover {
+  return {
+    moveNpcTo: vi.fn(() => Promise.resolve()),
+  }
+}
+
+describe('EventRunner', () => {
+  let dialogBox: ReturnType<typeof makeDialogBox>
+  let npcMover: ReturnType<typeof makeNpcMover>
+  let runner: EventRunner
+
+  beforeEach(() => {
+    dialogBox = makeDialogBox()
+    npcMover = makeNpcMover()
+    runner = new EventRunner(dialogBox as unknown as DialogBox, npcMover)
+  })
+
+  it('空のキューで即 isRunning=false になる', () => {
+    const onComplete = vi.fn()
+    runner.run([], onComplete)
+    expect(runner.isRunning).toBe(false)
+    expect(onComplete).toHaveBeenCalledOnce()
+  })
+
+  it('Wait コマンドで指定 ms 後に次のコマンドに進む', async () => {
+    vi.useFakeTimers()
+    const onComplete = vi.fn()
+    const commands: EventCommand[] = [{ type: 'Wait', ms: 100 }]
+    runner.run(commands, onComplete)
+    expect(runner.isRunning).toBe(true)
+    expect(onComplete).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(100)
+    await vi.runAllTimersAsync()
+    expect(runner.isRunning).toBe(false)
+    expect(onComplete).toHaveBeenCalledOnce()
+    vi.useRealTimers()
+  })
+
+  it('Dialog コマンドで dialogBox.show が呼ばれる', () => {
+    const commands: EventCommand[] = [{ type: 'Dialog', character: 'Alice', text: ['こんにちは'] }]
+    runner.run(commands)
+    expect(runner.isRunning).toBe(true)
+    expect(dialogBox.show).toHaveBeenCalledWith('Alice', 'こんにちは', undefined)
+  })
+
+  it('advance() で Dialog の次に進む', () => {
+    const onComplete = vi.fn()
+    ;(dialogBox as unknown as { isShowing: boolean }).isShowing = true
+    const commands: EventCommand[] = [{ type: 'Dialog', character: 'Bob', text: ['やあ'] }]
+    runner.run(commands, onComplete)
+    expect(runner.isRunning).toBe(true)
+    // advance() で Dialog を閉じて次へ
+    ;(dialogBox.isTyping as ReturnType<typeof vi.fn>).mockReturnValue(false)
+    runner.advance()
+    expect(dialogBox.hide).toHaveBeenCalled()
+    expect(onComplete).toHaveBeenCalledOnce()
+    expect(runner.isRunning).toBe(false)
+  })
+
+  it('onComplete コールバックが最後に呼ばれる', () => {
+    const onComplete = vi.fn()
+    const commands: EventCommand[] = [{ type: 'Narration', text: ['ナレーション'] }]
+    runner.run(commands, onComplete)
+    // Narration は advance() 待ち
+    expect(onComplete).not.toHaveBeenCalled()
+    ;(dialogBox as unknown as { isShowing: boolean }).isShowing = true
+    ;(dialogBox.isTyping as ReturnType<typeof vi.fn>).mockReturnValue(false)
+    runner.advance()
+    expect(onComplete).toHaveBeenCalledOnce()
+  })
+
+  it('destroy() で isRunning が false になる', () => {
+    const commands: EventCommand[] = [{ type: 'Dialog', character: 'X', text: ['test'] }]
+    runner.run(commands)
+    expect(runner.isRunning).toBe(true)
+    runner.destroy()
+    expect(runner.isRunning).toBe(false)
+  })
+})

--- a/frontend/src/game/eventRunner.ts
+++ b/frontend/src/game/eventRunner.ts
@@ -66,7 +66,9 @@ export class EventRunner {
     }
 
     if (cmd.type === 'Wait') {
-      setTimeout(() => this.step(), cmd.ms)
+      setTimeout(() => {
+        if (this.running) this.step()
+      }, cmd.ms)
       return
     }
 

--- a/frontend/src/game/eventRunner.ts
+++ b/frontend/src/game/eventRunner.ts
@@ -1,0 +1,95 @@
+/**
+ * RPG イベント実行エンジン (#197)
+ *
+ * EventCommand のキューを順に実行する。
+ * DialogBox への委譲・NPC 移動・Wait を担当。
+ * TopDownRenderer から呼ばれ、実行中は inputLocked = true を維持する。
+ */
+import type { EventCommand } from '../types'
+import type { DialogBox } from './DialogBox'
+
+export interface NpcMover {
+  /** NPC を指定タイルへアニメ移動させる。完了したら resolve する Promise を返す */
+  moveNpcTo(npcName: string, x: number, y: number, speed: number): Promise<void>
+}
+
+export class EventRunner {
+  private queue: EventCommand[] = []
+  private running = false
+  private dialogBox: DialogBox
+  private npcMover: NpcMover
+  private onComplete: (() => void) | undefined
+
+  constructor(dialogBox: DialogBox, npcMover: NpcMover) {
+    this.dialogBox = dialogBox
+    this.npcMover = npcMover
+  }
+
+  get isRunning(): boolean {
+    return this.running
+  }
+
+  /** イベントコマンド列を実行開始する */
+  run(commands: EventCommand[], onComplete?: () => void): void {
+    this.queue = [...commands]
+    this.running = true
+    this.onComplete = onComplete
+    this.step()
+  }
+
+  /** 現在の Dialog を送る（Enter/タップ時に呼ぶ） */
+  advance(): void {
+    if (!this.running) return
+    if (this.dialogBox.isTyping()) {
+      this.dialogBox.skipTypewriter()
+    } else if (this.dialogBox.isShowing) {
+      this.dialogBox.hide()
+      this.step()
+    }
+  }
+
+  private step(): void {
+    const cmd = this.queue.shift()
+    if (!cmd) {
+      this.running = false
+      const cb = this.onComplete
+      this.onComplete = undefined
+      cb?.()
+      return
+    }
+
+    if (cmd.type === 'NpcMove') {
+      this.npcMover.moveNpcTo(cmd.npc, cmd.x, cmd.y, cmd.speed ?? 3).then(() => this.step())
+      return
+    }
+
+    if (cmd.type === 'Wait') {
+      setTimeout(() => this.step(), cmd.ms)
+      return
+    }
+
+    if (cmd.type === 'Dialog') {
+      const name = cmd.character ?? ''
+      const text = cmd.text.join('\n')
+      this.dialogBox.show(name, text, undefined)
+      // advance() 呼び出し待ち（step は advance() で続く）
+      return
+    }
+
+    if (cmd.type === 'Narration') {
+      const text = cmd.text.join('\n')
+      this.dialogBox.show('', text, undefined)
+      // advance() 呼び出し待ち（step は advance() で続く）
+      return
+    }
+
+    // 未知のコマンドはスキップ
+    this.step()
+  }
+
+  destroy(): void {
+    this.queue = []
+    this.running = false
+    this.onComplete = undefined
+  }
+}

--- a/frontend/src/game/eventRunner.ts
+++ b/frontend/src/game/eventRunner.ts
@@ -59,7 +59,9 @@ export class EventRunner {
     }
 
     if (cmd.type === 'NpcMove') {
-      this.npcMover.moveNpcTo(cmd.npc, cmd.x, cmd.y, cmd.speed ?? 3).then(() => this.step())
+      this.npcMover.moveNpcTo(cmd.npc, cmd.x, cmd.y, cmd.speed ?? 3).then(() => {
+        if (this.running) this.step()
+      })
       return
     }
 

--- a/frontend/src/game/rpgProjectFromDoc.ts
+++ b/frontend/src/game/rpgProjectFromDoc.ts
@@ -23,6 +23,7 @@ export function collectRpgEvents(doc: EventDocument): UiRpgEvent[] {
         if ('RpgEvent' in ev) {
           result.push({
             name: ev.RpgEvent.name,
+            once: (ev.RpgEvent as { once?: boolean }).once ?? false,
             commands: ev.RpgEvent.commands as EventCommand[],
           })
         }

--- a/frontend/src/game/rpgProjectFromDoc.ts
+++ b/frontend/src/game/rpgProjectFromDoc.ts
@@ -6,8 +6,31 @@ import type {
   ItemDef,
   SpellDef,
   PartyMemberDef,
+  EventCommand,
 } from '../types'
-import type { RPGProject, MapData, UiNpcData, PlayerData } from '../types/rpg'
+import type { RPGProject, MapData, UiNpcData, PlayerData, UiRpgEvent } from '../types/rpg'
+
+/**
+ * Document 全体（全章 / 全シーン）を走査して `[イベント]` ブロックを収集する (#197)。
+ * parser の RpgEvent を UiRpgEvent に変換して返す。
+ */
+export function collectRpgEvents(doc: EventDocument): UiRpgEvent[] {
+  const result: UiRpgEvent[] = []
+  for (const chapter of doc.chapters) {
+    for (const scene of chapter.scenes) {
+      for (const ev of scene.events) {
+        if (typeof ev === 'string') continue
+        if ('RpgEvent' in ev) {
+          result.push({
+            name: ev.RpgEvent.name,
+            commands: ev.RpgEvent.commands as EventCommand[],
+          })
+        }
+      }
+    }
+  }
+  return result
+}
 
 /**
  * Document 全体（全章 / 全シーン）を走査して `[モンスター] [アイテム] [呪文]` の
@@ -115,6 +138,8 @@ export function rpgProjectFromDoc(
 
   // Document 全体からマスターデータを収集して RPGProject に同梱する (#174 / #172)
   const master = collectMasterData(doc)
+  // Document 全体から RPG イベントを収集する (#197)
+  const rpgEvents = collectRpgEvents(doc)
 
   return {
     name: projectName,
@@ -127,6 +152,7 @@ export function rpgProjectFromDoc(
     items: master.items,
     spells: master.spells,
     party: master.party,
+    rpgEvents: rpgEvents.length > 0 ? rpgEvents : undefined,
   }
 }
 

--- a/frontend/src/game/rpgProjectFromDoc.ts
+++ b/frontend/src/game/rpgProjectFromDoc.ts
@@ -8,7 +8,14 @@ import type {
   PartyMemberDef,
   EventCommand,
 } from '../types'
-import type { RPGProject, MapData, UiNpcData, PlayerData, UiRpgEvent } from '../types/rpg'
+import type {
+  RPGProject,
+  MapData,
+  UiNpcData,
+  PlayerData,
+  UiRpgEvent,
+  UiRpgTrigger,
+} from '../types/rpg'
 
 /**
  * Document 全体（全章 / 全シーン）を走査して `[イベント]` ブロックを収集する (#197)。
@@ -23,7 +30,6 @@ export function collectRpgEvents(doc: EventDocument): UiRpgEvent[] {
         if ('RpgEvent' in ev) {
           result.push({
             name: ev.RpgEvent.name,
-            once: (ev.RpgEvent as { once?: boolean }).once ?? false,
             commands: ev.RpgEvent.commands as EventCommand[],
           })
         }
@@ -34,7 +40,32 @@ export function collectRpgEvents(doc: EventDocument): UiRpgEvent[] {
 }
 
 /**
- * Document 全体（全章 / 全シーン）を走査して `[モンスター] [アイテム] [呪文]` の
+ * Document 全体（全章 / 全シーン）を走査して `[トリガー]` ブロックを収集する (#187)。
+ * parser の RpgTrigger を UiRpgTrigger に変換して返す。
+ */
+function collectRpgTriggers(doc: EventDocument): UiRpgTrigger[] {
+  const triggers: UiRpgTrigger[] = []
+  for (const chapter of doc.chapters) {
+    for (const scene of chapter.scenes) {
+      for (const ev of scene.events) {
+        if (typeof ev === 'string') continue
+        if ('RpgTrigger' in ev) {
+          const t = ev.RpgTrigger
+          triggers.push({
+            x: t.x,
+            y: t.y,
+            auto: t.auto,
+            scene: t.scene,
+            once: t.once,
+          })
+        }
+      }
+    }
+  }
+  return triggers
+}
+
+/**
  * マスター定義を ID 引きの Record に集約する (#174 / #172)。
  *
  * 重複 ID は **後勝ち**（同じ id を 2 度書いた場合、ドキュメント上で後に出てきた
@@ -141,6 +172,8 @@ export function rpgProjectFromDoc(
   const master = collectMasterData(doc)
   // Document 全体から RPG イベントを収集する (#197)
   const rpgEvents = collectRpgEvents(doc)
+  // Document 全体から RPG トリガーを収集する (#187)
+  const triggers = collectRpgTriggers(doc)
 
   return {
     name: projectName,
@@ -154,6 +187,7 @@ export function rpgProjectFromDoc(
     spells: master.spells,
     party: master.party,
     rpgEvents: rpgEvents.length > 0 ? rpgEvents : undefined,
+    triggers: triggers.length > 0 ? triggers : undefined,
   }
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -257,3 +257,12 @@ export interface EventRef {
 
 export type EditableDialogField = 'character' | 'expression' | 'text'
 export type EditableNarrationField = 'text'
+
+/**
+ * RPG イベントコマンド (#197)。parser の EventCommand と同期する。
+ */
+export type EventCommand =
+  | { type: 'NpcMove'; npc: string; x: number; y: number; speed?: number; direction?: Direction }
+  | { type: 'Wait'; ms: number }
+  | { type: 'Dialog'; character?: string; text: string[] }
+  | { type: 'Narration'; text: string[] }

--- a/frontend/src/types/rpg.ts
+++ b/frontend/src/types/rpg.ts
@@ -103,6 +103,15 @@ export interface PlayerData {
 }
 
 /**
+ * RPG イベント（コマンドキュー）の UI 側型 (#197)。
+ * parser の RpgEvent / EventCommand と同期する。
+ */
+export interface UiRpgEvent {
+  name: string
+  commands: import('../types').EventCommand[]
+}
+
+/**
  * イベントデータ（将来的な拡張用）
  */
 export interface EventData {
@@ -133,6 +142,11 @@ export interface RPGProject {
   player: PlayerData // プレイヤー初期データ
   npcs: UiNpcData[] // NPCリスト
   events?: EventData[] // イベントリスト（オプション）
+  /**
+   * RPG イベント（コマンドキュー）リスト (#197)。
+   * NPC の scene フィールドから参照される。
+   */
+  rpgEvents?: UiRpgEvent[]
   // プレイ時の表示モード。必須化済み。デフォルトは 'topdown' 相当。
   // （Doc の scene.view=Raycast から派生したときは 'raycast'）
   view: 'topdown' | 'raycast'

--- a/frontend/src/types/rpg.ts
+++ b/frontend/src/types/rpg.ts
@@ -108,8 +108,21 @@ export interface PlayerData {
  */
 export interface UiRpgEvent {
   name: string
-  once: boolean
   commands: import('../types').EventCommand[]
+}
+
+/** RPG タイル踏み込み / auto トリガー定義 (#187) */
+export interface UiRpgTrigger {
+  /** 踏み込みトリガーの X 座標。auto トリガーの場合は undefined */
+  x?: number
+  /** 踏み込みトリガーの Y 座標。auto トリガーの場合は undefined */
+  y?: number
+  /** true のときマップ進入時に自動発火 */
+  auto: boolean
+  /** 実行するイベント名 */
+  scene: string
+  /** true のとき初回のみ発火 */
+  once: boolean
 }
 
 /**
@@ -148,6 +161,8 @@ export interface RPGProject {
    * NPC の scene フィールドから参照される。
    */
   rpgEvents?: UiRpgEvent[]
+  /** RPG タイル踏み込み / auto トリガーリスト (#187) */
+  triggers?: UiRpgTrigger[]
   // プレイ時の表示モード。必須化済み。デフォルトは 'topdown' 相当。
   // （Doc の scene.view=Raycast から派生したときは 'raycast'）
   view: 'topdown' | 'raycast'

--- a/frontend/src/types/rpg.ts
+++ b/frontend/src/types/rpg.ts
@@ -108,6 +108,7 @@ export interface PlayerData {
  */
 export interface UiRpgEvent {
   name: string
+  once: boolean
   commands: import('../types').EventCommand[]
 }
 


### PR DESCRIPTION
## 関連 Issue
closes #197
refs #187

## 変更内容

### 新規ファイル
- `eventRunner.ts`: EventCommand キューを順実行。Dialog/Narration は advance() 待ち、NpcMove は Promise で完了待ち、Wait は setTimeout。onComplete コールバック対応。
- `eventRunner.test.ts`: 6テスト（空キュー・Wait・Dialog・advance・onComplete・destroy）

### 変更ファイル
- `TopDownRenderer.ts`: EventRunner / inputLocked フィールド追加。handleKeyDown/handleTap でロック中は advance() 委譲。tryTalk() で npc.data.scene があれば EventRunner 実行。moveNpcTo() でタイル単位アニメ移動。
- `rpgProjectFromDoc.ts`: collectRpgEvents() で全シーンの RpgEvent を収集し rpgEvents に含める
- `types/rpg.ts`: UiRpgEvent 型・RPGProject.rpgEvents フィールド追加
- `types.ts`: EventCommand 型追加

## テスト結果
- vitest: **506 passed**（新規 6 tests 含む）
- tsc --noEmit: エラーなし