### PR TITLE
高解像度レンダリング: 表示の鮮明化 + 動画書き出しを高解像度化 (#279)

### DIFF
--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -282,6 +282,13 @@ export class NovelRenderer {
       height: this.screenHeight,
       background: 0x000000,
       antialias: true,
+      // #279: 既定では device DPI でラスタライズして表示を鮮明にする。
+      // resolution 未指定だと PixiJS は 1 固定になり、論理解像度（9:16=450×800 等）の
+      // 裏バッファをそのまま拡大表示するためボケる（DOM は device DPI で自動ラスタライズ）。
+      // autoDensity=true で CSS サイズは論理 px のまま、裏バッファだけ resolution 倍にする。
+      // PixiJS v8 の Text は resolution 未指定ならレンダラ解像度に追従するので全テキストが鮮明になる。
+      resolution: typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1,
+      autoDensity: true,
     })
     this.appInitialized = true
 
@@ -509,6 +516,26 @@ export class NovelRenderer {
   /** AudioManager にアクセスする (#228 動画エクスポートの音声配線用) */
   getAudioManager(): AudioManager {
     return this.audioManager
+  }
+
+  /**
+   * 現在のレンダラ解像度を返す (#279 動画書き出しの高解像度化)。
+   * 書き出し前後で bump → restore するために退避用として使う。
+   */
+  getRenderResolution(): number {
+    return this.app?.renderer?.resolution ?? 1
+  }
+
+  /**
+   * レンダラ解像度を変更する (#279)。論理サイズ（screenWidth/Height）は据え置きで
+   * 裏バッファだけ resolution 倍にする。動画書き出し時に一時的に上げ、終了後に元へ戻す。
+   * 次フレームの再描画（VideoExporter は直後に jumpToScene する）で render-only 要素も
+   * 高解像度で再生成される。PixiJS v8 の Text はレンダラ解像度に追従する。
+   */
+  setRenderResolution(resolution: number): void {
+    if (!this.app?.renderer) return
+    if (!(resolution > 0) || !Number.isFinite(resolution)) return
+    this.app.renderer.resize(this.screenWidth, this.screenHeight, resolution)
   }
 
   /**

--- a/frontend/src/game/VideoExporter.test.ts
+++ b/frontend/src/game/VideoExporter.test.ts
@@ -168,4 +168,45 @@ describe('exportVideo resolution bump (#279)', () => {
     ).rejects.toThrow(/AudioManager could not provide MediaStream/)
     expect(calls).toEqual([5, 1])
   })
+
+  // review S1: bump 後〜recorder 配線前の同期コンストラクタ（captureStream / MediaStream /
+  // MediaRecorder）が throw しても、解像度・isExporting が巻き戻り、次の export がガードで
+  // 詰まらないこと。jsdom には MediaStream が無いため、その経路で実際に throw する。
+  it('restores resolution and clears the in-progress flag if a stream/recorder constructor throws', async () => {
+    const { exportVideo } = await import('./VideoExporter')
+
+    function rendererWithAudio(prev: number, calls: number[]) {
+      return {
+        getCanvas: () => ({ captureStream: () => ({ getVideoTracks: () => [] }) }),
+        getAudioManager: () => ({
+          ensureContext: () => {},
+          enableCapture: () => ({ getAudioTracks: () => [] }), // audioStream 取得は成功させる
+          disableCapture: () => {},
+        }),
+        getRenderResolution: () => prev,
+        setRenderResolution: (r: number) => {
+          calls.push(r)
+        },
+        setOnSceneChange: () => {},
+        setOnEnd: () => {},
+        takeOnEnd: () => null,
+        takeOnSceneChange: () => null,
+        jumpToScene: () => {},
+        setAutoMode: () => {},
+      } as unknown as Parameters<typeof exportVideo>[0]
+    }
+
+    const calls1: number[] = []
+    await expect(
+      exportVideo(rendererWithAudio(2, calls1), { startSceneId: 'a', endSceneId: 'b', fps: 30 })
+    ).rejects.toThrow()
+    expect(calls1).toEqual([3, 2]) // bump → restore
+
+    // isExporting がリセットされている（さもないと2回目が "already running" になる）
+    const calls2: number[] = []
+    await expect(
+      exportVideo(rendererWithAudio(2, calls2), { startSceneId: 'a', endSceneId: 'b', fps: 30 })
+    ).rejects.toThrow()
+    expect(calls2).toEqual([3, 2])
+  })
 })

--- a/frontend/src/game/VideoExporter.test.ts
+++ b/frontend/src/game/VideoExporter.test.ts
@@ -107,3 +107,65 @@ describe('exportVideo state machine (smoke)', () => {
     ).rejects.toThrow(/MediaRecorder is not supported/)
   })
 })
+
+describe('exportVideo resolution bump (#279)', () => {
+  let savedMR: unknown
+  beforeEach(() => {
+    savedMR = (globalThis as unknown as { MediaRecorder?: unknown }).MediaRecorder
+    class FakeMediaRecorder {
+      static isTypeSupported() {
+        return true
+      }
+    }
+    ;(globalThis as unknown as { MediaRecorder?: unknown }).MediaRecorder = FakeMediaRecorder
+  })
+  afterEach(() => {
+    ;(globalThis as unknown as { MediaRecorder?: unknown }).MediaRecorder = savedMR
+  })
+
+  // enableCapture が null を返す失敗経路で、解像度 bump → restore の順序だけを検証する
+  // （MediaRecorder 本体の完走をモックせずに #279-B の核だけを突く）。
+  function makeRenderer(prev: number, calls: number[]) {
+    return {
+      getCanvas: () => ({ captureStream: () => ({ getVideoTracks: () => [] }) }),
+      getAudioManager: () => ({
+        ensureContext: () => {},
+        enableCapture: () => null, // bump 後に失敗させて restore を観測する
+        disableCapture: () => {},
+      }),
+      getRenderResolution: () => prev,
+      setRenderResolution: (r: number) => {
+        calls.push(r)
+      },
+      setOnSceneChange: () => {},
+      setOnEnd: () => {},
+      takeOnEnd: () => null,
+      takeOnSceneChange: () => null,
+      jumpToScene: () => {},
+      setAutoMode: () => {},
+    } as unknown as Parameters<typeof import('./VideoExporter').exportVideo>[0]
+  }
+
+  it('bumps to max(3, prev) before capture and restores prev on failure', async () => {
+    const { exportVideo } = await import('./VideoExporter')
+    const calls: number[] = []
+    await expect(
+      exportVideo(makeRenderer(2, calls), { startSceneId: 'a', endSceneId: 'b', fps: 30 })
+    ).rejects.toThrow(/AudioManager could not provide MediaStream/)
+    expect(calls).toEqual([3, 2])
+  })
+
+  it('honors an explicit exportResolution and still restores prev', async () => {
+    const { exportVideo } = await import('./VideoExporter')
+    const calls: number[] = []
+    await expect(
+      exportVideo(makeRenderer(1, calls), {
+        startSceneId: 'a',
+        endSceneId: 'b',
+        fps: 30,
+        exportResolution: 5,
+      })
+    ).rejects.toThrow(/AudioManager could not provide MediaStream/)
+    expect(calls).toEqual([5, 1])
+  })
+})

--- a/frontend/src/game/VideoExporter.ts
+++ b/frontend/src/game/VideoExporter.ts
@@ -36,6 +36,13 @@ export interface VideoExportOptions {
    * 短くすると終端で BGM がプチっと切れる事故になるため、変更時は要注意。
    */
   postRollMs?: number
+  /**
+   * 録画中だけ適用するレンダラ解像度 (#279)。captureStream は canvas の裏バッファを
+   * そのまま録るため、書き出し解像度 = 論理サイズ × この値になる。未指定なら
+   * `max(3, 現在の解像度)`（9:16=450×800 で 1350×2400、16:9=800×450 で 2400×1350 ＝
+   * いずれも 1080×1920 以上）。録画後は元の解像度（device DPI）へ復元する。
+   */
+  exportResolution?: number
 }
 
 export interface VideoExportResult {
@@ -92,6 +99,7 @@ export async function exportVideo(
     onProgress,
     preRollMs = 50,
     postRollMs = 1200,
+    exportResolution: exportResolutionOpt,
   } = opts
 
   if (typeof MediaRecorder === 'undefined') {
@@ -108,11 +116,30 @@ export async function exportVideo(
     throw new Error('NovelRenderer canvas is not ready')
   }
 
+  // 多重録画ガード (review S3)。同 NovelRenderer に対する並行 exportVideo は
+  // takeOnEnd/takeOnSceneChange の前提（破壊的）を壊すため許可しない。
+  // #279: 解像度 bump / captureStream など副作用の前に最初に弾く（並行起動が
+  // 先行録画の解像度を巻き戻す事故を防ぐ）。
+  if (isExporting) {
+    throw new Error('VideoExporter is already running. Wait for the current export to finish.')
+  }
+  isExporting = true
+
+  // #279: 録画中だけレンダラ解像度を上げて高解像度の WebM を得る。captureStream は
+  // canvas の裏バッファを録るので、captureStream を作る前に resize しておく。
+  // 録画後は cleanup で必ず元解像度へ戻す（通常プレイの表示・挙動を無回帰に保つ）。
+  const prevResolution = renderer.getRenderResolution()
+  const exportResolution = exportResolutionOpt ?? Math.max(3, prevResolution)
+  renderer.setRenderResolution(exportResolution)
+
   const audio = renderer.getAudioManager()
   audio.ensureContext()
   const audioStream = audio.enableCapture()
   if (!audioStream) {
+    // 解像度・録画フラグを必ず巻き戻してから throw（前段で副作用を起こしているため）。
     audio.disableCapture()
+    renderer.setRenderResolution(prevResolution)
+    isExporting = false
     throw new Error('AudioManager could not provide MediaStream (AudioContext init failed)')
   }
 
@@ -121,14 +148,6 @@ export async function exportVideo(
     ...videoStream.getVideoTracks(),
     ...audioStream.getAudioTracks(),
   ])
-
-  // 多重録画ガード (review S3)。同 NovelRenderer に対する並行 exportVideo は
-  // takeOnEnd/takeOnSceneChange の前提（破壊的）を壊すため許可しない。
-  if (isExporting) {
-    audio.disableCapture()
-    throw new Error('VideoExporter is already running. Wait for the current export to finish.')
-  }
-  isExporting = true
 
   const chunks: Blob[] = []
   const recorder = new MediaRecorder(combined, { mimeType })
@@ -159,6 +178,8 @@ export async function exportVideo(
       renderer.setOnSceneChange(prevOnSceneChange)
       renderer.setOnEnd(prevOnEnd)
       audio.disableCapture()
+      // #279: 録画用に上げた解像度を元（device DPI）へ戻す。
+      renderer.setRenderResolution(prevResolution)
     } catch (e) {
       console.warn('[VideoExporter] cleanup failed', e)
     }

--- a/frontend/src/game/VideoExporter.ts
+++ b/frontend/src/game/VideoExporter.ts
@@ -143,14 +143,26 @@ export async function exportVideo(
     throw new Error('AudioManager could not provide MediaStream (AudioContext init failed)')
   }
 
-  const videoStream = canvas.captureStream(fps)
-  const combined = new MediaStream([
-    ...videoStream.getVideoTracks(),
-    ...audioStream.getAudioTracks(),
-  ])
+  // #279 (review S1): captureStream / MediaStream / MediaRecorder の同期コンストラクタが
+  // throw すると、bump した解像度と isExporting フラグが戻らず固着する（cleanup は
+  // recorder のコールバック経由でしか呼ばれないため）。ここで try/catch し、!audioStream
+  // 経路と同じく副作用（capture / 解像度 / フラグ）を巻き戻してから rethrow する。
+  let recorder!: MediaRecorder
+  try {
+    const videoStream = canvas.captureStream(fps)
+    const combined = new MediaStream([
+      ...videoStream.getVideoTracks(),
+      ...audioStream.getAudioTracks(),
+    ])
+    recorder = new MediaRecorder(combined, { mimeType })
+  } catch (e) {
+    audio.disableCapture()
+    renderer.setRenderResolution(prevResolution)
+    isExporting = false
+    throw e instanceof Error ? e : new Error(String(e))
+  }
 
   const chunks: Blob[] = []
-  const recorder = new MediaRecorder(combined, { mimeType })
   recorder.ondataavailable = (e) => {
     if (e.data && e.data.size > 0) chunks.push(e.data)
   }


### PR DESCRIPTION
## 概要

`#279`。PixiJS Application を `resolution` 指定なしで init していたため、canvas 裏バッファが論理解像度（9:16=450×800 等）のまま（resolution=1）になり、(1) 表示がボケる (2) `VideoExporter`(#228) の `captureStream` が録る WebM も低解像度、の2問題があった。orber 宣伝動画 OP/ED の実描画で発覚（studio-yokonami #1）。

## 変更

- **表示**（`NovelRenderer.init`）: `resolution: window.devicePixelRatio || 1` + `autoDensity: true` を追加。CSS サイズは論理 px のまま裏バッファだけ DPI 倍にする。PixiJS v8 の `Text` はレンダラ解像度に追従するため全テキストが鮮明になる。通常ゲームに過負荷をかけない（device DPI 相当）。
- **解像度 API**（`NovelRenderer`）: `getRenderResolution()` / `setRenderResolution(res)`（`renderer.resize(w,h,res)`）。
- **書き出し**（`VideoExporter`）: 録画前にレンダラ解像度を bump（既定 `max(3, 現在)` → 9:16 で **1350×2400**、16:9 で 2400×1350 ＝ いずれも 1080×1920 以上）、`cleanup` で必ず元へ復元。`exportResolution` オプションで上書き可。並行録画ガードを副作用（bump/captureStream）の前へ前倒しし、`enableCapture` 失敗経路でも解像度・フラグを巻き戻す。
- **テスト**: `VideoExporter.test` に bump→restore の順序検証と明示 `exportResolution` 検証を追加。

## 実機検証（rule 7・orber 宣伝動画 OP/ED）

- 表示: canvas 裏バッファ **450×800 → 900×1600**（deviceScaleFactor=2）。OP/ED カードが目視で鮮明化（before はボケ）。
- 書き出し: 録画中の canvas 裏バッファ **1350×2400**（=450×800×3）。captureStream が録るので WebM がこの解像度＝ Shorts 品質。
- `npm run lint` / `type-check` / **1002 テスト**すべて green。

## 受け入れ条件

- [x] 9:16 タイトルカードの表示が鮮明（A）
- [x] 書き出しの canvas 裏バッファが 1080×1920 以上（B・1350×2400 を実測）
- [x] 録画後に解像度が復元（cleanup で restore・テストで担保）
- [x] テスト追加
