### PR TITLE
fix: 立ち絵 X 座標を screenWidth 比率に変更

### DIFF
--- a/frontend/src/game/CharacterLayer.test.ts
+++ b/frontend/src/game/CharacterLayer.test.ts
@@ -23,7 +23,7 @@ function asInternals(layer: CharacterLayer): CharacterLayerInternals {
 
 describe('CharacterLayer fade (Issue #177)', () => {
   it('show() の新規表示は alpha 0 から fade-in を開始する', () => {
-    const layer = new CharacterLayer(450)
+    const layer = new CharacterLayer(800, 450)
     layer.show('hero', 'normal', '中央', '/assets')
     const state = asInternals(layer).characters.get('hero')
     expect(state).toBeDefined()
@@ -35,7 +35,7 @@ describe('CharacterLayer fade (Issue #177)', () => {
   })
 
   it('show() に instant: true を渡すと alpha 1 で即時表示し fadeAnimation は無し', () => {
-    const layer = new CharacterLayer(450)
+    const layer = new CharacterLayer(800, 450)
     layer.show('hero', 'normal', '中央', '/assets', { instant: true })
     const state = asInternals(layer).characters.get('hero')
     expect(state!.sprite.alpha).toBe(1)
@@ -43,7 +43,7 @@ describe('CharacterLayer fade (Issue #177)', () => {
   })
 
   it('remove() のデフォルトは fade-out（destroyOnComplete=true）に切り替えるだけ', () => {
-    const layer = new CharacterLayer(450)
+    const layer = new CharacterLayer(800, 450)
     layer.show('hero', 'normal', '中央', '/assets', { instant: true })
     layer.remove('hero')
     const state = asInternals(layer).characters.get('hero')
@@ -54,14 +54,14 @@ describe('CharacterLayer fade (Issue #177)', () => {
   })
 
   it('remove() に instant: true を渡すと characters から即座に消える', () => {
-    const layer = new CharacterLayer(450)
+    const layer = new CharacterLayer(800, 450)
     layer.show('hero', 'normal', '中央', '/assets', { instant: true })
     layer.remove('hero', { instant: true })
     expect(asInternals(layer).characters.has('hero')).toBe(false)
   })
 
   it('退場フェード中の同名キャラ再 show は fade-in に切り替える', () => {
-    const layer = new CharacterLayer(450)
+    const layer = new CharacterLayer(800, 450)
     layer.show('hero', 'normal', '中央', '/assets', { instant: true })
     layer.remove('hero')
     // 退場フェード中
@@ -119,7 +119,7 @@ describe('normalizePosition', () => {
 
 describe('CharacterLayer portrait mode (Issue #209)', () => {
   it('screenHeight=800（9:16）で sprite.y が 800 * (380 / 450) ≒ 676 になる', () => {
-    const layer = new CharacterLayer(800)
+    const layer = new CharacterLayer(450, 800)
     layer.show('hero', 'normal', '中央', '/assets', { instant: true })
     const state = asInternals(layer).characters.get('hero')
     expect(state).toBeDefined()

--- a/frontend/src/game/CharacterLayer.test.ts
+++ b/frontend/src/game/CharacterLayer.test.ts
@@ -126,3 +126,21 @@ describe('CharacterLayer portrait mode (Issue #209)', () => {
     expect(state!.sprite.y).toBeCloseTo(800 * (380 / ASPECT_RATIOS['16:9'].height), 5)
   })
 })
+
+describe('CharacterLayer X position ratio (Issue #216)', () => {
+  it('9:16（screenWidth=450）で center の sprite.x が 450 * 0.5 = 225 になる', () => {
+    const layer = new CharacterLayer(450, 800)
+    layer.show('hero', 'normal', 'center', '/assets', { instant: true })
+    const state = asInternals(layer).characters.get('hero')
+    expect(state).toBeDefined()
+    expect(state!.sprite.x).toBeCloseTo(225, 0)
+  })
+
+  it('16:9（screenWidth=800）で center の sprite.x が 800 * 0.5 = 400 になる', () => {
+    const layer = new CharacterLayer(800, 450)
+    layer.show('hero', 'normal', 'center', '/assets', { instant: true })
+    const state = asInternals(layer).characters.get('hero')
+    expect(state).toBeDefined()
+    expect(state!.sprite.x).toBeCloseTo(400, 0)
+  })
+})

--- a/frontend/src/game/CharacterLayer.ts
+++ b/frontend/src/game/CharacterLayer.ts
@@ -9,11 +9,11 @@ import type { Easing } from '../types'
 import { applyEasing, resolveDelta } from './easing'
 import { ASPECT_RATIOS } from './constants'
 
-/** キャラクターの画面上の配置位置 */
-const POSITION_X: Record<string, number> = {
-  left: 150,
-  center: 400,
-  right: 650,
+/** キャラクターの画面上の配置位置（screenWidth に対する比率） */
+const CHARACTER_X_RATIO: Record<string, number> = {
+  left: 150 / 800, // 0.1875
+  center: 400 / 800, // 0.5
+  right: 650 / 800, // 0.8125
 }
 
 /**
@@ -121,13 +121,21 @@ export class CharacterLayer extends Container {
   private elapsedMs: number = 0
   /** 足元 Y 座標（screenHeight * CHARACTER_Y_RATIO） */
   private readonly characterY: number
+  /** X 座標テーブル（screenWidth * CHARACTER_X_RATIO[pos]） */
+  private readonly positionX: Record<string, number>
 
   /**
+   * @param screenWidth 論理画面幅（ASPECT_RATIOS から取得した値を渡す）
    * @param screenHeight 論理画面高さ（ASPECT_RATIOS から取得した値を渡す）
    */
-  constructor(screenHeight: number) {
+  constructor(screenWidth: number, screenHeight: number) {
     super()
     this.characterY = screenHeight * CHARACTER_Y_RATIO
+    this.positionX = {
+      left: screenWidth * CHARACTER_X_RATIO.left,
+      center: screenWidth * CHARACTER_X_RATIO.center,
+      right: screenWidth * CHARACTER_X_RATIO.right,
+    }
   }
 
   /**
@@ -175,7 +183,7 @@ export class CharacterLayer extends Container {
 
       // 位置変更
       if (existing.position !== normalizedPosition) {
-        const x = POSITION_X[normalizedPosition] ?? POSITION_X['center']
+        const x = this.positionX[normalizedPosition] ?? this.positionX['center']
         existing.sprite.x = x
         existing.position = normalizedPosition
       }
@@ -189,7 +197,7 @@ export class CharacterLayer extends Container {
     }
 
     // 新規表示
-    const x = POSITION_X[normalizedPosition] ?? POSITION_X['center']
+    const x = this.positionX[normalizedPosition] ?? this.positionX['center']
     const sprite = new Sprite()
     sprite.anchor.set(0.5, 1)
     sprite.x = x

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -196,7 +196,7 @@ export class NovelRenderer {
     const ratio = parseAspectRatio(config?.aspectRatio)
     this.screenWidth = ASPECT_RATIOS[ratio].width
     this.screenHeight = ASPECT_RATIOS[ratio].height
-    this.characterLayer = new CharacterLayer(this.screenHeight)
+    this.characterLayer = new CharacterLayer(this.screenWidth, this.screenHeight)
     this.blackoutOverlay = new Graphics()
     this.defaultDialogBorderless = config?.dialogBorderless ?? false
     this.dialogBox = new DialogBox({


### PR DESCRIPTION
## 関連 Issue
closes #216

## 変更内容
- `CharacterLayer` の `POSITION_X`（px固定）を `CHARACTER_X_RATIO`（比率）に変更
- コンストラクタに `screenWidth` を追加し、`positionX` をインスタンスで計算
- `NovelRenderer` から `screenWidth` を渡すよう変更
- テスト側の `new CharacterLayer` 呼び出しも更新