### PR TITLE
feat: PROJECTS に amanuma を追加

### DIFF
--- a/worker/src/projects.ts
+++ b/worker/src/projects.ts
@@ -12,6 +12,7 @@ export const PROJECTS: ReadonlyArray<Project> = [
   { name: "friday-1930", title: "Friday 1930", repo: "kako-jun/friday-1930" },
   { name: "gymnasia", title: "Gymnasia", repo: "kako-jun/gymnasia" },
   { name: "llll-ll-media", title: "llll-ll-media", repo: "kako-jun/llll-ll-media" },
+  { name: "amanuma", title: "amanuma", repo: "kako-jun/amanuma" },
 ];
 
 export function findProject(name: string): Project | undefined {


### PR DESCRIPTION
kako-jun/amanuma#23 closes kako-jun/amanuma#23

amanuma は PixiJS v8 ベースの水中落ち物パズル (旧スリーセブン)。Issue #10〜#22 の連続 PR で PixiJS 移植 + ゲームデザイン刷新を完了。