### PR TITLE
test: CharacterLayer 立ち絵 Y のテストを現行仕様に同期 (#262)

### DIFF
--- a/frontend/src/game/CharacterLayer.test.ts
+++ b/frontend/src/game/CharacterLayer.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { CharacterLayer, normalizePosition } from './CharacterLayer'
-import { ASPECT_RATIOS } from './constants'
+import { CHARACTER_Y_RATIO, CharacterLayer, normalizePosition } from './CharacterLayer'
 
 interface FadeAnimationLike {
   fromAlpha: number
@@ -118,12 +117,14 @@ describe('normalizePosition', () => {
 })
 
 describe('CharacterLayer portrait mode (Issue #209)', () => {
-  it('screenHeight=800（9:16）で sprite.y が 800 * (380 / 450) ≒ 676 になる', () => {
+  it('足元 Y は screenHeight * CHARACTER_Y_RATIO になる（縦長モードでも比率追従）', () => {
+    // CHARACTER_Y_RATIO は #210 後に 380/450 → 1.0 へ変更（足元を画面下端に下げる意図）。
+    // 期待値は定数を直に参照して陳腐化を防ぐ（旧 `800*(380/450)≒676` 直書きの教訓・#262）。
     const layer = new CharacterLayer(450, 800)
     layer.show('hero', 'normal', '中央', '/assets', { instant: true })
     const state = asInternals(layer).characters.get('hero')
     expect(state).toBeDefined()
-    expect(state!.sprite.y).toBeCloseTo(800 * (380 / ASPECT_RATIOS['16:9'].height), 5)
+    expect(state!.sprite.y).toBeCloseTo(800 * CHARACTER_Y_RATIO, 5)
   })
 })
 

--- a/frontend/src/game/CharacterLayer.ts
+++ b/frontend/src/game/CharacterLayer.ts
@@ -69,12 +69,13 @@ export function normalizePosition(position: string): string {
   return POSITION_ALIASES_JA[position] ?? POSITION_ALIASES_EN[position] ?? position
 }
 
-/** 足元 Y 座標の比率。
+/** 足元 Y 座標の比率（`characterY = screenHeight * CHARACTER_Y_RATIO`）。
  *  以前は 380/450 ≒ 0.844 (DialogBox の上端あたり) だったが、
  *  枠なし・教育動画モードでは立ち絵の下端を画面下端まで下げたほうが座りが良い。
  *  影響範囲: 全 game の立ち絵が画面下端まで下がる。既存 game が枠ありで足元位置を
- *  そのままにしたい場合は別途オプション化が要る。 */
-const CHARACTER_Y_RATIO = 1.0
+ *  そのままにしたい場合は別途オプション化が要る。
+ *  テストが期待値を直書きして陳腐化するのを防ぐため export する（#262）。 */
+export const CHARACTER_Y_RATIO = 1.0
 
 interface CharacterState {
   sprite: Sprite


### PR DESCRIPTION
## 概要

`CharacterLayer.test.ts` のポートレートモードテストが旧仕様の期待値を直書きしたまま取り残され、**main の CI（Frontend TypeScript）が赤**だった。実装は正しく、テストのみの追従。

## 詳細

`CHARACTER_Y_RATIO` は Issue #210 後に `380/450 ≈ 0.844` → `1.0` へ意図的に変更されている（コメント: 「枠なし・教育動画モードでは立ち絵の下端を画面下端まで下げたほうが座りが良い」）。`characterY = screenHeight * 1.0` が正しい挙動だが、テストは `800 * (380 / 450) ≒ 676` を期待したまま。

## 変更

- `CHARACTER_Y_RATIO` を export
- テストの期待値を `screenHeight * CHARACTER_Y_RATIO` に修正（定数を参照して再陳腐化を防ぐ）
- テストタイトルを現行挙動に更新

## 検証

- フルスイート 692/692 緑、`tsc --noEmit` クリーン

Closes #262