### PR TITLE
fix: 選択肢クリック直後の advance 競合を修正（#211）

### DIFF
--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -914,7 +914,6 @@ export class NovelRenderer {
   }
 
   private handleAdvance = (): void => {
-    // 選択肢クリックと同フレームの advance を抑制する (#211)
     if (this.justSelectedChoice) {
       this.justSelectedChoice = false
       return
@@ -939,6 +938,10 @@ export class NovelRenderer {
   }
 
   private handleKeyDown = (e: KeyboardEvent): void => {
+    if (this.justSelectedChoice) {
+      this.justSelectedChoice = false
+      return
+    }
     this.audioManager.ensureContext()
 
     // Escape: 開いているオーバーレイを閉じる
@@ -1088,7 +1091,12 @@ export class NovelRenderer {
       this.choiceOverlay.show(
         event.Choice.options,
         (jump: string) => {
-          this.justSelectedChoice = true // 同フレームの advance を抑制 (#211)
+          // 同フレームの advance を抑制。jumpToScene が例外を投げても次の
+          // イベントループで確実にリセットされるよう setTimeout(0) を使う (#211)
+          this.justSelectedChoice = true
+          setTimeout(() => {
+            this.justSelectedChoice = false
+          }, 0)
           this.waitingForChoice = false
           this.choiceOverlay.hide()
           this.jumpToScene(jump)

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -118,6 +118,8 @@ export class NovelRenderer {
 
   /** 選択肢表示中フラグ */
   private waitingForChoice = false
+  /** 選択肢クリック直後の同フレーム advance を抑制するフラグ (#211) */
+  private justSelectedChoice = false
 
   /** Wait イベント実行中フラグ */
   private waitingForWait = false
@@ -912,6 +914,11 @@ export class NovelRenderer {
   }
 
   private handleAdvance = (): void => {
+    // 選択肢クリックと同フレームの advance を抑制する (#211)
+    if (this.justSelectedChoice) {
+      this.justSelectedChoice = false
+      return
+    }
     this.audioManager.ensureContext()
     if (this.backlogOverlay.visible) {
       this.backlogOverlay.hide()
@@ -1081,6 +1088,7 @@ export class NovelRenderer {
       this.choiceOverlay.show(
         event.Choice.options,
         (jump: string) => {
+          this.justSelectedChoice = true // 同フレームの advance を抑制 (#211)
           this.waitingForChoice = false
           this.choiceOverlay.hide()
           this.jumpToScene(jump)


### PR DESCRIPTION
closes #211

選択肢ボタン pointerdown が Canvas DOM リスナー handleAdvance にも伝播し advance() が呼ばれるバグを修正。justSelectedChoice フラグ + setTimeout(0) 自動リセットで handleAdvance/handleKeyDown 両経路をガード。vitest 516 pass