### PR TITLE
fix: 立ち絵 Y 座標を screenHeight 比率に変更（縦長モード対応）

### DIFF
--- a/frontend/src/game/CharacterLayer.test.ts
+++ b/frontend/src/game/CharacterLayer.test.ts
@@ -22,7 +22,7 @@ function asInternals(layer: CharacterLayer): CharacterLayerInternals {
 
 describe('CharacterLayer fade (Issue #177)', () => {
   it('show() の新規表示は alpha 0 から fade-in を開始する', () => {
-    const layer = new CharacterLayer()
+    const layer = new CharacterLayer(450)
     layer.show('hero', 'normal', '中央', '/assets')
     const state = asInternals(layer).characters.get('hero')
     expect(state).toBeDefined()
@@ -34,7 +34,7 @@ describe('CharacterLayer fade (Issue #177)', () => {
   })
 
   it('show() に instant: true を渡すと alpha 1 で即時表示し fadeAnimation は無し', () => {
-    const layer = new CharacterLayer()
+    const layer = new CharacterLayer(450)
     layer.show('hero', 'normal', '中央', '/assets', { instant: true })
     const state = asInternals(layer).characters.get('hero')
     expect(state!.sprite.alpha).toBe(1)
@@ -42,7 +42,7 @@ describe('CharacterLayer fade (Issue #177)', () => {
   })
 
   it('remove() のデフォルトは fade-out（destroyOnComplete=true）に切り替えるだけ', () => {
-    const layer = new CharacterLayer()
+    const layer = new CharacterLayer(450)
     layer.show('hero', 'normal', '中央', '/assets', { instant: true })
     layer.remove('hero')
     const state = asInternals(layer).characters.get('hero')
@@ -53,14 +53,14 @@ describe('CharacterLayer fade (Issue #177)', () => {
   })
 
   it('remove() に instant: true を渡すと characters から即座に消える', () => {
-    const layer = new CharacterLayer()
+    const layer = new CharacterLayer(450)
     layer.show('hero', 'normal', '中央', '/assets', { instant: true })
     layer.remove('hero', { instant: true })
     expect(asInternals(layer).characters.has('hero')).toBe(false)
   })
 
   it('退場フェード中の同名キャラ再 show は fade-in に切り替える', () => {
-    const layer = new CharacterLayer()
+    const layer = new CharacterLayer(450)
     layer.show('hero', 'normal', '中央', '/assets', { instant: true })
     layer.remove('hero')
     // 退場フェード中

--- a/frontend/src/game/CharacterLayer.test.ts
+++ b/frontend/src/game/CharacterLayer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { CharacterLayer, normalizePosition } from './CharacterLayer'
+import { ASPECT_RATIOS } from './constants'
 
 interface FadeAnimationLike {
   fromAlpha: number
@@ -122,6 +123,6 @@ describe('CharacterLayer portrait mode (Issue #209)', () => {
     layer.show('hero', 'normal', '中央', '/assets', { instant: true })
     const state = asInternals(layer).characters.get('hero')
     expect(state).toBeDefined()
-    expect(state!.sprite.y).toBeCloseTo(800 * (380 / 450), 5)
+    expect(state!.sprite.y).toBeCloseTo(800 * (380 / ASPECT_RATIOS['16:9'].height), 5)
   })
 })

--- a/frontend/src/game/CharacterLayer.test.ts
+++ b/frontend/src/game/CharacterLayer.test.ts
@@ -8,7 +8,7 @@ interface FadeAnimationLike {
 }
 
 interface CharacterStateLike {
-  sprite: { alpha: number }
+  sprite: { alpha: number; y: number }
   fadeAnimation: FadeAnimationLike | null
 }
 
@@ -113,5 +113,15 @@ describe('normalizePosition', () => {
     expect(normalizePosition('まんなか')).toBe('center')
     expect(normalizePosition('右寄り')).toBe('right')
     expect(normalizePosition('右端')).toBe('right')
+  })
+})
+
+describe('CharacterLayer portrait mode (Issue #209)', () => {
+  it('screenHeight=800（9:16）で sprite.y が 800 * (380 / 450) ≒ 676 になる', () => {
+    const layer = new CharacterLayer(800)
+    layer.show('hero', 'normal', '中央', '/assets', { instant: true })
+    const state = asInternals(layer).characters.get('hero')
+    expect(state).toBeDefined()
+    expect(state!.sprite.y).toBeCloseTo(800 * (380 / 450), 5)
   })
 })

--- a/frontend/src/game/CharacterLayer.ts
+++ b/frontend/src/game/CharacterLayer.ts
@@ -56,8 +56,8 @@ export function normalizePosition(position: string): string {
   return POSITION_ALIASES_JA[position] ?? POSITION_ALIASES_EN[position] ?? position
 }
 
-/** 足元 Y 座標（ダイアログボックス上端あたり） */
-const CHARACTER_Y = 380
+/** 足元 Y 座標の比率（横長 450px 基準: 380/450 ≒ 0.844） */
+const CHARACTER_Y_RATIO = 380 / 450
 
 interface CharacterState {
   sprite: Sprite
@@ -118,6 +118,13 @@ export class CharacterLayer extends Container {
   private animTicker: Ticker | null = null
   /** ticker.deltaMS の累計を保持してアニメ進行に使う */
   private elapsedMs: number = 0
+  /** 足元 Y 座標（screenHeight * CHARACTER_Y_RATIO） */
+  private readonly characterY: number
+
+  constructor(screenHeight: number) {
+    super()
+    this.characterY = screenHeight * CHARACTER_Y_RATIO
+  }
 
   /**
    * キャラクター立ち絵を表示する。既に表示中なら position / expression を更新する。
@@ -182,7 +189,7 @@ export class CharacterLayer extends Container {
     const sprite = new Sprite()
     sprite.anchor.set(0.5, 1)
     sprite.x = x
-    sprite.y = CHARACTER_Y
+    sprite.y = this.characterY
     sprite.alpha = instant ? 1 : 0
     this.addChild(sprite)
 

--- a/frontend/src/game/CharacterLayer.ts
+++ b/frontend/src/game/CharacterLayer.ts
@@ -7,6 +7,7 @@
 import { Assets, Container, Sprite, Ticker } from 'pixi.js'
 import type { Easing } from '../types'
 import { applyEasing, resolveDelta } from './easing'
+import { ASPECT_RATIOS } from './constants'
 
 /** キャラクターの画面上の配置位置 */
 const POSITION_X: Record<string, number> = {
@@ -57,7 +58,7 @@ export function normalizePosition(position: string): string {
 }
 
 /** 足元 Y 座標の比率（横長 450px 基準: 380/450 ≒ 0.844） */
-const CHARACTER_Y_RATIO = 380 / 450
+const CHARACTER_Y_RATIO = 380 / ASPECT_RATIOS['16:9'].height
 
 interface CharacterState {
   sprite: Sprite
@@ -121,6 +122,9 @@ export class CharacterLayer extends Container {
   /** 足元 Y 座標（screenHeight * CHARACTER_Y_RATIO） */
   private readonly characterY: number
 
+  /**
+   * @param screenHeight 論理画面高さ（ASPECT_RATIOS から取得した値を渡す）
+   */
   constructor(screenHeight: number) {
     super()
     this.characterY = screenHeight * CHARACTER_Y_RATIO

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -191,12 +191,12 @@ export class NovelRenderer {
     this.app = new Application()
     this.bgGraphics = new Graphics()
     this.bgContainer = new Container()
-    this.characterLayer = new CharacterLayer()
-    this.blackoutOverlay = new Graphics()
-    this.defaultDialogBorderless = config?.dialogBorderless ?? false
     const ratio = parseAspectRatio(config?.aspectRatio)
     this.screenWidth = ASPECT_RATIOS[ratio].width
     this.screenHeight = ASPECT_RATIOS[ratio].height
+    this.characterLayer = new CharacterLayer(this.screenHeight)
+    this.blackoutOverlay = new Graphics()
+    this.defaultDialogBorderless = config?.dialogBorderless ?? false
     this.dialogBox = new DialogBox({
       screenWidth: this.screenWidth,
       screenHeight: this.screenHeight,


### PR DESCRIPTION
## 関連 Issue
closes #209

## 変更内容

### 原因
`CharacterLayer.ts` の `CHARACTER_Y = 380` が固定値だったため、縦長（9:16: height=800px）モードで立ち絵が画面上方に表示されていた。

| モード | キャンバス高さ | 修正前 Y | 修正後 Y |
|---|---|---|---|
| 16:9（横長） | 450px | 380px | 380px（変わらず） |
| 9:16（縦長） | 800px | 380px（上方にずれる）| ≒676px（ダイアログ直上） |
| 4:3 | 600px | 380px | ≒506px |

### 修正内容
- `CHARACTER_Y = 380`（固定値）→ `CHARACTER_Y_RATIO = 380 / ASPECT_RATIOS['16:9'].height`（比率）
- `CharacterLayer` コンストラクタに `screenHeight: number` を追加
- `NovelRenderer` から `new CharacterLayer(this.screenHeight)` で渡す
- `CharacterLayer.test.ts` に 9:16（screenHeight=800）のテストケースを追加

## テスト
vitest 516 tests pass