### PR TITLE
feat: URLクエリによるデバッグ起点指定 (#220 Phase 3・完結)

### DIFF
--- a/docs/adr/0002-deterministic-state-and-debuggability.md
+++ b/docs/adr/0002-deterministic-state-and-debuggability.md
@@ -107,7 +107,7 @@ renderer.startFrom({
 - 特定フラグ組み合わせの分岐を直接開く
 - 長いシーンの後半から開発を始める
 
-### 4. URL クエリによるデバッグ起点指定（#220 Phase 3、開発環境限定）
+### 4. URL クエリによるデバッグ起点指定（#220 Phase 3、開発環境限定）✅ 実装済み（2026-06-01）
 
 ```
 ?debug_scene=1-2&debug_flags=saw_characters:true
@@ -115,6 +115,7 @@ renderer.startFrom({
 ```
 
 `import.meta.env.DEV` の場合のみ有効。本番では無視する。
+実装: 純粋パーサ `frontend/src/game/debugQuery.ts` の `parseDebugQuery(search)` が `{script}` / `{scene}` / `null` を返し、`NovelPlayer.tsx` が `setScenes` 後に DEV ガード付きで `playScript`/`startFrom` を呼ぶ。`debug_script` 優先。vitest 20 ケース。**これで #220 の全 Phase（1 playScript / 2 startFrom / 3 URL クエリ）が完了。**
 
 ## Consequences（影響）
 

--- a/docs/guidelines/README.md
+++ b/docs/guidelines/README.md
@@ -23,7 +23,7 @@
 ### 3. GameState 完全シリアライズ + 任意局面起動 ⚠️ 内部は達成・public API が未提供
 - `NovelGameState` は JSON 化可能なプレーンオブジェクト。演出の中間状態（フェード途中・タイプライター途中）は持たない（ADR 0002）
 - `applyState(state)` で任意状態に復元できる（現状 private、`NovelRenderer.ts`）
-- **public API 化の進捗**: `playScript(steps)`（#220 Phase 1）+ `startFrom({sceneId, flags?})`（#220 Phase 2）実装済み — 操作列リプレイ / 任意状態起動。残ギャップ: URL クエリ起点指定（Phase 3）。`docs/roadmap/` 参照
+- **public API 化: ✅ #220 全 Phase 完了** — `playScript(steps)`（Phase 1）/ `startFrom({sceneId, flags?})`（Phase 2）/ URL クエリ起点指定 `?debug_scene=…&debug_script=…`（Phase 3、`debugQuery.ts`、DEV 限定）。操作列リプレイ・任意状態起動・URL 共有が揃い、決定論的デバッグが public に到達
 - **新規レンダラ/モードを作るときの完了条件**: 「任意の state から `applyState` 相当で起動できる」ことを満たす。これは設計品質の**機械的な検証点**（状態と描画が分離できている証明）
 
 ### 4. 単一責務／網状依存の禁止 ⚠️ god-object 傾向あり

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -11,9 +11,9 @@ ADR 0002 で設計済みだが public API が未提供。内部 `applyState` は
 
 - [x] **`playScript(steps)` API**（Issue #220 Phase 1）— クリック操作列を配列で受けて決定論的に状態を進める。再入ガード + 再生中 msPerChar=0 / 完了・例外時に復元。vitest 17 ケース。2026-06-01 実装（`NovelRenderer.playScript`、`Step` 型は `GameState.ts`）
 - [x] **`startFrom(sceneId, flags)` API**（Issue #220 Phase 2）— 任意シーン+フラグ状態から起動。history リセット、flags 置換、不正 sceneId は完全 no-op。vitest 25 ケース。2026-06-01 実装（`NovelRenderer.startFrom`、`StartFromOptions` は `GameState.ts`）
-- [ ] **URL クエリでデバッグ起点指定**（Issue #220 Phase 3、`import.meta.env.DEV` 限定）— `?debug_scene=…&debug_flags=…&debug_script=…`
+- [x] **URL クエリでデバッグ起点指定**（Issue #220 Phase 3、`import.meta.env.DEV` 限定）— `?debug_scene=…&debug_flags=…&debug_script=…`。純粋パーサ `frontend/src/game/debugQuery.ts`（`parseDebugQuery`）+ `NovelPlayer.tsx` で DEV ガード配線、vitest 20 ケース。2026-06-01 実装で **#220 全フェーズ完了**
 
-**完了の機械的検証点**: 「コード1行 / URL 1本で特定局面を再現できる」。これが満たされれば規律3（任意局面起動）が public に達成される。
+**完了の機械的検証点**: 「コード1行 / URL 1本で特定局面を再現できる」。✅ 達成（playScript / startFrom / URL クエリ）。規律3（任意局面起動）が public に到達。
 
 ## Phase: レンダラの責務分割（god-object 傾向の解消）
 

--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Event, EventScene } from '../types'
 import { NovelRenderer } from '../game/NovelRenderer'
+import { parseDebugQuery } from '../game/debugQuery'
 import { type Settings, loadSettings, makeDebouncedSaveSettings } from '../game/settings'
 import { type AspectRatio, ASPECT_RATIOS, parseAspectRatio } from '../game/constants'
 import SettingsOverlay from './SettingsOverlay'
@@ -100,6 +101,17 @@ function NovelPlayer({
       renderer.applySettings(settings)
       if (scenes && scenes.length > 0) {
         renderer.setScenes(scenes)
+        // URL クエリによるデバッグ起点指定 (#220 Phase 3)。
+        // DEV ビルドでのみ有効。production ではこのブロックごと tree-shake される。
+        // debug_scene は sceneId 前提のため scenes 経路（setScenes）でのみ配線する。
+        if (import.meta.env.DEV) {
+          const debug = parseDebugQuery(window.location.search)
+          if (debug && 'script' in debug) {
+            void renderer.playScript(debug.script)
+          } else if (debug && 'scene' in debug) {
+            renderer.startFrom(debug.scene)
+          }
+        }
       } else {
         renderer.setEvents(events)
       }

--- a/frontend/src/game/debugQuery.test.ts
+++ b/frontend/src/game/debugQuery.test.ts
@@ -133,7 +133,7 @@ describe('parseDebugQuery (#220)', () => {
 
   it('17: NaN な index はキーを付けない', () => {
     const r = parseDebugQuery('?debug_scene=1-2&debug_eventIndex=abc&debug_textIndex=xyz')
-    const scene = (r as { scene: Record<string, unknown> }).scene
+    const scene = (r as unknown as { scene: Record<string, unknown> }).scene
     expect(scene).toEqual({ sceneId: '1-2' })
     expect('eventIndex' in scene).toBe(false)
     expect('textIndex' in scene).toBe(false)
@@ -154,5 +154,16 @@ describe('parseDebugQuery (#220)', () => {
     const withQ = parseDebugQuery('?debug_scene=1-2&debug_flags=k:true')
     const withoutQ = parseDebugQuery('debug_scene=1-2&debug_flags=k:true')
     expect(withoutQ).toEqual(withQ)
+  })
+
+  it('21: 空/全無効 debug_script は scene へフォールスルー（空 script が scene を握りつぶさない）', () => {
+    // 空 script のみ → null
+    expect(parseDebugQuery('?debug_script=')).toBeNull()
+    // 空 script + 有効 scene → scene が返る（script が空配列で握りつぶさない）
+    expect(parseDebugQuery('?debug_script=&debug_scene=1-2')).toEqual({ scene: { sceneId: '1-2' } })
+    // 全トークン無効な script + 有効 scene → scene が返る
+    expect(parseDebugQuery('?debug_script=foo,bar&debug_scene=1-2')).toEqual({
+      scene: { sceneId: '1-2' },
+    })
   })
 })

--- a/frontend/src/game/debugQuery.test.ts
+++ b/frontend/src/game/debugQuery.test.ts
@@ -1,0 +1,158 @@
+/**
+ * parseDebugQuery(search) のテスト (#220 Phase 3)。
+ *
+ * URL の query string を playScript() / startFrom() の引数へ変換する純粋パーサの検証。
+ * 副作用なし・DOM 非依存なので、`new URLSearchParams` を内部で使う関数に文字列を渡し、
+ * 戻り値（{ script } / { scene } / null）を直接突き合わせる最小構成で行う。
+ *
+ * 観点ごとに 1 テスト。正常系だけでなく flag 型変換の境界・script トークンの堅牢性
+ * （不正トークンのスキップ）・index の NaN・null/空文字も網羅する。
+ */
+import { describe, it, expect } from 'vitest'
+import { parseDebugQuery } from './debugQuery'
+import type { FlagValue } from '../types'
+
+// flag 期待値ヘルパ（startFrom.test.ts と同じスタイル）
+const boolFlag = (b: boolean): FlagValue => ({ Bool: b })
+
+describe('parseDebugQuery (#220)', () => {
+  // ===== A. 正常系 =====
+
+  it('1: debug_script=advance,advance,choice:1-1 → script 3 Step', () => {
+    const r = parseDebugQuery('?debug_script=advance,advance,choice:1-1')
+    expect(r).toEqual({
+      script: [{ type: 'advance' }, { type: 'advance' }, { type: 'choice', jump: '1-1' }],
+    })
+  })
+
+  it('2: debug_scene=1-2 のみ → { scene: { sceneId: "1-2" } }', () => {
+    const r = parseDebugQuery('?debug_scene=1-2')
+    expect(r).toEqual({ scene: { sceneId: '1-2' } })
+  })
+
+  it('3: debug_scene + debug_flags → flags に Bool が入る', () => {
+    const r = parseDebugQuery('?debug_scene=1-2&debug_flags=saw_characters:true')
+    expect(r).toEqual({
+      scene: { sceneId: '1-2', flags: { saw_characters: boolFlag(true) } },
+    })
+  })
+
+  it('4: debug_script=wait:500 → { type: "wait", ms: 500 }', () => {
+    const r = parseDebugQuery('?debug_script=wait:500')
+    expect(r).toEqual({ script: [{ type: 'wait', ms: 500 }] })
+  })
+
+  // ===== B. 優先順位 =====
+
+  it('5: script と scene 両方指定 → script が優先される', () => {
+    const r = parseDebugQuery('?debug_script=advance&debug_scene=1-2')
+    expect(r).toEqual({ script: [{ type: 'advance' }] })
+  })
+
+  // ===== C. flags 型変換（境界・同値） =====
+
+  it('6: flag "true" → Bool(true)', () => {
+    const r = parseDebugQuery('?debug_scene=1-2&debug_flags=k:true')
+    expect((r as { scene: { flags: Record<string, FlagValue> } }).scene.flags).toEqual({
+      k: { Bool: true },
+    })
+  })
+
+  it('7: flag "false" → Bool(false)', () => {
+    const r = parseDebugQuery('?debug_scene=1-2&debug_flags=k:false')
+    expect((r as { scene: { flags: Record<string, FlagValue> } }).scene.flags).toEqual({
+      k: { Bool: false },
+    })
+  })
+
+  it('8: flag "42" → Number(42)', () => {
+    const r = parseDebugQuery('?debug_scene=1-2&debug_flags=k:42')
+    expect((r as { scene: { flags: Record<string, FlagValue> } }).scene.flags).toEqual({
+      k: { Number: 42 },
+    })
+  })
+
+  it('9: flag "-1.5" → Number(-1.5)', () => {
+    const r = parseDebugQuery('?debug_scene=1-2&debug_flags=k:-1.5')
+    expect((r as { scene: { flags: Record<string, FlagValue> } }).scene.flags).toEqual({
+      k: { Number: -1.5 },
+    })
+  })
+
+  it('10: flag "hello" → String', () => {
+    const r = parseDebugQuery('?debug_scene=1-2&debug_flags=k:hello')
+    expect((r as { scene: { flags: Record<string, FlagValue> } }).scene.flags).toEqual({
+      k: { String: 'hello' },
+    })
+  })
+
+  it('11: flag の値が空文字 → String("")（Number(0) にしない）', () => {
+    const r = parseDebugQuery('?debug_scene=1-2&debug_flags=k:')
+    expect((r as { scene: { flags: Record<string, FlagValue> } }).scene.flags).toEqual({
+      k: { String: '' },
+    })
+  })
+
+  it('12: 複数 flag a:true,b:5,c:x がそれぞれ正しい型に変換される', () => {
+    const r = parseDebugQuery('?debug_scene=1-2&debug_flags=a:true,b:5,c:x')
+    expect((r as { scene: { flags: Record<string, FlagValue> } }).scene.flags).toEqual({
+      a: { Bool: true },
+      b: { Number: 5 },
+      c: { String: 'x' },
+    })
+  })
+
+  // ===== D. script 堅牢性（異常系・不正トークンのスキップ） =====
+
+  it('13: 不正 script トークン（空 / choice: / wait:abc / 未知）をスキップする', () => {
+    // 空トークン, jump 空の choice:, NaN な wait:abc, 引数無しの未知トークン foo を挟む
+    const r = parseDebugQuery('?debug_script=advance,,choice:,wait:abc,foo,advance')
+    expect(r).toEqual({ script: [{ type: 'advance' }, { type: 'advance' }] })
+  })
+
+  it('14: flag の key 無し（:val）はスキップされる', () => {
+    const r = parseDebugQuery('?debug_scene=1-2&debug_flags=:val,ok:true')
+    expect((r as { scene: { flags: Record<string, FlagValue> } }).scene.flags).toEqual({
+      ok: { Bool: true },
+    })
+  })
+
+  it('15: flag の val 無し（区切り無しの key だけ）はスキップされる', () => {
+    const r = parseDebugQuery('?debug_scene=1-2&debug_flags=key,ok:true')
+    expect((r as { scene: { flags: Record<string, FlagValue> } }).scene.flags).toEqual({
+      ok: { Bool: true },
+    })
+  })
+
+  // ===== E. index =====
+
+  it('16: debug_eventIndex / debug_textIndex が scene に反映される', () => {
+    const r = parseDebugQuery('?debug_scene=1-2&debug_eventIndex=3&debug_textIndex=2')
+    expect(r).toEqual({ scene: { sceneId: '1-2', eventIndex: 3, textIndex: 2 } })
+  })
+
+  it('17: NaN な index はキーを付けない', () => {
+    const r = parseDebugQuery('?debug_scene=1-2&debug_eventIndex=abc&debug_textIndex=xyz')
+    const scene = (r as { scene: Record<string, unknown> }).scene
+    expect(scene).toEqual({ sceneId: '1-2' })
+    expect('eventIndex' in scene).toBe(false)
+    expect('textIndex' in scene).toBe(false)
+  })
+
+  // ===== F. null / 空 =====
+
+  it('18: 該当パラメータ無し → null', () => {
+    expect(parseDebugQuery('?other=1')).toBeNull()
+    expect(parseDebugQuery('')).toBeNull()
+  })
+
+  it('19: debug_scene=（空文字）→ null（script も無いため）', () => {
+    expect(parseDebugQuery('?debug_scene=')).toBeNull()
+  })
+
+  it('20: 先頭 ? の有無で結果は変わらない', () => {
+    const withQ = parseDebugQuery('?debug_scene=1-2&debug_flags=k:true')
+    const withoutQ = parseDebugQuery('debug_scene=1-2&debug_flags=k:true')
+    expect(withoutQ).toEqual(withQ)
+  })
+})

--- a/frontend/src/game/debugQuery.ts
+++ b/frontend/src/game/debugQuery.ts
@@ -1,0 +1,132 @@
+/**
+ * URL クエリによるデバッグ起点指定のパーサ (#220 Phase 3)。
+ *
+ * `import.meta.env.DEV` 時に NovelPlayer から呼ばれ、URL の query string を
+ * playScript() / startFrom() の引数に変換する。副作用なし・DOM 非依存の純粋関数で、
+ * テスト容易性のためにパースロジックをここに隔離する（レンダラ／component に直書きしない）。
+ *
+ * 仕様:
+ * - `?debug_script=advance,advance,choice:1-1` → { script: Step[] }（優先）
+ * - `?debug_scene=1-2&debug_flags=saw_characters:true` → { scene: StartFromOptions }
+ * - どちらも無ければ null
+ */
+
+import type { Step, StartFromOptions } from './GameState'
+import type { FlagValue } from '../types'
+
+/** parseDebugQuery の戻り値。script 指定 / scene 指定 / 該当なし(null) の三択。 */
+export type DebugQueryResult = { script: Step[] } | { scene: StartFromOptions } | null
+
+/**
+ * 文字列値を FlagValue に変換する。
+ * - "true" / "false" → Bool
+ * - 数値文字列 → Number
+ * - それ以外 → String
+ */
+function toFlagValue(raw: string): FlagValue {
+  if (raw === 'true') return { Bool: true }
+  if (raw === 'false') return { Bool: false }
+  // 空文字は数値変換すると 0 になってしまうため除外し、String 扱いにする
+  if (raw !== '' && !Number.isNaN(Number(raw))) return { Number: Number(raw) }
+  return { String: raw }
+}
+
+/**
+ * `debug_script` の値（カンマ区切りトークン列）を Step[] にパースする。
+ * 不正トークンはスキップして堅牢に処理する。
+ *
+ * - `advance` → { type: 'advance' }
+ * - `choice:<jump>` → { type: 'choice', jump: <jump> }
+ * - `wait:<ms>` → { type: 'wait', ms: Number(<ms>) }（数値にならない場合はスキップ）
+ */
+function parseScript(value: string): Step[] {
+  const steps: Step[] = []
+  for (const rawToken of value.split(',')) {
+    const token = rawToken.trim()
+    if (token === '') continue
+
+    if (token === 'advance') {
+      steps.push({ type: 'advance' })
+      continue
+    }
+
+    const sep = token.indexOf(':')
+    if (sep === -1) continue // 引数を伴わない未知トークンはスキップ
+
+    const kind = token.slice(0, sep)
+    const arg = token.slice(sep + 1)
+
+    if (kind === 'choice') {
+      if (arg === '') continue
+      steps.push({ type: 'choice', jump: arg })
+    } else if (kind === 'wait') {
+      const ms = Number(arg)
+      if (Number.isNaN(ms)) continue
+      steps.push({ type: 'wait', ms })
+    }
+    // 未知の kind はスキップ
+  }
+  return steps
+}
+
+/**
+ * `debug_flags` の値（`key:val,key2:val2`）を Record<string, FlagValue> にパースする。
+ * 不正トークン（key 無し等）はスキップする。
+ */
+function parseFlags(value: string): Record<string, FlagValue> {
+  const flags: Record<string, FlagValue> = {}
+  for (const rawPair of value.split(',')) {
+    const pair = rawPair.trim()
+    if (pair === '') continue
+    const sep = pair.indexOf(':')
+    if (sep === -1) continue // val 無しはスキップ
+    const key = pair.slice(0, sep).trim()
+    if (key === '') continue
+    const val = pair.slice(sep + 1)
+    flags[key] = toFlagValue(val)
+  }
+  return flags
+}
+
+/**
+ * URL の query string をデバッグ起点指定にパースする。
+ *
+ * @param search `window.location.search`（先頭 `?` の有無どちらも可）
+ * @returns debug_script があれば { script }（優先）、無く debug_scene があれば { scene }、
+ *          どちらも無ければ null
+ */
+export function parseDebugQuery(search: string): DebugQueryResult {
+  const params = new URLSearchParams(search)
+
+  // debug_script を優先
+  const scriptParam = params.get('debug_script')
+  if (scriptParam !== null) {
+    return { script: parseScript(scriptParam) }
+  }
+
+  const sceneId = params.get('debug_scene')
+  if (sceneId !== null && sceneId !== '') {
+    const scene: StartFromOptions = { sceneId }
+
+    const flagsParam = params.get('debug_flags')
+    if (flagsParam !== null) {
+      scene.flags = parseFlags(flagsParam)
+    }
+
+    const eventIndexParam = params.get('debug_eventIndex')
+    if (eventIndexParam !== null) {
+      const n = Number(eventIndexParam)
+      if (!Number.isNaN(n)) scene.eventIndex = n
+    }
+
+    const textIndexParam = params.get('debug_textIndex')
+    if (textIndexParam !== null) {
+      const n = Number(textIndexParam)
+      if (!Number.isNaN(n)) scene.textIndex = n
+    }
+
+    return { scene }
+  }
+
+  return null
+}

--- a/frontend/src/game/debugQuery.ts
+++ b/frontend/src/game/debugQuery.ts
@@ -98,10 +98,12 @@ function parseFlags(value: string): Record<string, FlagValue> {
 export function parseDebugQuery(search: string): DebugQueryResult {
   const params = new URLSearchParams(search)
 
-  // debug_script を優先
+  // debug_script を優先。ただし空・全トークン無効で Step が0件なら
+  // debug_scene へフォールスルーする（空 script が有効な scene を握りつぶさないため）
   const scriptParam = params.get('debug_script')
   if (scriptParam !== null) {
-    return { script: parseScript(scriptParam) }
+    const script = parseScript(scriptParam)
+    if (script.length > 0) return { script }
   }
 
   const sceneId = params.get('debug_scene')


### PR DESCRIPTION
closes #220

## 変更内容
ADR 0002 Phase 3。これで #220 の全 Phase（1 playScript / 2 startFrom / 3 URL クエリ）が完了。

- **新規 `frontend/src/game/debugQuery.ts`** — 純粋パーサ `parseDebugQuery(search)` が `{script: Step[]}` / `{scene: StartFromOptions}` / `null` を返す（副作用なし・DOM 非依存＝テスト容易。guidelines「単一責務・純粋関数化」準拠）
  - `?debug_script=advance,advance,choice:1-1` → playScript / `?debug_scene=1-2&debug_flags=saw_characters:true` → startFrom。`debug_script` 優先
  - flags 変換: `true/false`→Bool、数値→Number、他→String。不正トークンはスキップ
- **`NovelPlayer.tsx`** — `setScenes` 直後に `import.meta.env.DEV` ガード付きで配線（本番は tree-shake され無視）
- docs 更新（roadmap / adr 0002 / guidelines を Phase 3 完了に）

## テスト
- 新規 `debugQuery.test.ts` 20 ケース（script/scene 優先・flags 型変換境界・不正トークン堅牢性・index・null/空・先頭?有無）
- 全体 690 pass（既知の `CharacterLayer.test.ts` #209 の 1 fail は無関係）

## 設計準拠
パースを純粋関数に隔離し component/renderer に直書きしない（`docs/guidelines/` 規律）。`/impl` が guidelines を自動参照して実装。