### PR TITLE
fix: メニュー戻り後のダイアログ空表示・型エラー修正

### DIFF
--- a/frontend/src/game/CharacterLayer.test.ts
+++ b/frontend/src/game/CharacterLayer.test.ts
@@ -9,7 +9,7 @@ interface FadeAnimationLike {
 }
 
 interface CharacterStateLike {
-  sprite: { alpha: number; y: number }
+  sprite: { alpha: number; x: number; y: number }
   fadeAnimation: FadeAnimationLike | null
 }
 

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -374,6 +374,8 @@ export class NovelRenderer {
     this.characterLayer.clear()
     this.blackoutOverlay.visible = false
     this.currentBgmPath = null
+    // シーン遷移時にダイアログを明示的にクリアする（前シーンの残留テキスト防止 #217）
+    this.dialogBox.clearText()
     // per-scene [枠なし]/[枠あり] はシーン遷移でデフォルト値にリセット
     this.dialogBox.setBorderless(this.defaultDialogBorderless)
 


### PR DESCRIPTION
## 関連 Issue
closes #217

## 変更内容

### NovelRenderer.ts
- `resetAndStartEvents` に `dialogBox.clearText()` を追加
- シーン遷移時に前シーンの残留テキストを明示的にクリア

### CharacterLayer.test.ts
- `CharacterStateLike.sprite` に `x: number` を追加（#216 追加テストの型エラー修正）

## 注意
「1回クリック必要」の根本原因はテスト環境で再現しなかった。
防御的修正として `clearText()` を追加したが、ブラウザでの動作確認が必要。