### PR TITLE
docs+test: PR #265 レビュー指摘対応（architecture.md純粋モジュール登録・computeCoverFit round-trip等価性テスト・境界追加）

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -215,6 +215,13 @@ NovelRenderer (PixiJS)          ← 1イベントずつ描画
 
 `Dialog` と `Narration` のみユーザー操作（クリック/キー）で進行する。
 
+### NovelRenderer の純粋計算モジュール (#260)
+
+`NovelRenderer.ts` は god-object 化しやすいため、入力→出力が決定論的で `this` / PixiJS / DOM / TimeController に一切依存しない計算を専用モジュールへ漸進分離している（#260）。`ruby.ts` / `rubyLayout.ts` / `raycastProjection.ts` と同じ流儀で、NovelRenderer 側は「いつ計算するか」「結果をどの表示オブジェクト・オーディオに当てるか」だけを保持する。各関数は抽出前に NovelRenderer 内へ直書きされていた式・数値・文字列と完全一致し（挙動不変）、リファレンス等価性をユニットテストで機械的に担保する。
+
+- **`frontend/src/game/screenEffects.ts`（時間→値、#143 / #264）**: 画面効果の毎フレーム計算を集約する。`effectProgress(elapsedMs, durationMs)` が `min(elapsed/duration, 1)` の進行率を返し（`durationMs <= 0` / 非有限は即完了 `1`、負 elapsed は `0` にクランプ）、それを使って `computeShakeOffset`（`decay = 1 - progress`・`offsetX = sin(elapsed*0.05)*intensity*decay`・`offsetY = cos(elapsed*0.037)*intensity*decay*0.6` の減衰揺れ）、`computeFlashAlpha`（`peak*(1-progress)` の線形フェードアウト）、`computeFadeAlpha`（`from + (to-from)*progress` の線形補間、`progress>=1` で `to` ちょうど）を算出する。いずれも `done = progress >= 1` を返し、NaN/Infinity の振幅・alpha は `0` 扱い。境界値テストは `screenEffects.test.ts`
+- **`frontend/src/game/novelLayout.ts`（幾何・色パース・URL 解決・state 変換、#265）**: NovelRenderer の純粋計算 4 種を集約する。`computeCoverFit(textureWidth, textureHeight, screenWidth, screenHeight)` は背景画像をアスペクト比維持で画面に「カバー」し中央寄せした `{width, height, x, y}` を返す（`scale = max(screenW/texW, screenH/texH)` で短辺を画面に合わせ長辺を溢れさせ、はみ出し分を中央でトリミング）。`parseHexColor(hex)` は `#RRGGBB` を PixiJS 用数値色に変換（先頭 '#' を 1 つだけ除去 → `parseInt(_, 16)`、NaN は白 `0xffffff` フォールバック）。`resolveAssetUrl(baseUrl, kind, path)` はアセット相対パスを `${baseUrl}/${kind}/${path 先頭 '/' を 1 つ除去}` の配信 URL に解決（`kind` は `'images' | 'sounds'`）。`saveSlotToGameState(data, normalizedFade)` は `SaveSlotData` を復元用 `NovelGameState` に写像する（video/isBlackout/characters/currentBgmPath は古いセーブ向け後方互換フォールバック付き、fade は PixiJS 非依存を保つため正規化済みの値を引数で受け取る）。境界値・リファレンス等価性テストは `novelLayout.test.ts`
+
 ## セーブ/ロード
 
 ### 保存先

--- a/frontend/src/game/novelLayout.test.ts
+++ b/frontend/src/game/novelLayout.test.ts
@@ -4,9 +4,11 @@ import type { SaveSlotData } from './SaveManager'
 import type { BackgroundFade } from './GameState'
 
 describe('computeCoverFit', () => {
-  // 抽出前に NovelRenderer.applyCoverFit 内で直書きされていた式（リファレンス実装）。
-  // sprite.{width,height,x,y} に代入していた値をそのまま再現する。
-  function inlineCoverFit(texW: number, texH: number, screenW: number, screenH: number) {
+  // 注意: これは「抽出後の computeCoverFit と同一の直接計算式」であって、
+  // 抽出前の PIXI set/read-back 経路の再現ではない（両者は同じ式なので一致して当然）。
+  // applyCoverFit が実際に通る set→read-back round-trip の等価性は、後段の
+  // 「round-trip 等価性」テストで pixiReadBack オラクルを使って別途縛る。
+  function directCoverFit(texW: number, texH: number, screenW: number, screenH: number) {
     const scaleX = screenW / texW
     const scaleY = screenH / texH
     const scale = Math.max(scaleX, scaleY)
@@ -20,7 +22,33 @@ describe('computeCoverFit', () => {
     }
   }
 
-  it('リファレンス等価性: 抽出前 inline 式と数値完全一致', () => {
+  // PIXI v8 Sprite の set→read-back 経路を数値で再現するオラクル。
+  // applyCoverFit は computeCoverFit の戻り値を Object.assign(sprite, {...}) で
+  // sprite.{width,height,x,y} に流し込む。width/height は「実 px」ではなく scale を
+  // 介して保持・読み戻されるため、抽出前から実際に画面へ出ていた寸法はこの round-trip 後の値。
+  //
+  //   set width(v):  scale.x = (origW !== 0) ? v/origW * sign : sign   // sign = Math.sign(scale.x) || 1
+  //   get width():   Math.abs(scale.x) * origW
+  //
+  // 生成直後の Sprite は scale.x = scale.y = 1 なので sign = 1。x/y は position の素通し setter
+  // （read-back 変換なし）。よって画面に出る寸法は下記のとおり。
+  // 参照: node_modules/pixi.js/lib/scene/container/container-mixins/measureMixin.mjs (_setWidth/_setHeight)
+  //        node_modules/pixi.js/lib/scene/sprite/Sprite.mjs (get/set width, get/set height)
+  function pixiReadBack(origW: number, origH: number, screenW: number, screenH: number) {
+    const fit = computeCoverFit(origW, origH, screenW, screenH)
+    // width setter → scale.x（sign=1 で初期化された Sprite を前提）
+    const scaleX = origW !== 0 ? fit.width / origW : 1
+    const scaleY = origH !== 0 ? fit.height / origH : 1
+    // getter で読み戻した実表示寸法
+    return {
+      width: Math.abs(scaleX) * origW,
+      height: Math.abs(scaleY) * origH,
+      x: fit.x, // position はそのまま
+      y: fit.y,
+    }
+  }
+
+  it('リファレンス等価性: 抽出後 computeCoverFit と直接計算式が数値完全一致', () => {
     const cases: Array<[number, number, number, number]> = [
       [1920, 1080, 1920, 1080], // 完全一致（scale=1, x=y=0）
       [1000, 1000, 1920, 1080], // 縦長画面 → 幅基準でカバー
@@ -31,7 +59,60 @@ describe('computeCoverFit', () => {
       [333, 777, 1920, 1080], // 半端な比
     ]
     for (const [tw, th, sw, sh] of cases) {
-      expect(computeCoverFit(tw, th, sw, sh)).toEqual(inlineCoverFit(tw, th, sw, sh))
+      expect(computeCoverFit(tw, th, sw, sh)).toEqual(directCoverFit(tw, th, sw, sh))
+    }
+  })
+
+  it('round-trip 等価性: PIXI set→read-back 経路後も寸法が保たれる', () => {
+    // PR #265 が同値性を疑った当の経路（sprite.width=v で scale.x=v/origW を設定し、
+    // get width=abs(scale.x)*origW で読み戻す）を pixiReadBack で再現し、
+    // computeCoverFit が「設定→読み戻し」を生き残ることを複数入力で機械的に確認する。
+    // 小/大/極端アスペクト比 + 実画面解像度数種を網羅。
+    const cases: Array<[number, number, number, number]> = [
+      [1920, 1080, 1920, 1080], // 等倍
+      [1, 1, 1920, 1080], // 極小テクスチャ → 巨大拡大
+      [8000, 6000, 1366, 768], // 巨大テクスチャ → 縮小（ノートPC解像度）
+      [3840, 2160, 2560, 1440], // 4K → WQHD
+      [100, 4000, 1920, 1080], // 極端な縦長アスペクト
+      [4000, 100, 1280, 720], // 極端な横長アスペクト
+      [1242, 2688, 375, 812], // モバイル縦（iPhone 系）
+      [375, 812, 1920, 1080], // モバイル画像を横画面へ
+      [333, 777, 800, 600], // 半端な比 + SVGA
+    ]
+    for (const [tw, th, sw, sh] of cases) {
+      const fit = computeCoverFit(tw, th, sw, sh)
+      const readBack = pixiReadBack(tw, th, sw, sh)
+      // computeCoverFit の生出力と、PIXI 経路を通した後の表示寸法が一致する
+      // （cover-fit の width/height は常に非負なので abs を通しても値は変わらない）。
+      expect(fit.width).toBeCloseTo(readBack.width, 6)
+      expect(fit.height).toBeCloseTo(readBack.height, 6)
+      expect(fit.x).toBeCloseTo(readBack.x, 6)
+      expect(fit.y).toBeCloseTo(readBack.y, 6)
+      // round-trip 後も「画面を必ず覆う」cover 不変条件が崩れない
+      expect(readBack.width).toBeGreaterThanOrEqual(sw - 1e-6)
+      expect(readBack.height).toBeGreaterThanOrEqual(sh - 1e-6)
+    }
+  })
+
+  it('退化入力: 抽出前後で同じ式 → 同じ結果（texW=0 / NaN / 負値）', () => {
+    // 本体ロジックは不変なので「直接計算式と同じ結果を返す」ことだけを縛る。
+    // raycastProjection 系テストが NaN/Infinity を網羅する流儀に揃える。
+    const degenerate: Array<[number, number, number, number]> = [
+      [0, 1080, 1920, 1080], // texW=0 → scaleX=Infinity → scale=Infinity → width=NaN(0*Inf)
+      [1920, 0, 1920, 1080], // texH=0 → scaleY=Infinity
+      [0, 0, 1920, 1080], // 両方 0
+      [1920, 1080, 0, 0], // 画面 0 → scale=0 → width=0
+      [NaN, 1080, 1920, 1080], // texW NaN
+      [1920, NaN, 1920, 1080], // texH NaN
+      [1920, 1080, NaN, 1080], // screenW NaN
+      [-1920, 1080, 1920, 1080], // 負のテクスチャ幅
+      [1920, 1080, -1920, -1080], // 負の画面
+      [Infinity, 1080, 1920, 1080], // texW Infinity → scaleX=0
+      [1920, 1080, Infinity, 1080], // screenW Infinity → scale=Infinity
+    ]
+    for (const [tw, th, sw, sh] of degenerate) {
+      // toEqual は NaN 同士を一致と見なす（Object.is ベース）ので退化系でも縛れる
+      expect(computeCoverFit(tw, th, sw, sh)).toEqual(directCoverFit(tw, th, sw, sh))
     }
   })
 
@@ -107,6 +188,19 @@ describe('parseHexColor', () => {
   it("先頭 '#' は 1 つだけ除去（replace の元挙動）", () => {
     // '##ff' → '#ff' → parseInt('#ff',16)=NaN → 白
     expect(parseHexColor('##ff')).toBe(0xffffff)
+  })
+
+  it("中間の '#' は最初の 1 つだけ除去（replace('#','') のセマンティクス固定）", () => {
+    // replace(文字列, '') は最初の出現だけを置換する。中間 # でもこの挙動を縛る。
+    // '1#2' → 先頭でなく中間の最初の # を 1 つ消して '12' → parseInt('12',16)=0x12=18
+    expect(parseHexColor('1#2')).toBe(0x12)
+    expect(parseHexColor('1#2')).toBe(inlineParseHexColor('1#2'))
+    // '#1#2' → 最初の # だけ消えて '1#2' → parseInt('1#2',16) は '1' まで読んで 0x1
+    expect(parseHexColor('#1#2')).toBe(0x1)
+    expect(parseHexColor('#1#2')).toBe(inlineParseHexColor('#1#2'))
+    // 'a#b#c' → 最初の # だけ消えて 'ab#c' → parseInt('ab#c',16)='ab' まで → 0xab
+    expect(parseHexColor('a#b#c')).toBe(0xab)
+    expect(parseHexColor('a#b#c')).toBe(inlineParseHexColor('a#b#c'))
   })
 })
 


### PR DESCRIPTION
## 背景

PR #265（NovelRenderer から純粋計算 4 ブロックを抽出）のマージ後、独立レビューで出た must/should/nit 指摘を全件対応する follow-up。dev-doctrine の review 方針「must/should/nit 全件修正・0 件に収束」に従う。

**プロダクションコード（`frontend/src/game/novelLayout.ts` 本体）は無変更**。変更は `docs/architecture.md`（純粋モジュール登録）と `frontend/src/game/novelLayout.test.ts`（テスト追加 + テスト内コメント修正）のみ。

## 対応した指摘

### 1. [should] docs/architecture.md に純粋モジュール登録漏れ
レンダリングパイプライン節の配下に「NovelRenderer の純粋計算モジュール (#260)」サブ節を新設し、`ruby.ts` / `rubyLayout.ts` / `raycastProjection.ts` と同じ粒度・文体で 2 モジュールを登録した。

- `screenEffects.ts`（#143 / #264）— 時間→値計算: `effectProgress` / `computeShakeOffset`（減衰揺れ）/ `computeFlashAlpha` / `computeFadeAlpha`
- `novelLayout.ts`（#265）— `computeCoverFit` / `parseHexColor` / `resolveAssetUrl` / `saveSlotToGameState`

### 2. [should・最重要] computeCoverFit の round-trip 等価性テスト追加 + コメント是正
従来の `inlineCoverFit` は「抽出後の computeCoverFit と同一の直接計算式」であり、PR #265 が同値性を疑った当の経路＝PIXI の `sprite.width = v`（`scale.x = v/origW`）→ `get width`（`abs(scale.x)*origW`）の round-trip を再現していなかった。

- **`pixiReadBack` オラクル**を追加。PIXI v8 の実 set→read-back セマンティクス（`measureMixin._setWidth` / `Sprite.get/set width`）を数値で再現し、`computeCoverFit` の出力が「設定→読み戻し」を生き残ることを実画面解像度・極端アスペクト比・モバイル縦など 9 入力で `toBeCloseTo` 突き合わせ + cover 不変条件（必ず画面を覆う）を確認する round-trip 等価性テストを 1 本追加。
- 既存 `inlineCoverFit` を `directCoverFit` に改名し、コメントを「これは抽出後の式そのもの（pre-extraction の set/read-back 経路ではない）」と正直に修正。

### 3. [nit] computeCoverFit の退化系境界テスト
`texW=0`（scale Infinity → NaN）/ `NaN` / `Infinity` / 負値などの退化入力で、抽出前後が同式である以上同じ結果を返すことを `directCoverFit` 突き合わせで縛るテストを追加（raycastProjection 系の NaN/Infinity 流儀に合わせる）。`toEqual` の Object.is ベース比較で NaN 同士も縛れる。

### 4. [nit] parseHexColor の中間 # ケース
`'1#2'` / `'#1#2'` / `'a#b#c'` のような中間 # 入力で `replace('#','')` が最初の 1 つだけ消すセマンティクスを固定するテストを追加。

## 検証

- `npm test -- --run`: 772 → 775 tests 緑（novelLayout.test.ts は 17 → 20）
- `npm run type-check`: 緑
- `npm run lint`: 緑
- lint-staged の eslint --fix / prettier --write: テストファイル変更なし（既に準拠）

## 親 Issue

#260 は NovelRenderer 肥大トレンドの監視継続なので **close しない**。