### PR TITLE
refactor: NovelRenderer から画面効果の時間→値計算を純粋関数化 (#260)

### DIFF
--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -45,6 +45,7 @@ import { Event, EventScene } from '../types'
 import { ASPECT_RATIOS, type AspectRatio, parseAspectRatio } from './constants'
 import { isRead, loadReadProgress, markRead } from './readProgress'
 import { TimeController, defaultTimeController } from './TimeController'
+import { computeShakeOffset, computeFlashAlpha, computeFadeAlpha } from './screenEffects'
 
 /** Dialog / Narration から text を取り出すヘルパー */
 export function getTextEvent(event: Event):
@@ -819,14 +820,11 @@ export class NovelRenderer {
 
     const tick = (): void => {
       const elapsed = performance.now() - this.shakeStartMs
-      const progress = Math.min(elapsed / durationMs, 1)
-      // 減衰 sin 波: 残り時間に比例して振幅を絞る
-      const decay = 1 - progress
-      const offsetX = Math.sin(elapsed * 0.05) * intensityPx * decay
-      const offsetY = Math.cos(elapsed * 0.037) * intensityPx * decay * 0.6
+      // 減衰 sin/cos 揺れの数式は screenEffects.computeShakeOffset に集約 (#260)
+      const { offsetX, offsetY, done } = computeShakeOffset(elapsed, intensityPx, durationMs)
       this.app.stage.position.set(offsetX, offsetY)
 
-      if (progress < 1) {
+      if (!done) {
         this.shakeTimer = this.time.setTimeout(tick, intervalMs)
       } else {
         this.app.stage.position.set(0, 0)
@@ -860,10 +858,11 @@ export class NovelRenderer {
 
     this.effectTimer = this.time.setInterval(() => {
       const elapsed = performance.now() - startMs
-      const progress = Math.min(elapsed / durationMs, 1)
       if (!this.effectOverlay) return
-      this.effectOverlay.alpha = peakAlpha * (1 - progress)
-      if (progress >= 1) {
+      // alpha 補間は screenEffects.computeFlashAlpha に集約 (#260)
+      const { alpha, done } = computeFlashAlpha(elapsed, peakAlpha, durationMs)
+      this.effectOverlay.alpha = alpha
+      if (done) {
         this.effectOverlay.visible = false
         this.effectOverlay.alpha = 0
         if (this.effectTimer) {
@@ -905,11 +904,12 @@ export class NovelRenderer {
 
     this.effectTimer = this.time.setInterval(() => {
       const elapsed = performance.now() - startMs
-      const progress = Math.min(elapsed / durationMs, 1)
       if (!this.effectOverlay) return
-      this.effectOverlay.alpha = fromAlpha + (toAlpha - fromAlpha) * progress
-      if (progress >= 1) {
-        this.effectOverlay.alpha = toAlpha
+      // alpha 補間は screenEffects.computeFadeAlpha に集約 (#260)。
+      // done 時に alpha=toAlpha ちょうどを返すので、従来の「progress>=1 で toAlpha を当て直す」挙動と一致。
+      const { alpha, done } = computeFadeAlpha(elapsed, fromAlpha, toAlpha, durationMs)
+      this.effectOverlay.alpha = alpha
+      if (done) {
         // toAlpha が 0 なら不可視に戻す
         if (toAlpha <= 0) {
           this.effectOverlay.visible = false

--- a/frontend/src/game/screenEffects.test.ts
+++ b/frontend/src/game/screenEffects.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest'
+import {
+  effectProgress,
+  computeShakeOffset,
+  computeFlashAlpha,
+  computeFadeAlpha,
+} from './screenEffects'
+
+describe('effectProgress', () => {
+  it('途中は elapsed/duration', () => {
+    expect(effectProgress(0, 1000)).toBe(0)
+    expect(effectProgress(250, 1000)).toBe(0.25)
+    expect(effectProgress(500, 1000)).toBe(0.5)
+    expect(effectProgress(1000, 1000)).toBe(1)
+  })
+
+  it('duration を超えても 1 にクランプ', () => {
+    expect(effectProgress(1500, 1000)).toBe(1)
+    expect(effectProgress(Number.MAX_VALUE, 1000)).toBe(1)
+  })
+
+  it('負の elapsed は 0 にクランプ', () => {
+    expect(effectProgress(-100, 1000)).toBe(0)
+  })
+
+  it('duration <= 0 / 非有限は即完了 (1)', () => {
+    expect(effectProgress(0, 0)).toBe(1)
+    expect(effectProgress(0, -5)).toBe(1)
+    expect(effectProgress(0, NaN)).toBe(1)
+    expect(effectProgress(0, Infinity)).toBe(1)
+  })
+
+  it('elapsed が非有限なら完了 (1) にする', () => {
+    expect(effectProgress(NaN, 1000)).toBe(1)
+    expect(effectProgress(Infinity, 1000)).toBe(1)
+  })
+})
+
+describe('computeShakeOffset', () => {
+  // 抽出前に NovelRenderer.startShake の tick 内で直書きされていた式。
+  // リファレンス等価性: 抽出後の computeShakeOffset と一致することを確認する。
+  function referenceShake(elapsed: number, intensityPx: number, durationMs: number) {
+    const progress = Math.min(elapsed / durationMs, 1)
+    const decay = 1 - progress
+    const offsetX = Math.sin(elapsed * 0.05) * intensityPx * decay
+    const offsetY = Math.cos(elapsed * 0.037) * intensityPx * decay * 0.6
+    return { offsetX, offsetY, done: progress >= 1 }
+  }
+
+  it('リファレンス等価性: 抽出前の inline 式と一致 (代表時刻)', () => {
+    const intensity = 12
+    const duration = 600
+    for (const elapsed of [0, 50, 100, 200, 333, 450, 599]) {
+      const ref = referenceShake(elapsed, intensity, duration)
+      const got = computeShakeOffset(elapsed, intensity, duration)
+      expect(got.offsetX).toBeCloseTo(ref.offsetX, 12)
+      expect(got.offsetY).toBeCloseTo(ref.offsetY, 12)
+      expect(got.done).toBe(ref.done)
+    }
+  })
+
+  it('progress=0 で振幅最大、Y は X の係数違い（cos 起点なので Y は最大、X は 0）', () => {
+    // elapsed=0: sin(0)=0 → offsetX=0、cos(0)=1 → offsetY = intensity*1*0.6
+    const r = computeShakeOffset(0, 10, 500)
+    expect(r.offsetX).toBeCloseTo(0, 12)
+    expect(r.offsetY).toBeCloseTo(10 * 0.6, 12)
+    expect(r.done).toBe(false)
+  })
+
+  it('duration 到達で done=true・減衰により振幅 0', () => {
+    const r = computeShakeOffset(500, 10, 500)
+    expect(r.done).toBe(true)
+    // decay = 1 - 1 = 0 なので両軸とも 0
+    expect(r.offsetX).toBeCloseTo(0, 12)
+    expect(r.offsetY).toBeCloseTo(0, 12)
+  })
+
+  it('duration 超過でも done=true・振幅 0', () => {
+    const r = computeShakeOffset(9999, 10, 500)
+    expect(r.done).toBe(true)
+    // 0 / -0 はどちらも振幅ゼロ（PixiJS の position 設定では同一）なので絶対値で比較
+    expect(Math.abs(r.offsetX)).toBe(0)
+    expect(Math.abs(r.offsetY)).toBe(0)
+  })
+
+  it('intensity が非有限なら揺れなし', () => {
+    const r = computeShakeOffset(100, NaN, 500)
+    expect(Math.abs(r.offsetX)).toBe(0)
+    expect(Math.abs(r.offsetY)).toBe(0)
+  })
+
+  it('減衰: 同じ位相でも progress が進むほど振幅が小さい', () => {
+    // 位相が同じになる時刻を選ぶ代わりに、振幅の上限 |offset| <= intensity*decay を確認
+    const intensity = 20
+    const duration = 1000
+    const early = computeShakeOffset(100, intensity, duration)
+    const late = computeShakeOffset(900, intensity, duration)
+    const earlyDecay = 1 - 0.1
+    const lateDecay = 1 - 0.9
+    expect(Math.abs(early.offsetX)).toBeLessThanOrEqual(intensity * earlyDecay + 1e-9)
+    expect(Math.abs(late.offsetX)).toBeLessThanOrEqual(intensity * lateDecay + 1e-9)
+  })
+})
+
+describe('computeFlashAlpha', () => {
+  // 抽出前 NovelRenderer.startFlash の inline 式
+  function referenceFlash(elapsed: number, peakAlpha: number, durationMs: number) {
+    const progress = Math.min(elapsed / durationMs, 1)
+    return { alpha: peakAlpha * (1 - progress), done: progress >= 1 }
+  }
+
+  it('リファレンス等価性: 抽出前の inline 式と一致', () => {
+    const peak = 0.8
+    const duration = 400
+    for (const elapsed of [0, 50, 100, 200, 399, 400]) {
+      const ref = referenceFlash(elapsed, peak, duration)
+      const got = computeFlashAlpha(elapsed, peak, duration)
+      expect(got.alpha).toBeCloseTo(ref.alpha, 12)
+      expect(got.done).toBe(ref.done)
+    }
+  })
+
+  it('開始時は peak、完了時は 0', () => {
+    expect(computeFlashAlpha(0, 0.8, 400).alpha).toBeCloseTo(0.8, 12)
+    const end = computeFlashAlpha(400, 0.8, 400)
+    expect(end.alpha).toBeCloseTo(0, 12)
+    expect(end.done).toBe(true)
+  })
+
+  it('中点は peak の半分', () => {
+    expect(computeFlashAlpha(200, 0.8, 400).alpha).toBeCloseTo(0.4, 12)
+  })
+
+  it('peak が非有限なら alpha=0', () => {
+    expect(computeFlashAlpha(0, NaN, 400).alpha).toBe(0)
+  })
+})
+
+describe('computeFadeAlpha', () => {
+  // 抽出前 NovelRenderer.startFade の inline 式（progress>=1 で toAlpha を当て直す挙動込み）
+  function referenceFade(elapsed: number, fromAlpha: number, toAlpha: number, durationMs: number) {
+    const progress = Math.min(elapsed / durationMs, 1)
+    let alpha = fromAlpha + (toAlpha - fromAlpha) * progress
+    if (progress >= 1) alpha = toAlpha
+    return { alpha, done: progress >= 1 }
+  }
+
+  it('リファレンス等価性: 抽出前の inline 式と一致（fade-in / fade-out 両方）', () => {
+    const duration = 500
+    for (const [from, to] of [
+      [0, 1],
+      [1, 0],
+      [0.2, 0.9],
+    ]) {
+      for (const elapsed of [0, 100, 250, 400, 500, 600]) {
+        const ref = referenceFade(elapsed, from, to, duration)
+        const got = computeFadeAlpha(elapsed, from, to, duration)
+        expect(got.alpha).toBeCloseTo(ref.alpha, 12)
+        expect(got.done).toBe(ref.done)
+      }
+    }
+  })
+
+  it('開始は from、完了は to ちょうど', () => {
+    expect(computeFadeAlpha(0, 0.2, 0.9, 500).alpha).toBeCloseTo(0.2, 12)
+    const end = computeFadeAlpha(500, 0.2, 0.9, 500)
+    expect(end.alpha).toBe(0.9)
+    expect(end.done).toBe(true)
+  })
+
+  it('fade-out: from=1 to=0 の中点は 0.5', () => {
+    expect(computeFadeAlpha(250, 1, 0, 500).alpha).toBeCloseTo(0.5, 12)
+  })
+
+  it('完了時は補間誤差を残さず to を返す', () => {
+    // duration 超過でも done かつ alpha=to
+    const r = computeFadeAlpha(9999, 0.3, 0.7, 500)
+    expect(r.alpha).toBe(0.7)
+    expect(r.done).toBe(true)
+  })
+
+  it('from / to が非有限なら 0 扱い', () => {
+    expect(computeFadeAlpha(100, NaN, 0.5, 500).alpha).toBeGreaterThanOrEqual(0)
+    expect(computeFadeAlpha(500, 0.5, NaN, 500).alpha).toBe(0)
+  })
+})

--- a/frontend/src/game/screenEffects.ts
+++ b/frontend/src/game/screenEffects.ts
@@ -1,0 +1,120 @@
+/**
+ * 画面効果 (#143) の時間→値 純粋計算。
+ *
+ * `NovelRenderer` の `startShake` / `startFlash` / `startFade` は内部で
+ * `performance.now()` を読み、その経過時間から「stage の揺れオフセット」や
+ * 「effectOverlay の alpha」を毎フレーム計算して PixiJS に反映していた。
+ * その計算自体（減衰 sin/cos 揺れ・線形 alpha 補間）は決定論的な pure computation
+ * なので、`easing.ts` / `raycastProjection.ts` と同じ流儀でここに切り出す（#260 漸進分離）。
+ *
+ * PixiJS / DOM / TimeController に一切依存しない。`NovelRenderer` 側はタイマー駆動の
+ * 「いつ計算するか」と「結果をどの表示オブジェクトに当てるか」だけを持つ。
+ */
+
+/**
+ * 経過時間と継続時間から進行率 t を返す（0..1 にクランプ済み）。
+ *
+ * `progress = min(elapsed / durationMs, 1)` を 1 箇所に集約したもの。
+ * shake / flash / fade の 3 経路で同じ式を使っていた。
+ *
+ * 入力契約:
+ *  - `durationMs <= 0` または非有限 → `1`（即完了扱い。0 除算と発散を回避）
+ *  - `elapsed` の `NaN/Infinity` → `1`（破損時刻は完了扱いにして演出を残さない）
+ *  - 負の `elapsed` は `0` にクランプ
+ */
+export function effectProgress(elapsedMs: number, durationMs: number): number {
+  if (!Number.isFinite(durationMs) || durationMs <= 0) return 1
+  if (!Number.isFinite(elapsedMs)) return 1
+  if (elapsedMs <= 0) return 0
+  const t = elapsedMs / durationMs
+  return t > 1 ? 1 : t
+}
+
+/** 画面シェイク 1 フレーム分の stage オフセット（px）。 */
+export interface ShakeOffset {
+  /** stage.position.x に設定する横揺れ量 */
+  offsetX: number
+  /** stage.position.y に設定する縦揺れ量 */
+  offsetY: number
+  /** 演出が完了したか（progress >= 1）。true なら呼び出し側はオフセットを 0 に戻して終了する */
+  done: boolean
+}
+
+/**
+ * 減衰 sin/cos 波ベースの画面シェイクオフセットを返す純粋関数 (#143)。
+ *
+ * 元 `NovelRenderer.startShake` の tick 内と同一の式:
+ *   decay   = 1 - progress
+ *   offsetX = sin(elapsed * 0.05) * intensityPx * decay
+ *   offsetY = cos(elapsed * 0.037) * intensityPx * decay * 0.6
+ * 残り時間に比例して振幅を絞る（progress=1 で振幅 0）。X より Y を弱く（×0.6）して
+ * 横揺れ主体の自然な揺れにする。位相係数 0.05 / 0.037 は互いに素に近い比でうねりを出す。
+ *
+ * `done` は `progress >= 1`。呼び出し側は `done` のとき stage を (0,0) に戻して停止する。
+ *
+ * 入力契約:
+ *  - `intensityPx` の `NaN/Infinity` は `0` 扱い（揺れなし）
+ *  - `elapsedMs` / `durationMs` は `effectProgress` の契約に従う
+ */
+export function computeShakeOffset(
+  elapsedMs: number,
+  intensityPx: number,
+  durationMs: number
+): ShakeOffset {
+  const progress = effectProgress(elapsedMs, durationMs)
+  const safeIntensity = Number.isFinite(intensityPx) ? intensityPx : 0
+  const decay = 1 - progress
+  const safeElapsed = Number.isFinite(elapsedMs) ? elapsedMs : 0
+  const offsetX = Math.sin(safeElapsed * 0.05) * safeIntensity * decay
+  const offsetY = Math.cos(safeElapsed * 0.037) * safeIntensity * decay * 0.6
+  return { offsetX, offsetY, done: progress >= 1 }
+}
+
+/** flash / fade 1 フレーム分の alpha と完了状態。 */
+export interface EffectAlpha {
+  /** effectOverlay.alpha に設定する不透明度 */
+  alpha: number
+  /** 演出が完了したか（progress >= 1） */
+  done: boolean
+}
+
+/**
+ * フラッシュ演出の alpha を返す純粋関数 (#143)。
+ *
+ * 元 `NovelRenderer.startFlash` と同一: `alpha = peakAlpha * (1 - progress)`。
+ * peak から 0 へ線形フェードアウトする。`done`（progress>=1）のとき呼び出し側は
+ * overlay を不可視に戻す。
+ *
+ * 入力契約: `peakAlpha` の `NaN/Infinity` は `0` 扱い。
+ */
+export function computeFlashAlpha(
+  elapsedMs: number,
+  peakAlpha: number,
+  durationMs: number
+): EffectAlpha {
+  const progress = effectProgress(elapsedMs, durationMs)
+  const safePeak = Number.isFinite(peakAlpha) ? peakAlpha : 0
+  return { alpha: safePeak * (1 - progress), done: progress >= 1 }
+}
+
+/**
+ * フェード演出の alpha を返す純粋関数 (#143)。
+ *
+ * 元 `NovelRenderer.startFade` と同一: `alpha = fromAlpha + (toAlpha - fromAlpha) * progress`。
+ * fromAlpha → toAlpha へ線形補間する。`done`（progress>=1）のとき alpha は `toAlpha` ちょうど
+ * （補間誤差を残さないよう呼び出し側で `toAlpha` を当て直す元挙動と一致させる）。
+ *
+ * 入力契約: `fromAlpha` / `toAlpha` の `NaN/Infinity` は `0` 扱い。
+ */
+export function computeFadeAlpha(
+  elapsedMs: number,
+  fromAlpha: number,
+  toAlpha: number,
+  durationMs: number
+): EffectAlpha {
+  const progress = effectProgress(elapsedMs, durationMs)
+  const safeFrom = Number.isFinite(fromAlpha) ? fromAlpha : 0
+  const safeTo = Number.isFinite(toAlpha) ? toAlpha : 0
+  if (progress >= 1) return { alpha: safeTo, done: true }
+  return { alpha: safeFrom + (safeTo - safeFrom) * progress, done: false }
+}


### PR DESCRIPTION
## 概要

dev-doctrine（ゲーム profile）規律4「肥大トレンドの監視 + 純粋計算の漸進分離」(#260) の **1 歩目**。一気に割らず、境界が明確で副作用の無い純粋計算を **1 ブロックだけ** 抽出する。

`NovelRenderer` の画面効果 (#143) — `startShake` / `startFlash` / `startFade` — は内部で `performance.now()` を読み、その経過時間から「stage の揺れオフセット」「effectOverlay の alpha」を毎フレーム計算して PixiJS に当てていた。その計算自体（減衰 sin/cos 揺れ・線形 alpha 補間）は決定論的な pure computation なので、`raycastProjection.ts` / `easing.ts` と同じ流儀で `screenEffects.ts` に切り出した。

## 抽出内容（新モジュール `frontend/src/game/screenEffects.ts`）

| 公開関数 | シグネチャ | 元の場所 |
|---|---|---|
| `effectProgress` | `(elapsedMs, durationMs) => number` (0..1 クランプ) | shake/flash/fade の 3 経路で重複していた `min(elapsed/duration, 1)` を集約 |
| `computeShakeOffset` | `(elapsedMs, intensityPx, durationMs) => { offsetX, offsetY, done }` | `startShake` の tick 内 |
| `computeFlashAlpha` | `(elapsedMs, peakAlpha, durationMs) => { alpha, done }` | `startFlash` の interval 内 |
| `computeFadeAlpha` | `(elapsedMs, fromAlpha, toAlpha, durationMs) => { alpha, done }` | `startFade` の interval 内 |

`NovelRenderer` 側はタイマー駆動（いつ計算するか）と表示反映（結果をどの表示オブジェクトに当てるか）だけを残す。PixiJS / DOM / TimeController には一切依存しない。

## 挙動不変の根拠

- **リファレンス等価性テスト**: 抽出前に inline で書かれていた式（`Math.min(elapsed/durationMs,1)`, 減衰 sin/cos, alpha 補間）をテスト内に複製し、抽出後の関数と代表時刻で `toBeCloseTo(_, 12)` 一致を確認（shake / flash / fade それぞれ）。
- `computeFadeAlpha` は `done`（progress>=1）のとき `toAlpha` ちょうどを返す。元コードの「補間後に `progress>=1` で `alpha=toAlpha` を当て直す」挙動と一致（補間誤差を残さない）。
- `durationMs<=0` / 非有限は `effectProgress=1`（即完了）の防御。DSL 由来の duration は常に正なので golden path の挙動は不変。
- 既存テスト全緑（755 件、うち新規 20 件）+ type-check 緑。

## 行数 before → after

- `NovelRenderer.ts`: 2017 → 2017 行（13 挿入 / 13 削除。本 Issue は **行数ダイエットではなく** god-object 化の監視 + 純粋計算の凝集が目的。テスト不能だった ~12 行の数式を純粋モジュールへ移し、責務凝集とテスト網羅を改善した）
- 新規: `screenEffects.ts` 120 行 / `screenEffects.test.ts` 186 行

## #260 は close しない

監視 Issue（肥大トレンドの定期再確認 + 新機能追加のたびに「その部分だけ純粋関数化」する規約）として継続する。本 PR はその漸進分離の 1 歩。

## 実機確認の golden path

frontend dev サーバ（`cd frontend && npm run dev`）で、画面効果を含むシナリオを開き次を目視:
- `[シェイク]`（Shake）: 画面が減衰しながら揺れ、停止後に元位置 (0,0) に戻る
- `[フラッシュ]`（Flash）: 指定色が peak alpha から 0 へフェードアウトして消える
- `[フェード]`（Fade）: 指定色が from_alpha → to_alpha へ補間（to=0 なら最後に不可視へ）

シーク / バック操作で効果が残留しないこと（`applyState` のリセットは本 PR で未変更）も併せて確認。