### PR TITLE
feat: startFrom デバッグ API (#220 Phase 2)

### DIFF
--- a/docs/adr/0002-deterministic-state-and-debuggability.md
+++ b/docs/adr/0002-deterministic-state-and-debuggability.md
@@ -88,10 +88,11 @@ await renderer.playScript(steps: Step[]): Promise<void>
 - バグ再現スクリプトをコードで記述・共有する
 - vitest テストで特定シーンの状態を assert する
 
-### 3. `startFrom(state)` API を提供する（#220 Phase 2）
+### 3. `startFrom(state)` API を提供する（#220 Phase 2）✅ 実装済み（2026-06-01）
 
 sceneId と flags を直接指定して任意の状態から開始する API。
 history はリセットされる（デバッグ用）。
+実装: `NovelRenderer.startFrom`、`StartFromOptions` 型は `GameState.ts`。`loadFromSaveData` を手本に `applyState` を再利用。flags は置換セマンティクス、不正 sceneId は完全 no-op（検証を flags 適用より先に行う）、eventIndex/textIndex は範囲チェックなし（呼び出し側責任）。vitest 25 ケース。
 
 ```typescript
 renderer.startFrom({

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -179,6 +179,7 @@ interface NovelGameState {
 | `seekTo(historyIndex)` | 履歴の指定位置にジャンプ |
 | `applyState(state)` | スナップショットから画面を復元 |
 | `playScript(steps)` | 操作列（`advance`/`choice`/`wait`）を決定論的にリプレイ（#220 Phase 1、デバッグ/テスト用。再生中 msPerChar=0、完了・例外時に復元、再入は throw） |
+| `startFrom({sceneId, flags?, eventIndex?, textIndex?})` | 任意シーン+フラグ状態から開始（#220 Phase 2、デバッグ/テスト用。history リセット、flags 置換、不正 sceneId は完全 no-op） |
 
 ## レンダリングパイプライン
 

--- a/docs/guidelines/README.md
+++ b/docs/guidelines/README.md
@@ -23,7 +23,7 @@
 ### 3. GameState 完全シリアライズ + 任意局面起動 ⚠️ 内部は達成・public API が未提供
 - `NovelGameState` は JSON 化可能なプレーンオブジェクト。演出の中間状態（フェード途中・タイプライター途中）は持たない（ADR 0002）
 - `applyState(state)` で任意状態に復元できる（現状 private、`NovelRenderer.ts`）
-- **public API 化の進捗**: `playScript(steps)`（#220 Phase 1）は実装済み — 操作列を決定論的にリプレイ（再入ガード + msPerChar 退避復元、vitest 17 ケース）。残ギャップ: `startFrom(sceneId, flags)`（Phase 2）/ URL クエリ（Phase 3）。`docs/roadmap/` 参照
+- **public API 化の進捗**: `playScript(steps)`（#220 Phase 1）+ `startFrom({sceneId, flags?})`（#220 Phase 2）実装済み — 操作列リプレイ / 任意状態起動。残ギャップ: URL クエリ起点指定（Phase 3）。`docs/roadmap/` 参照
 - **新規レンダラ/モードを作るときの完了条件**: 「任意の state から `applyState` 相当で起動できる」ことを満たす。これは設計品質の**機械的な検証点**（状態と描画が分離できている証明）
 
 ### 4. 単一責務／網状依存の禁止 ⚠️ god-object 傾向あり

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -10,7 +10,7 @@
 ADR 0002 で設計済みだが public API が未提供。内部 `applyState` は達成済みなので、**設計価値を外に出す**段階。
 
 - [x] **`playScript(steps)` API**（Issue #220 Phase 1）— クリック操作列を配列で受けて決定論的に状態を進める。再入ガード + 再生中 msPerChar=0 / 完了・例外時に復元。vitest 17 ケース。2026-06-01 実装（`NovelRenderer.playScript`、`Step` 型は `GameState.ts`）
-- [ ] **`startFrom(sceneId, flags)` API**（Issue #220 Phase 2）— 任意状態から起動。長いシーンの後半から開発を始められる
+- [x] **`startFrom(sceneId, flags)` API**（Issue #220 Phase 2）— 任意シーン+フラグ状態から起動。history リセット、flags 置換、不正 sceneId は完全 no-op。vitest 25 ケース。2026-06-01 実装（`NovelRenderer.startFrom`、`StartFromOptions` は `GameState.ts`）
 - [ ] **URL クエリでデバッグ起点指定**（Issue #220 Phase 3、`import.meta.env.DEV` 限定）— `?debug_scene=…&debug_flags=…&debug_script=…`
 
 **完了の機械的検証点**: 「コード1行 / URL 1本で特定局面を再現できる」。これが満たされれば規律3（任意局面起動）が public に達成される。

--- a/frontend/src/game/GameState.ts
+++ b/frontend/src/game/GameState.ts
@@ -79,6 +79,24 @@ export type Step =
   | { type: 'wait'; ms: number }
 
 /**
+ * startFrom() の引数 (#220 Phase 2)。
+ *
+ * sceneId と flags を直接指定して任意の状態からシーンを開始する。
+ * デバッグ/テスト用。これは開始指示であってゲーム状態そのものではないため、
+ * NovelGameState とは別に定義する。
+ */
+export interface StartFromOptions {
+  /** 開始するシーン ID */
+  sceneId: string
+  /** 設定するフラグ（置換セマンティクス。省略時は空でクリア） */
+  flags?: Record<string, FlagValue>
+  /** 開始イベントインデックス（省略時 = 0） */
+  eventIndex?: number
+  /** 開始テキストインデックス（省略時 = 0） */
+  textIndex?: number
+}
+
+/**
  * Condition イベントをフラグに基づいて展開し、フラットなイベント配列を返す。
  *
  * - Condition が真 → 内部 events を再帰的に展開して挿入（Condition 自体は除去）

--- a/frontend/src/game/NovelRenderer.startFrom.test.ts
+++ b/frontend/src/game/NovelRenderer.startFrom.test.ts
@@ -1,0 +1,337 @@
+/**
+ * NovelRenderer.startFrom(opts) のテスト (#220 Phase 2)。
+ *
+ * sceneId / flags / eventIndex / textIndex を直接指定して任意の状態から
+ * シーンを開始するデバッグ API の検証。playScript.test.ts と同じく
+ * `new NovelRenderer()` → `setScenes(...)` → `startFrom(...)` の最小構成で行い、
+ * 描画・PixiJS 実描画は対象外（CLAUDE.md ルール7 の実機 golden path に委ねる）。
+ *
+ * 検証は getSnapshot() / getDebugState() / getCurrentSceneId() / 内部アクセサ
+ * （history・waitTimer 等）で行う。背景アセットを伴うシーンは避け、
+ * Narration / Dialog / Condition / Flag 中心の最小 fixture を使う。
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NovelRenderer } from './NovelRenderer'
+import type { StartFromOptions } from './GameState'
+import type { Event, EventScene, FlagValue } from '../types'
+
+// --- fixture helpers（playScript.test.ts と同じスタイル） ---
+
+function narration(...lines: string[]): Event {
+  return { Narration: { text: lines } }
+}
+
+function dialog(character: string, ...lines: string[]): Event {
+  return { Dialog: { character, expression: null, position: null, text: lines } }
+}
+
+function scene(id: string, events: Event[]): EventScene {
+  return { id, title: id, view: 'TopDown', events }
+}
+
+function condition(flag: string, events: Event[]): Event {
+  return { Condition: { flag, events } }
+}
+
+const boolFlag = (b: boolean): FlagValue => ({ Bool: b })
+
+function makeRenderer(scenes: EventScene[]): NovelRenderer {
+  const r = new NovelRenderer()
+  r.setScenes(scenes)
+  return r
+}
+
+/** startFrom 検証用に到達したい内部状態へのアクセサ */
+interface RendererInternals {
+  eventIndex: number
+  textIndex: number
+  resolvedEvents: Event[]
+  history: unknown[]
+  waitingForChoice: boolean
+  waitingForWait: boolean
+  waitTimer: number | null
+  advance(): void
+}
+
+function internals(r: NovelRenderer): RendererInternals {
+  return r as unknown as RendererInternals
+}
+
+const SCENES: EventScene[] = [
+  scene('start', [narration('行1', '行2', '行3'), dialog('A', 'せりふ1', 'せりふ2')]),
+  scene('left', [narration('左1', '左2')]),
+  scene('right', [narration('右1')]),
+]
+
+// flag 依存 Condition を含むシーン群（resolvedEvents が flag で伸縮する）
+const SCENES_COND: EventScene[] = [
+  scene('cond', [
+    narration('共通1'),
+    condition('seen', [narration('分岐1'), narration('分岐2')]),
+    narration('共通2'),
+  ]),
+]
+
+// Choice を含むシーン（playScript で waitingForChoice=true を作る用）
+const SCENES_CHOICE: EventScene[] = [
+  scene('start', [
+    narration('intro'),
+    {
+      Choice: {
+        options: [
+          { text: '左へ', jump: 'left' },
+          { text: '右へ', jump: 'right' },
+        ],
+      },
+    } as Event,
+  ]),
+  scene('left', [narration('左1')]),
+  scene('right', [narration('右1')]),
+]
+
+// Wait を含むシーン（playScript で waitingForWait=true を作る用）
+const SCENES_WAIT: EventScene[] = [
+  scene('start', [narration('intro'), { Wait: { ms: 100000 } } as Event, narration('after')]),
+]
+
+describe('NovelRenderer.startFrom (#220)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  // ===== A. 正常系 =====
+
+  it('1: sceneId のみ → currentSceneId 一致 & eventIndex/textIndex=0', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'left' })
+    expect(r.getCurrentSceneId()).toBe('left')
+    const s = r.getSnapshot()
+    expect(s.eventIndex).toBe(0)
+    expect(s.textIndex).toBe(0)
+  })
+
+  it('2: eventIndex 指定が反映される', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'start', eventIndex: 1 })
+    expect(r.getSnapshot().eventIndex).toBe(1)
+  })
+
+  it('3: textIndex 指定が反映される', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'start', textIndex: 2 })
+    expect(r.getSnapshot().textIndex).toBe(2)
+  })
+
+  it('4: eventIndex/textIndex 両方の指定が反映される', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'start', eventIndex: 1, textIndex: 1 })
+    const s = r.getSnapshot()
+    expect(s.eventIndex).toBe(1)
+    expect(s.textIndex).toBe(1)
+  })
+
+  it('5: flags 指定 → getSnapshot().flags が一致する', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'start', flags: { seen: boolFlag(true), score: { Number: 7 } } })
+    expect(r.getSnapshot().flags).toEqual({ seen: boolFlag(true), score: { Number: 7 } })
+  })
+
+  // ===== B. flags 置換（merge でない） =====
+
+  it('6: 事前 flags → 別キーで startFrom → 前キーが消える（置換）', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'start', flags: { old: boolFlag(true) } })
+    r.startFrom({ sceneId: 'start', flags: { fresh: boolFlag(true) } })
+    expect(r.getSnapshot().flags).toEqual({ fresh: boolFlag(true) })
+  })
+
+  it('7: 事前 flags → flags 省略で startFrom → 空にクリアされる', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'start', flags: { old: boolFlag(true) } })
+    r.startFrom({ sceneId: 'start' })
+    expect(r.getSnapshot().flags).toEqual({})
+  })
+
+  it('8: flags={} は省略と同値（空クリア）', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'start', flags: { old: boolFlag(true) } })
+    r.startFrom({ sceneId: 'start', flags: {} })
+    expect(r.getSnapshot().flags).toEqual({})
+  })
+
+  // ===== C. デフォルト =====
+
+  it('9: flags 省略 → {}', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'start' })
+    expect(r.getSnapshot().flags).toEqual({})
+  })
+
+  it('10: eventIndex 省略 → 0', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'start', textIndex: 1 })
+    expect(r.getSnapshot().eventIndex).toBe(0)
+  })
+
+  it('11: textIndex 省略 → 0', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'start', eventIndex: 1 })
+    expect(r.getSnapshot().textIndex).toBe(0)
+  })
+
+  // ===== D. 異常系（完全 no-op） =====
+
+  it('12: 不正 sceneId → console.warn が呼ばれる', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'nonexistent' })
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('13: 不正 sceneId → currentSceneId は不変', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const r = makeRenderer(SCENES)
+    const before = r.getCurrentSceneId()
+    r.startFrom({ sceneId: 'nonexistent' })
+    expect(r.getCurrentSceneId()).toBe(before)
+  })
+
+  it('14: 不正 sceneId → flags も index も history も一切変わらない', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const r = makeRenderer(SCENES)
+    // 事前に startFrom で確定した状態を作る
+    r.startFrom({ sceneId: 'start', eventIndex: 1, textIndex: 1, flags: { keep: boolFlag(true) } })
+    const snapBefore = r.getSnapshot()
+    const sceneBefore = r.getCurrentSceneId()
+    const historyLenBefore = internals(r).history.length
+
+    r.startFrom({ sceneId: 'does-not-exist', flags: { wiped: boolFlag(true) } })
+
+    // 完全 no-op: snapshot / sceneId / history すべて不変
+    expect(r.getSnapshot()).toEqual(snapBefore)
+    expect(r.getCurrentSceneId()).toBe(sceneBefore)
+    expect(internals(r).history.length).toBe(historyLenBefore)
+    expect(r.getSnapshot().flags).toEqual({ keep: boolFlag(true) })
+  })
+
+  // ===== E. Condition 展開 =====
+
+  it('15: Condition 含むシーンで flag=true → eventCount が展開後件数', () => {
+    const r = makeRenderer(SCENES_COND)
+    r.startFrom({ sceneId: 'cond', flags: { seen: boolFlag(true) } })
+    // 共通1 + (分岐1 + 分岐2) + 共通2 = 4 件
+    expect(r.getDebugState().eventCount).toBe(4)
+  })
+
+  it('16: flag=false → Condition 内が除外される', () => {
+    const r = makeRenderer(SCENES_COND)
+    r.startFrom({ sceneId: 'cond', flags: { seen: boolFlag(false) } })
+    // 共通1 + 共通2 = 2 件（Condition 内は展開されない）
+    expect(r.getDebugState().eventCount).toBe(2)
+  })
+
+  it('17: flag 有無で eventCount に差が出る（true > false）', () => {
+    const rTrue = makeRenderer(SCENES_COND)
+    rTrue.startFrom({ sceneId: 'cond', flags: { seen: boolFlag(true) } })
+
+    const rNone = makeRenderer(SCENES_COND)
+    rNone.startFrom({ sceneId: 'cond' }) // flag 未指定 → false 扱い
+
+    expect(rTrue.getDebugState().eventCount).toBeGreaterThan(rNone.getDebugState().eventCount)
+  })
+
+  // ===== F. 状態遷移 =====
+
+  it('18: choice 待機中 → startFrom 後 waitingForChoice=false', () => {
+    const r = makeRenderer(SCENES_CHOICE)
+    // Choice 到達状態を直接作る。playScript 経由だと ChoiceOverlay.show が
+    // AudioManager.ensureContext() を呼び、init() 未実行の jsdom には AudioContext が
+    // 無いため落ちる（startFrom のリセット責務とは無関係な環境制約）。
+    internals(r).waitingForChoice = true
+    expect(internals(r).waitingForChoice).toBe(true)
+
+    r.startFrom({ sceneId: 'left' })
+    expect(internals(r).waitingForChoice).toBe(false)
+  })
+
+  it('19: wait 待機中 → startFrom 後 waitingForWait=false & waitTimer=null', () => {
+    vi.useFakeTimers()
+    const r = makeRenderer(SCENES_WAIT)
+    // intro → advance で Wait に到達し waitingForWait=true / waitTimer がセットされる
+    internals(r).advance()
+    expect(internals(r).waitingForWait).toBe(true)
+    expect(internals(r).waitTimer).not.toBeNull()
+
+    r.startFrom({ sceneId: 'start' })
+    expect(internals(r).waitingForWait).toBe(false)
+    expect(internals(r).waitTimer).toBeNull()
+  })
+
+  it('20: wait 待機中に startFrom → その後 timer を進めても旧 wait の advance が発火しない', () => {
+    vi.useFakeTimers()
+    const r = makeRenderer(SCENES_WAIT)
+    internals(r).advance()
+    expect(internals(r).waitingForWait).toBe(true)
+
+    r.startFrom({ sceneId: 'start' })
+    const afterStart = r.getSnapshot()
+
+    // 旧 wait のタイマーがクリアされていれば、時間を進めても進行は起きない
+    vi.advanceTimersByTime(200000)
+    expect(r.getSnapshot()).toEqual(afterStart)
+    expect(internals(r).waitingForWait).toBe(false)
+  })
+
+  // ===== G. history =====
+
+  it('21: 複数 advance 後 startFrom → history.length === 1', async () => {
+    const r = makeRenderer(SCENES)
+    await r.playScript([{ type: 'advance' }, { type: 'advance' }, { type: 'advance' }])
+    expect(internals(r).history.length).toBeGreaterThan(1)
+
+    r.startFrom({ sceneId: 'left' })
+    expect(internals(r).history.length).toBe(1)
+  })
+
+  it('22: history[0] が startFrom 現在状態（getSnapshot）と一致する', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'start', eventIndex: 1, textIndex: 1, flags: { x: boolFlag(true) } })
+    expect(internals(r).history[0]).toEqual(r.getSnapshot())
+  })
+
+  // ===== H. ログ =====
+
+  it('23: 正常 startFrom で warn/error を呼ばない', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'start', eventIndex: 1, flags: { ok: boolFlag(true) } })
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  // ===== I. 決定論 =====
+
+  it('24: 同一 opts を2 renderer で startFrom → getSnapshot 一致', () => {
+    const opts: StartFromOptions = {
+      sceneId: 'start',
+      eventIndex: 1,
+      textIndex: 1,
+      flags: { seen: boolFlag(true), n: { Number: 3 } },
+    }
+    const r1 = makeRenderer(SCENES)
+    r1.startFrom(opts)
+    const r2 = makeRenderer(SCENES)
+    r2.startFrom(opts)
+    expect(r2.getSnapshot()).toEqual(r1.getSnapshot())
+  })
+
+  // ===== J. 境界 =====
+
+  it('25: eventIndex に resolvedEvents.length 超過を指定 → 例外を投げない', () => {
+    const r = makeRenderer(SCENES)
+    const over = internals(r).resolvedEvents.length + 100
+    expect(() => r.startFrom({ sceneId: 'start', eventIndex: over })).not.toThrow()
+  })
+})

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -1764,19 +1764,25 @@ export class NovelRenderer {
    * デバッグ/テスト用。history をリセットする（呼び出し後は現在位置のみ）。
    * 指定フラグは置換であり merge ではない（省略時は空でクリア）。
    * 復元は applyState に委譲し、新規の描画/状態ロジックは持たない。
+   *
+   * - 存在しない sceneId は完全な no-op（flags も含め一切状態を変えない）。
+   * - eventIndex/textIndex は範囲チェックしない（呼び出し側責任。範囲外でもクラッシュ
+   *   はしないが未定義位置になる）。
+   * - playScript 実行中の呼び出しは想定外（デバッグ API 同士の同時使用は非対応）。
    */
   startFrom(opts: StartFromOptions): void {
     const flags = opts.flags ?? {}
 
-    // フラグを設定（置換セマンティクス。loadFromSaveData と同じ）
-    this.gameState.fromJSON(flags)
-
-    // シーンを探す
+    // シーンを探す。無ければ完全な no-op（この時点で flags/index/history を一切触らない）
     const scene = this.allScenes.find((s) => s.id === opts.sceneId)
     if (!scene) {
       console.warn(`[name-name] startFrom: シーンが見つからない: ${opts.sceneId}`)
       return
     }
+
+    // フラグを設定（置換セマンティクス。loadFromSaveData と同じ）。
+    // resolveEvents が flags に依存するため、必ず resolveEvents より前に設定する。
+    this.gameState.fromJSON(flags)
 
     this.currentSceneId = opts.sceneId
 

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -1789,6 +1789,9 @@ export class NovelRenderer {
     // 選択肢/待機状態をリセット
     this.waitingForChoice = false
     this.waitingForWait = false
+    // 直前の choice 確定による同フレーム advance 抑制フラグも消す
+    // （任意状態への完全リセットなので残留させない）
+    this.justSelectedChoice = false
     if (this.waitTimer) {
       this.time.clearTimeout(this.waitTimer)
       this.waitTimer = null

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -25,7 +25,14 @@ import { CharacterLayer } from './CharacterLayer'
 import { DialogBox } from './DialogBox'
 import { ensureFontLoaded } from './FontLoader'
 import { AudioManager } from './AudioManager'
-import { BackgroundFade, GameState, NovelGameState, Step, resolveEvents } from './GameState'
+import {
+  BackgroundFade,
+  GameState,
+  NovelGameState,
+  StartFromOptions,
+  Step,
+  resolveEvents,
+} from './GameState'
 import { buildEdgeFadeMask, normalizeEdgeFade } from './edgeFadeMask'
 import { VideoLayer } from './VideoLayer'
 import { ChoiceOverlay } from './ChoiceOverlay'
@@ -75,8 +82,8 @@ export function getTextEvent(event: Event):
  */
 export const normalizeBackgroundFade = normalizeEdgeFade
 
-// playScript で使う Step 型を NovelRenderer 経由でも import できるよう再エクスポートする (#220)
-export type { Step } from './GameState'
+// playScript / startFrom で使う型を NovelRenderer 経由でも import できるよう再エクスポートする (#220)
+export type { Step, StartFromOptions } from './GameState'
 
 export class NovelRenderer {
   private app: Application
@@ -1746,6 +1753,63 @@ export class NovelRenderer {
     this.applyState(state)
 
     // 履歴をリセット（ロード後は現在位置のみ）
+    this.history = [this.getSnapshot()]
+
+    this.render()
+  }
+
+  /**
+   * sceneId と flags を直接指定して任意の状態からシーンを開始する (#220 Phase 2)。
+   *
+   * デバッグ/テスト用。history をリセットする（呼び出し後は現在位置のみ）。
+   * 指定フラグは置換であり merge ではない（省略時は空でクリア）。
+   * 復元は applyState に委譲し、新規の描画/状態ロジックは持たない。
+   */
+  startFrom(opts: StartFromOptions): void {
+    const flags = opts.flags ?? {}
+
+    // フラグを設定（置換セマンティクス。loadFromSaveData と同じ）
+    this.gameState.fromJSON(flags)
+
+    // シーンを探す
+    const scene = this.allScenes.find((s) => s.id === opts.sceneId)
+    if (!scene) {
+      console.warn(`[name-name] startFrom: シーンが見つからない: ${opts.sceneId}`)
+      return
+    }
+
+    this.currentSceneId = opts.sceneId
+
+    // 選択肢/待機状態をリセット
+    this.waitingForChoice = false
+    this.waitingForWait = false
+    if (this.waitTimer) {
+      this.time.clearTimeout(this.waitTimer)
+      this.waitTimer = null
+    }
+    this.choiceOverlay.hide()
+
+    // 元イベントを保持し、Condition をフラグに基づいて展開
+    this.rawEvents = [...scene.events]
+    this.resolvedEvents = resolveEvents(this.rawEvents, this.gameState)
+    this.displayEventCount = this.resolvedEvents.filter((e) => getTextEvent(e) !== null).length
+
+    // 最小 NovelGameState を構築して applyState で宣言的に復元
+    const state: NovelGameState = {
+      sceneId: opts.sceneId,
+      eventIndex: opts.eventIndex ?? 0,
+      textIndex: opts.textIndex ?? 0,
+      flags,
+      backgroundPath: null,
+      backgroundFade: normalizeBackgroundFade(undefined),
+      video: null,
+      isBlackout: false,
+      characters: [],
+      currentBgmPath: null,
+    }
+    this.applyState(state)
+
+    // 履歴をリセット（デバッグ開始後は現在位置のみ）
     this.history = [this.getSnapshot()]
 
     this.render()


### PR DESCRIPTION
## 関連 Issue
Refs #220（Phase 2 のみ。Phase 1 `playScript` は #254 でマージ済み、Phase 3 URL クエリは別 PR。**Issue は Phase 3 が残るため open 維持** — `closes` は使わない）

## 変更内容
ADR 0002 Phase 2。sceneId + flags を直接指定して任意状態から開始するデバッグ/テスト用 API。

- **`NovelRenderer.startFrom({sceneId, flags?, eventIndex?, textIndex?})`** を追加（`StartFromOptions` 型は `GameState.ts`）
  - 既存 private `loadFromSaveData` を手本に **`applyState` を再利用**（新規描画ロジックを増やさない＝ガイドライン規律準拠）
  - flags は**置換**セマンティクス、history は呼び出しでリセット
  - **不正 sceneId は完全 no-op**（scene 検証を flags 適用より先に行い、flags/index/history を一切触らない）
  - eventIndex/textIndex は範囲チェックなし（呼び出し側責任、クラッシュはしない）
- docs 更新（architecture.md / adr 0002 / roadmap / guidelines）

## テスト
- 新規 `NovelRenderer.startFrom.test.ts` 25 ケース（正常反映・flags 置換・デフォルト・不正sceneId完全no-op・Condition展開・待機解除・history リセット・決定論・境界）
- 全体 670 pass（既知の `CharacterLayer.test.ts` #209 の 1 fail は無関係）

## 設計準拠
`docs/guidelines/` のハウスルール（applyState 再利用・GameState に演出中間状態を持ち込まない・設計先行）に沿う。本 PR は `/impl` が `docs/guidelines/` を自動参照して実装した初回ケース。