### PR TITLE
fix: #198 再レビュー指摘修正（tryMove inputLocked ガード・once フラグ設計明示）

### DIFF
--- a/frontend/src/game/TopDownRenderer.ts
+++ b/frontend/src/game/TopDownRenderer.ts
@@ -475,6 +475,9 @@ export class TopDownRenderer {
   }
 
   private tryMove(direction: Direction): void {
+    // inputLocked 中は移動を受け付けない。handleKeyDown / handleSwipe 側でもガードしているが、
+    // 将来の呼び出し元追加時の安全網として tryMove 自体でも確認する (#198)
+    if (this.inputLocked) return
     this.playerDirection = direction
     this.updateDirectionIndicator()
 
@@ -528,6 +531,10 @@ export class TopDownRenderer {
 
   /**
    * マップ進入時にautoトリガーを全て発火する (#198)
+   *
+   * `load()` から呼ばれるため、マップを再訪（load 再呼び出し）するたびに実行される。
+   * once=false の auto トリガーはマップ再訪のたびに発火する（意図的な仕様）。
+   * once=true の auto トリガーは初回進入時のみ発火し、以後はフラグでスキップされる。
    */
   private fireAutoTriggers(): void {
     const triggers = this.gameData?.triggers
@@ -544,10 +551,17 @@ export class TopDownRenderer {
   private fireTrigger(trigger: UiRpgTrigger): void {
     if (!this.eventRunner || !this.gameData) return
     const event = this.gameData.rpgEvents?.find((e) => e.name === trigger.scene)
-    if (!event) return
+    if (!event) {
+      console.warn(`[TopDownRenderer] trigger scene not found: "${trigger.scene}"`)
+      return
+    }
     if (trigger.once) {
       const key = triggerDoneKey(trigger.scene)
       if (localStorage.getItem(key)) return
+      // EventRunner.run() は同期的にキューを設定して step() を呼ぶだけであり、
+      // 例外を throw しない設計（eventRunner.ts: run() 参照）。
+      // この前提のもと「run() の直前に書き込む」ことで
+      // 「run が呼ばれたが onComplete が未発火」状態でもフラグが重複発火を防ぐ。
       localStorage.setItem(key, '1')
     }
     this.inputLocked = true
@@ -619,7 +633,8 @@ export class TopDownRenderer {
         if (isOnce) {
           const key = triggerDoneKey(npc.data.scene)
           if (localStorage.getItem(key)) return
-          // run が確実に呼ばれる直前に書き込む
+          // EventRunner.run() は例外を throw しない設計のため、
+          // run() の直前に書き込むことで重複発火を安全に防ぐ（fireTrigger と同方針）。
           localStorage.setItem(key, '1')
         }
         this.inputLocked = true

--- a/frontend/src/types/rpg.ts
+++ b/frontend/src/types/rpg.ts
@@ -111,7 +111,12 @@ export interface UiRpgEvent {
   commands: import('../types').EventCommand[]
 }
 
-/** RPG タイル踏み込み / auto トリガー定義 (#187) */
+/** RPG タイル踏み込み / auto トリガー定義 (#187)
+ *
+ * `scene` は RPGProject 内でユニークな名前を使うこと。
+ * once=true のフラグは `trigger_{scene}` キーで localStorage に保存されるため、
+ * 異なるトリガーに同じ scene 名を使うと once フラグが共有される。
+ */
 export interface UiRpgTrigger {
   /** 踏み込みトリガーの X 座標。auto トリガーの場合は undefined */
   x?: number


### PR DESCRIPTION
## 背景

PR #201 マージ後の再レビューで must 指摘 2 件が検出されたため修正。

## 変更内容

### must-1: `fireTrigger` の once フラグ書き込みタイミングの設計前提を明示

`EventRunner.run()` は同期的にキューを設定するだけで例外を throw しない設計であることをコードコメントに明記。これにより「run() 直前にフラグを書く」方針の安全性を担保する根拠を明示した。`tryTalk` 側の既存コメントも同方針に統一。

### must-2: `tryMove` に `inputLocked` ガードを追加

`handleKeyDown` / `handleSwipe` 側でガード済みだが、将来の呼び出し元追加時の安全網として `tryMove` 自体にも `if (this.inputLocked) return` を追加。

### should/nit

- `fireAutoTriggers` のメソッドコメントに once=false の再訪再発火仕様を明記
- `UiRpgTrigger` に scene 名ユニーク前提の JSDoc を追加（once フラグのキー共有設計を明示）
- `fireTrigger` で scene が見つからない場合に `console.warn` を追加（デバッグ支援）