### PR TITLE
refactor: NovelRenderer から純粋計算4ブロックを切り出し肥大を縮小 (#260)

### DIFF
--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -46,6 +46,7 @@ import { ASPECT_RATIOS, type AspectRatio, parseAspectRatio } from './constants'
 import { isRead, loadReadProgress, markRead } from './readProgress'
 import { TimeController, defaultTimeController } from './TimeController'
 import { computeShakeOffset, computeFlashAlpha, computeFadeAlpha } from './screenEffects'
+import { computeCoverFit, parseHexColor, resolveAssetUrl, saveSlotToGameState } from './novelLayout'
 
 /** Dialog / Narration から text を取り出すヘルパー */
 export function getTextEvent(event: Event):
@@ -793,16 +794,7 @@ export class NovelRenderer {
   }
 
   // ---- 画面効果メソッド (#143) ----
-
-  /**
-   * 16進カラーコード（"#rrggbb"）を PixiJS の 0xRRGGBB 数値に変換する。
-   * パース失敗時は 0xffffff を返す。
-   */
-  private parseHexColor(hex: string): number {
-    const clean = hex.replace('#', '')
-    const n = parseInt(clean, 16)
-    return isNaN(n) ? 0xffffff : n
-  }
+  // 16進カラーパース parseHexColor は novelLayout に切り出した (#260)
 
   /**
    * 画面シェイク演出 (#143)。
@@ -845,7 +837,7 @@ export class NovelRenderer {
       this.effectTimer = null
     }
 
-    const color = this.parseHexColor(colorHex)
+    const color = parseHexColor(colorHex)
     this.effectOverlay.clear()
     this.effectOverlay.rect(0, 0, this.screenWidth, this.screenHeight)
     this.effectOverlay.fill(color)
@@ -891,7 +883,7 @@ export class NovelRenderer {
       this.effectTimer = null
     }
 
-    const color = this.parseHexColor(colorHex)
+    const color = parseHexColor(colorHex)
     this.effectOverlay.clear()
     this.effectOverlay.rect(0, 0, this.screenWidth, this.screenHeight)
     this.effectOverlay.fill(color)
@@ -1151,7 +1143,7 @@ export class NovelRenderer {
 
     // BGM復元
     if (state.currentBgmPath) {
-      const soundUrl = `${this.assetBaseUrl}/sounds/${state.currentBgmPath.replace(/^\//, '')}`
+      const soundUrl = resolveAssetUrl(this.assetBaseUrl, 'sounds', state.currentBgmPath)
       this.audioManager.playBgm(soundUrl)
       this.currentBgmPath = state.currentBgmPath
     } else {
@@ -1372,7 +1364,7 @@ export class NovelRenderer {
     }
     if ('Bgm' in event) {
       if (event.Bgm.action === 'Play' && event.Bgm.path) {
-        const soundUrl = `${this.assetBaseUrl}/sounds/${event.Bgm.path.replace(/^\//, '')}`
+        const soundUrl = resolveAssetUrl(this.assetBaseUrl, 'sounds', event.Bgm.path)
         // fade_ms (#145): 指定があれば fade-in、未指定なら即時再生
         this.audioManager.playBgm(soundUrl, event.Bgm.fade_ms ?? undefined)
         this.currentBgmPath = event.Bgm.path
@@ -1388,7 +1380,7 @@ export class NovelRenderer {
       return
     }
     if ('Se' in event) {
-      const soundUrl = `${this.assetBaseUrl}/sounds/${event.Se.path.replace(/^\//, '')}`
+      const soundUrl = resolveAssetUrl(this.assetBaseUrl, 'sounds', event.Se.path)
       // fade_ms (#145): 指定があれば fade-in、未指定なら即時再生
       this.audioManager.playSe(soundUrl, event.Se.fade_ms ?? undefined)
       return
@@ -1531,8 +1523,7 @@ export class NovelRenderer {
 
     if (!this.assetBaseUrl) return
 
-    const cleanPath = path.replace(/^\//, '')
-    const url = `${this.assetBaseUrl}/images/${cleanPath}`
+    const url = resolveAssetUrl(this.assetBaseUrl, 'images', path)
 
     // ロード要求ごとにトークンを更新し、古い非同期完了による UAF / race を防ぐ。
     // キャッシュヒットで同期描画する場合も必ず進めること。さもないと直前に
@@ -1566,13 +1557,10 @@ export class NovelRenderer {
   }
 
   private applyCoverFit(sprite: Sprite): void {
-    const scaleX = this.screenWidth / sprite.texture.width
-    const scaleY = this.screenHeight / sprite.texture.height
-    const scale = Math.max(scaleX, scaleY)
-    sprite.width = sprite.texture.width * scale
-    sprite.height = sprite.texture.height * scale
-    sprite.x = (this.screenWidth - sprite.width) / 2
-    sprite.y = (this.screenHeight - sprite.height) / 2
+    // カバーフィット幾何は novelLayout.computeCoverFit に集約 (#260)。
+    // 戻り値の {width,height,x,y} を Object.assign で sprite の各 setter に流し込む。
+    const { width, height } = sprite.texture
+    Object.assign(sprite, computeCoverFit(width, height, this.screenWidth, this.screenHeight))
   }
 
   /**
@@ -1780,20 +1768,10 @@ export class NovelRenderer {
       return
     }
 
-    // SaveSlotData から背景/動画/立ち絵/BGM まで含む完全な状態を構築
-    const state: NovelGameState = {
-      sceneId: data.sceneId,
-      eventIndex: data.eventIndex,
-      textIndex: data.textIndex,
-      flags: data.flags,
-      backgroundPath: data.backgroundPath,
-      backgroundFade: normalizeBackgroundFade(data.backgroundFade),
-      // 動画レイヤ (#252)。後方互換: 古いセーブには無い → null（動画なし）。
-      video: data.video ?? null,
-      isBlackout: data.isBlackout ?? false,
-      characters: data.characters ?? [],
-      currentBgmPath: data.currentBgmPath ?? null,
-    }
+    // SaveSlotData → NovelGameState のフィールド対応・後方互換フォールバックは
+    // novelLayout.saveSlotToGameState に集約 (#260)。fade だけは PixiJS を間接参照する
+    // normalizeBackgroundFade をここで適用し、純粋関数には正規化済みの値を渡す。
+    const state = saveSlotToGameState(data, normalizeBackgroundFade(data.backgroundFade))
     this.restoreToScene(scene, state)
   }
 
@@ -1891,7 +1869,7 @@ export class NovelRenderer {
     }
 
     if (voicePath) {
-      const voiceUrl = `${this.assetBaseUrl}/sounds/${voicePath.replace(/^\//, '')}`
+      const voiceUrl = resolveAssetUrl(this.assetBaseUrl, 'sounds', voicePath)
       // voice は fire-and-forget で再生する。autoAdvance は typing onDone / [待機] が決定する。
       // 以前は voice 終了で scheduleAutoAdvance を呼んでいたが、これだと voice の長さで
       // 中央ホールド時間が伸びてしまい「決まった時間で次へ進む」設計と合わなかった。

--- a/frontend/src/game/novelLayout.test.ts
+++ b/frontend/src/game/novelLayout.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest'
+import { computeCoverFit, parseHexColor, resolveAssetUrl, saveSlotToGameState } from './novelLayout'
+import type { SaveSlotData } from './SaveManager'
+import type { BackgroundFade } from './GameState'
+
+describe('computeCoverFit', () => {
+  // 抽出前に NovelRenderer.applyCoverFit 内で直書きされていた式（リファレンス実装）。
+  // sprite.{width,height,x,y} に代入していた値をそのまま再現する。
+  function inlineCoverFit(texW: number, texH: number, screenW: number, screenH: number) {
+    const scaleX = screenW / texW
+    const scaleY = screenH / texH
+    const scale = Math.max(scaleX, scaleY)
+    const width = texW * scale
+    const height = texH * scale
+    return {
+      width,
+      height,
+      x: (screenW - width) / 2,
+      y: (screenH - height) / 2,
+    }
+  }
+
+  it('リファレンス等価性: 抽出前 inline 式と数値完全一致', () => {
+    const cases: Array<[number, number, number, number]> = [
+      [1920, 1080, 1920, 1080], // 完全一致（scale=1, x=y=0）
+      [1000, 1000, 1920, 1080], // 縦長画面 → 幅基準でカバー
+      [1920, 1080, 1000, 1000], // 横長画像 → 高さ基準でカバー
+      [800, 600, 1920, 1080], // 拡大
+      [4000, 3000, 1920, 1080], // 縮小
+      [1280, 720, 1920, 1080], // 同アスペクト拡大（scale=1.5, x=y=0）
+      [333, 777, 1920, 1080], // 半端な比
+    ]
+    for (const [tw, th, sw, sh] of cases) {
+      expect(computeCoverFit(tw, th, sw, sh)).toEqual(inlineCoverFit(tw, th, sw, sh))
+    }
+  })
+
+  it('カバー（contain ではない）: 画面を必ず覆い、長辺がはみ出す', () => {
+    // 1000x1000 の正方形画像を 1920x1080 にカバー → 幅 1920 を満たす scale=1.92
+    const fit = computeCoverFit(1000, 1000, 1920, 1080)
+    expect(fit.width).toBe(1920)
+    expect(fit.height).toBe(1920) // 高さは画面(1080)を超えてはみ出す
+    expect(fit.x).toBe(0)
+    expect(fit.y).toBe((1080 - 1920) / 2) // 上下に等分してはみ出し中央寄せ（負値）
+  })
+
+  it('同サイズなら scale=1・原点 (0,0)', () => {
+    expect(computeCoverFit(1920, 1080, 1920, 1080)).toEqual({
+      width: 1920,
+      height: 1080,
+      x: 0,
+      y: 0,
+    })
+  })
+
+  it('中央寄せ: はみ出し分を左右/上下で等分する', () => {
+    // 横長画像 4000x1080 を 1920x1080 にカバー → 高さ基準 scale=1, 幅 4000 がはみ出す
+    const fit = computeCoverFit(4000, 1080, 1920, 1080)
+    expect(fit.height).toBe(1080)
+    expect(fit.width).toBe(4000)
+    expect(fit.x).toBe((1920 - 4000) / 2) // 左右均等（負値）
+    expect(fit.y).toBe(0)
+  })
+})
+
+describe('parseHexColor', () => {
+  // 抽出前 NovelRenderer.parseHexColor の inline 実装（リファレンス）。
+  function inlineParseHexColor(hex: string): number {
+    const clean = hex.replace('#', '')
+    const n = parseInt(clean, 16)
+    return isNaN(n) ? 0xffffff : n
+  }
+
+  it('リファレンス等価性: 抽出前 inline 実装と一致', () => {
+    const cases = [
+      '#ffffff',
+      '#000000',
+      '#ff0000',
+      '#00ff00',
+      '#0000ff',
+      'ffffff', // # なし
+      '#abc', // 短縮
+      '#FFFFFF', // 大文字
+      'zzzzzz', // 不正 → 白フォールバック
+      '#', // 空 → NaN → 白
+      '', // 空文字 → NaN → 白
+      '#12g', // 途中まで（parseInt の寛容な解釈）
+    ]
+    for (const c of cases) {
+      expect(parseHexColor(c)).toBe(inlineParseHexColor(c))
+    }
+  })
+
+  it('代表値', () => {
+    expect(parseHexColor('#ffffff')).toBe(0xffffff)
+    expect(parseHexColor('#000000')).toBe(0x000000)
+    expect(parseHexColor('#ff0000')).toBe(0xff0000)
+    expect(parseHexColor('ff0000')).toBe(0xff0000) // # 省略
+  })
+
+  it('不正値は白 (0xffffff) にフォールバック', () => {
+    expect(parseHexColor('zzz')).toBe(0xffffff)
+    expect(parseHexColor('#')).toBe(0xffffff)
+    expect(parseHexColor('')).toBe(0xffffff)
+  })
+
+  it("先頭 '#' は 1 つだけ除去（replace の元挙動）", () => {
+    // '##ff' → '#ff' → parseInt('#ff',16)=NaN → 白
+    expect(parseHexColor('##ff')).toBe(0xffffff)
+  })
+})
+
+describe('resolveAssetUrl', () => {
+  // 抽出前に 5 箇所で直書きされていた式（リファレンス）。
+  function inlineResolveUrl(baseUrl: string, kind: 'images' | 'sounds', path: string): string {
+    return `${baseUrl}/${kind}/${path.replace(/^\//, '')}`
+  }
+
+  it('リファレンス等価性: 抽出前 inline 式と一致', () => {
+    const cases: Array<[string, 'images' | 'sounds', string]> = [
+      ['/assets', 'images', 'bg/room.png'],
+      ['/assets', 'images', '/bg/room.png'], // 先頭スラッシュ付き
+      ['/assets', 'sounds', 'bgm/main.mp3'],
+      ['/assets', 'sounds', '/se/click.wav'],
+      ['https://cdn.example.com', 'sounds', 'voice/a.mp3'],
+      ['', 'images', 'x.png'], // 空 baseUrl
+    ]
+    for (const [base, kind, path] of cases) {
+      expect(resolveAssetUrl(base, kind, path)).toBe(inlineResolveUrl(base, kind, path))
+    }
+  })
+
+  it('images / sounds の種別をパスに反映', () => {
+    expect(resolveAssetUrl('/assets', 'images', 'bg.png')).toBe('/assets/images/bg.png')
+    expect(resolveAssetUrl('/assets', 'sounds', 'bgm.mp3')).toBe('/assets/sounds/bgm.mp3')
+  })
+
+  it("path 先頭の '/' を 1 つだけ落とす", () => {
+    expect(resolveAssetUrl('/assets', 'sounds', '/bgm.mp3')).toBe('/assets/sounds/bgm.mp3')
+    // 二重スラッシュは 1 つだけ落ちる（元 replace(/^\//) の挙動）
+    expect(resolveAssetUrl('/assets', 'sounds', '//bgm.mp3')).toBe('/assets/sounds//bgm.mp3')
+  })
+})
+
+describe('saveSlotToGameState', () => {
+  function baseData(): SaveSlotData {
+    return {
+      slot: 1,
+      sceneId: 'scene-1',
+      eventIndex: 5,
+      textIndex: 2,
+      flags: { hasKey: { Bool: true } },
+      backgroundPath: 'bg/room.png',
+      isBlackout: true,
+      characters: [{ name: 'A', expression: 'smile', position: 'center' }],
+      currentBgmPath: 'bgm/main.mp3',
+      savedAt: '2026-01-01T00:00:00.000Z',
+      sceneName: 'Room',
+    }
+  }
+
+  // 抽出前 NovelRenderer.loadFromSaveData 内の state 構築ブロック（リファレンス）。
+  // fade は呼び出し側で正規化済みの値を渡す前提なので、ここでも正規化済み値をそのまま使う。
+  function inlineState(data: SaveSlotData, normalizedFade: BackgroundFade | null) {
+    return {
+      sceneId: data.sceneId,
+      eventIndex: data.eventIndex,
+      textIndex: data.textIndex,
+      flags: data.flags,
+      backgroundPath: data.backgroundPath,
+      backgroundFade: normalizedFade,
+      video: data.video ?? null,
+      isBlackout: data.isBlackout ?? false,
+      characters: data.characters ?? [],
+      currentBgmPath: data.currentBgmPath ?? null,
+    }
+  }
+
+  it('リファレンス等価性: 抽出前 inline ブロックと一致（全フィールド指定）', () => {
+    const data = baseData()
+    const fade: BackgroundFade = { top: 0.5, bottom: 0, left: 0, right: 0 }
+    expect(saveSlotToGameState(data, fade)).toEqual(inlineState(data, fade))
+  })
+
+  it('全フィールドが data から正しく写像される', () => {
+    const data = baseData()
+    const state = saveSlotToGameState(data, null)
+    expect(state).toEqual({
+      sceneId: 'scene-1',
+      eventIndex: 5,
+      textIndex: 2,
+      flags: { hasKey: { Bool: true } },
+      backgroundPath: 'bg/room.png',
+      backgroundFade: null,
+      video: null,
+      isBlackout: true,
+      characters: [{ name: 'A', expression: 'smile', position: 'center' }],
+      currentBgmPath: 'bgm/main.mp3',
+    })
+  })
+
+  it('後方互換フォールバック: video 未定義 → null', () => {
+    const data = baseData()
+    delete (data as Partial<SaveSlotData>).video
+    expect(saveSlotToGameState(data, null).video).toBeNull()
+  })
+
+  it('後方互換フォールバック: video あり → その値', () => {
+    const data = baseData()
+    data.video = { path: 'v/intro.mp4', loop: true } as SaveSlotData['video']
+    expect(saveSlotToGameState(data, null).video).toEqual({ path: 'v/intro.mp4', loop: true })
+  })
+
+  it('正規化済み fade をそのまま採用（純粋関数は再正規化しない）', () => {
+    const data = baseData()
+    const fade: BackgroundFade = { top: 0, bottom: 0.3, left: 0, right: 0 }
+    expect(saveSlotToGameState(data, fade).backgroundFade).toBe(fade)
+    expect(saveSlotToGameState(data, null).backgroundFade).toBeNull()
+  })
+
+  it('sceneId は data の値をそのまま代入（呼び出し側が非 null を保証）', () => {
+    const data = baseData()
+    data.sceneId = 'other-scene'
+    expect(saveSlotToGameState(data, null).sceneId).toBe('other-scene')
+  })
+})

--- a/frontend/src/game/novelLayout.ts
+++ b/frontend/src/game/novelLayout.ts
@@ -1,0 +1,143 @@
+/**
+ * `NovelRenderer` の純粋計算（幾何・色パース・URL/フォント解決）。
+ *
+ * `NovelRenderer.ts`（god-object）の肥大トレンド監視と漸進分離 (#260) の一環。
+ * 入力→出力が決定論的で、`this` / PixiJS / DOM / TimeController に一切依存しない計算だけを
+ * ここに集約する。`screenEffects.ts`（時間→値）/ `raycastProjection.ts`（射影幾何）/
+ * `easing.ts` と同じ流儀。NovelRenderer 側は「いつ計算するか」「結果をどの表示オブジェクト・
+ * オーディオに当てるか」だけを保持する。
+ *
+ * 各関数は抽出前に NovelRenderer 内へ直書きされていた式と数値・文字列が完全に一致する
+ * （挙動不変）。リファレンス等価性は novelLayout.test.ts で機械的に担保する。
+ */
+
+import type { BackgroundFade, NovelGameState } from './GameState'
+import type { SaveSlotData } from './SaveManager'
+
+/** カバーフィット後の背景スプライト寸法と配置（px）。 */
+export interface CoverFit {
+  /** sprite.width に設定する表示幅（px） */
+  width: number
+  /** sprite.height に設定する表示高さ（px） */
+  height: number
+  /** sprite.x に設定する左上 X（中央寄せのオフセット） */
+  x: number
+  /** sprite.y に設定する左上 Y（中央寄せのオフセット） */
+  y: number
+}
+
+/**
+ * 背景画像をアスペクト比維持で画面いっぱいに「カバー」し、中央寄せした寸法を返す純粋関数。
+ *
+ * 元 `NovelRenderer.applyCoverFit` と同一:
+ *   scaleX = screenW / texW
+ *   scaleY = screenH / texH
+ *   scale  = max(scaleX, scaleY)         // 短辺を画面に合わせ、長辺は溢れさせる（cover）
+ *   width  = texW * scale
+ *   height = texH * scale
+ *   x = (screenW - width) / 2            // 溢れた分を左右（または上下）に等分して中央寄せ
+ *   y = (screenH - height) / 2
+ *
+ * `Math.max(scaleX, scaleY)` で「画面を覆う最小倍率」を選ぶため、画像は必ず画面全体を埋め、
+ * はみ出した方向は中央でトリミングされる（contain ではなく cover）。
+ *
+ * NovelRenderer 側はこの結果を sprite.{width,height,x,y} にそのまま代入するだけ。
+ * texture サイズと screen サイズはどちらも純粋な数値で、PixiJS Sprite には触れない。
+ */
+export function computeCoverFit(
+  textureWidth: number,
+  textureHeight: number,
+  screenWidth: number,
+  screenHeight: number
+): CoverFit {
+  const scaleX = screenWidth / textureWidth
+  const scaleY = screenHeight / textureHeight
+  const scale = Math.max(scaleX, scaleY)
+  const width = textureWidth * scale
+  const height = textureHeight * scale
+  return {
+    width,
+    height,
+    x: (screenWidth - width) / 2,
+    y: (screenHeight - height) / 2,
+  }
+}
+
+/**
+ * `#RRGGBB` 形式（またはプレフィックス省略の `RRGGBB`）を PixiJS 用の数値色に変換する純粋関数。
+ *
+ * 元 `NovelRenderer.parseHexColor` と同一:
+ *   clean = hex の先頭 '#' を 1 つだけ除去
+ *   n     = parseInt(clean, 16)
+ *   結果  = NaN なら 0xffffff（白フォールバック）、それ以外は n
+ *
+ * `replace('#', '')` は最初の '#' のみ除去する元実装をそのまま踏襲する。
+ * `parseInt(_, 16)` の寛容な解釈（途中までパース・先頭空白許容等）も元と一致。
+ * 不正値で白にフォールバックするのは Flash/Fade のオーバーレイ色が消えないようにするため。
+ */
+export function parseHexColor(hex: string): number {
+  const clean = hex.replace('#', '')
+  const n = parseInt(clean, 16)
+  return isNaN(n) ? 0xffffff : n
+}
+
+/** アセット URL の種別。`images/` か `sounds/` のサブディレクトリに対応する。 */
+export type AssetKind = 'images' | 'sounds'
+
+/**
+ * アセットの相対パスを配信用の絶対 URL に解決する純粋関数。
+ *
+ * 元 NovelRenderer 内に 5 箇所直書きされていた式を 1 つに集約:
+ *   `${baseUrl}/${kind}/${path.replace(/^\//, '')}`
+ * 背景画像（images）と BGM/SE/voice/復元 BGM（sounds）で同形だった。
+ *
+ * `path.replace(/^\//, '')` は path 先頭の '/' を 1 つだけ落とす（`/bgm/a.mp3` →
+ * `bgm/a.mp3`）。baseUrl と kind の間・kind と path の間は常に '/' 1 つで連結する。
+ * baseUrl 末尾の '/' 正規化はしない（元実装どおり。呼び出し側は baseUrl を末尾スラッシュ
+ * なしで渡す前提）。
+ */
+export function resolveAssetUrl(baseUrl: string, kind: AssetKind, path: string): string {
+  return `${baseUrl}/${kind}/${path.replace(/^\//, '')}`
+}
+
+/**
+ * セーブスロットデータ (`SaveSlotData`) を復元用の `NovelGameState` に変換する純粋関数。
+ *
+ * 元 `NovelRenderer.loadFromSaveData` 内に直書きされていた state 構築ブロックと同一の
+ * フィールド対応・後方互換フォールバックを集約する:
+ *   sceneId        = data.sceneId（呼び出し側で非 null を保証してから渡す）
+ *   eventIndex     = data.eventIndex
+ *   textIndex      = data.textIndex
+ *   flags          = data.flags
+ *   backgroundPath = data.backgroundPath
+ *   backgroundFade = normalizedFade（呼び出し側で normalizeBackgroundFade 済みを渡す）
+ *   video          = data.video ?? null      // 古いセーブには無い → 動画なし
+ *   isBlackout     = data.isBlackout ?? false
+ *   characters     = data.characters ?? []
+ *   currentBgmPath = data.currentBgmPath ?? null
+ *
+ * `backgroundFade` の正規化（`normalizeBackgroundFade` / `edgeFadeMask`）は PixiJS を間接
+ * 参照するため、このモジュールを PixiJS 非依存に保つ目的で「正規化済みの値」を引数で受け取る。
+ * これにより本関数は `data` の読み取りと定数フォールバックだけの純粋写像になる。
+ *
+ * `data.sceneId` は型上 `string | null` だが、呼び出し側（`loadFromSaveData`）が null を
+ * 早期 return で弾いた後に呼ぶ前提。元実装も同じ前提で `state.sceneId = data.sceneId`
+ * としていたため、ここでもそのまま代入する（挙動不変）。
+ */
+export function saveSlotToGameState(
+  data: SaveSlotData,
+  normalizedFade: BackgroundFade | null
+): NovelGameState {
+  return {
+    sceneId: data.sceneId,
+    eventIndex: data.eventIndex,
+    textIndex: data.textIndex,
+    flags: data.flags,
+    backgroundPath: data.backgroundPath,
+    backgroundFade: normalizedFade,
+    video: data.video ?? null,
+    isBlackout: data.isBlackout ?? false,
+    characters: data.characters ?? [],
+    currentBgmPath: data.currentBgmPath ?? null,
+  }
+}


### PR DESCRIPTION
## 概要

NovelRenderer.ts (god-object, 2017行) の肥大トレンド監視・純粋計算の漸進分離 (#260) の続き。
前回 PR #264 (screenEffects = 時間→値計算1ブロック) では行数がほぼ据え置きだったため、
今回は **this/PIXI/DOM 非依存の決定論的計算を4ブロック** 抜き、新モジュール
`frontend/src/game/novelLayout.ts` へ集約して **行数を実際に減らした**。

大原則は不変: god-object を一気に割らない / 挙動完全不変 / 互換バイパスを足さない /
各抽出は独立に安全。リスクの高い状態遷移や PIXI 副作用は触らず、入力→出力が決定的な計算だけを抜いた。

## 抽出ブロック (4個)

| 関数 | 抽出元 | 純粋である根拠 |
|---|---|---|
| `computeCoverFit(texW, texH, screenW, screenH)` | `applyCoverFit` の scale/中央寄せ幾何 | 数値4つ→`{width,height,x,y}`。sprite には触れず呼び出し側が `Object.assign` で setter に流す |
| `parseHexColor(hex): number` | `parseHexColor` メソッド | string→number。`replace`/`parseInt`/`isNaN` のみ |
| `resolveAssetUrl(baseUrl, kind, path): string` | アセット URL 構築 (images/sounds) | **直書き5箇所**を1関数に集約。文字列結合 + `replace(/^\//,'')` のみ |
| `saveSlotToGameState(data, normalizedFade): NovelGameState` | `loadFromSaveData` の state 構築ブロック | `data` 読み取り + 定数フォールバックのみ。fade 正規化(PIXI間接参照)は呼び出し側で適用し純粋関数には正規化済み値を渡す |

`novelLayout.ts` は `import type` のみ (GameState / SaveManager の型) で **PixiJS 非依存** を維持。
循環依存なし。

## 挙動不変の根拠

各ブロックに **リファレンス等価性テスト**（抽出前の inline 式をテスト内に複製し、抽出後と数値・文字列の完全一致を検証）を追加。
`novelLayout.test.ts` 17 tests。`screenEffects` と同じ流儀で、挙動不変の機械的証拠とする。

## 行数 before → after

- `NovelRenderer.ts`: **2017 → 1995 (net -22)**
- 新規 `novelLayout.ts`: +143、`novelLayout.test.ts`: +226

## テスト・品質

- frontend テスト: **755 → 772 (+17)**、全緑
- `npm run type-check`: 緑
- `npm run lint` / format: 緑

## 実機で確認すべき golden path

`cd frontend && npm run dev`（vite、デフォルト port 5173）で以下を目視:
1. **背景表示 (computeCoverFit)**: 異なるアスペクト比の背景画像が画面いっぱいにカバー表示・中央寄せされる。歪み・余白なし
2. **Flash / Fade 演出 (parseHexColor)**: `[フラッシュ]`/`[フェード]` を含むシナリオで指定色のオーバーレイが正しい色で出る
3. **BGM/SE/voice/背景ロード (resolveAssetUrl)**: 音声再生・背景ロードが従来どおり（パス先頭スラッシュ有無の両方）
4. **セーブ→ロード復元 (saveSlotToGameState)**: セーブしてロードすると背景/動画/立ち絵/BGM/暗転/フラグが正しく復元される。古いセーブ（video フィールドなし）も動画なしで復元

## 補足

`#260` は肥大トレンドの監視継続タスクなので **close しない**（Closes は付けていない）。
次の漸進候補: フォント解決の優先順 (`per-line ?? per-game ?? runtime`, 2箇所重複) の純粋化。今回は call site が printWidth で多行化し行数が増えるため見送り。