### PR TITLE
feat(worker): register elevator-gurl and the-peeple

### DIFF
--- a/worker/src/projects.ts
+++ b/worker/src/projects.ts
@@ -20,6 +20,8 @@ export const PROJECTS: ReadonlyArray<Project> = [
   { name: "endroll-jumpers", title: "endroll-jumpers", repo: "kako-jun/endroll-jumpers", external_url: "https://endroll-jumpers.llll-ll.com" },
   { name: "yatagarrage", title: "Yatagarrage: Hanabi Sparkout", repo: "kako-jun/yatagarrage", external_url: "https://yatagarrage.llll-ll.com" },
   { name: "legend-of-window-ninja", title: "ウィンドウ忍者伝説", repo: "kako-jun/legend-of-window-ninja", external_url: "https://kako-jun.github.io/legend-of-window-ninja/" },
+  { name: "elevator-gurl", title: "elevator-gurl", repo: "kako-jun/elevator-gurl", external_url: "https://elevator-gurl.llll-ll.com" },
+  { name: "the-peeple", title: "the-peeple", repo: "kako-jun/the-peeple", external_url: "https://the-peeple.llll-ll.com" },
 ];
 
 export function findProject(name: string): Project | undefined {

--- a/worker/src/projects.ts
+++ b/worker/src/projects.ts
@@ -20,8 +20,8 @@ export const PROJECTS: ReadonlyArray<Project> = [
   { name: "endroll-jumpers", title: "endroll-jumpers", repo: "kako-jun/endroll-jumpers", external_url: "https://endroll-jumpers.llll-ll.com" },
   { name: "yatagarrage", title: "Yatagarrage: Hanabi Sparkout", repo: "kako-jun/yatagarrage", external_url: "https://yatagarrage.llll-ll.com" },
   { name: "legend-of-window-ninja", title: "ウィンドウ忍者伝説", repo: "kako-jun/legend-of-window-ninja", external_url: "https://kako-jun.github.io/legend-of-window-ninja/" },
-  { name: "elevator-gurl", title: "elevator-gurl", repo: "kako-jun/elevator-gurl", external_url: "https://elevator-gurl.llll-ll.com" },
-  { name: "the-peeple", title: "the-peeple", repo: "kako-jun/the-peeple", external_url: "https://the-peeple.llll-ll.com" },
+  { name: "elevator-gurl", title: "ヱレベヰターガール", repo: "kako-jun/elevator-gurl", external_url: "https://elevator-gurl.llll-ll.com" },
+  { name: "the-peeple", title: "The Peeple", repo: "kako-jun/the-peeple", external_url: "https://the-peeple.llll-ll.com" },
 ];
 
 export function findProject(name: string): Project | undefined {

--- a/worker/test/projects.test.ts
+++ b/worker/test/projects.test.ts
@@ -18,15 +18,10 @@ describe("GET /api/projects", () => {
     const res = await worker.fetch(req, ENV, ctx);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { projects: Array<{ name: string }> };
-    expect(body.projects.length).toBe(6);
-    expect(body.projects.map((p) => p.name)).toEqual([
-      "ogurasia",
-      "skirts-colour",
-      "friday-1930",
-      "gymnasia",
-      "llll-ll-media",
-      "amanuma",
-    ]);
+    const names = body.projects.map((p) => p.name);
+    for (const required of ["ogurasia", "skirts-colour", "friday-1930", "gymnasia", "llll-ll-media", "amanuma"]) {
+      expect(names).toContain(required);
+    }
   });
 
   it("attaches CORS headers for the allowed origin", async () => {


### PR DESCRIPTION
Closes #241

## Summary

- `worker/src/projects.ts` の PROJECTS に elevator-gurl と the-peeple を追加（表示名: ヱレベヰターガール / The Peeple、external_url は `<name>.llll-ll.com` 規約）
- `worker/test/projects.test.ts` が個数 6 / 順序固定をハードコードしていたが、登録数が 13 まで増えた時点で既に失敗していたため、必須プロジェクトを含むかの inclusion 検証に書き換え

## Test plan

- [x] `npm test` (worker) で 45 件全件 PASS