### PR TITLE
test: #286 S1-goBack を異なる話者ケースにして lastSpeaker 再シードの回帰検出力を持たせる（＋font_size空引用のNoneテスト）

### DIFF
--- a/frontend/src/game/NovelRenderer.novel.test.ts
+++ b/frontend/src/game/NovelRenderer.novel.test.ts
@@ -502,6 +502,55 @@ describe('NovelRenderer novel 復元経路の役割配置と誤 nudge 防止 (#2
     expect(layerOf(r).getSpritePosition('ひな')!.x).toBe(RESPONDER_X)
   })
 
+  // S1-goBack-crossspeaker: goBack の復元先と「異なる話者」へ前進したとき、復元時に lastSpeaker を
+  //   復元先話者へ据え直しているか（applyState の `this.lastSpeaker = restoredEvt.character`）を弁別する。
+  //
+  //   なぜ別ケースが要るか（PR #289 独立レビューの should）:
+  //     上の S1-goBack は「ひな→ひな（同一話者）」で復元・前進するため、復元時に lastSpeaker を
+  //     どう据えても（復元先=ひな／null／戻す前の値=ひな のいずれでも）前進時 speakerChanged=false で
+  //     nudge しない。よって `this.lastSpeaker = restoredEvt.character` を「null 固定」や「代入削除」に
+  //     壊しても緑のまま通り、再シードの回帰を検出できない。
+  //
+  //   本ケースの設計（復元先話者 ≠ 前進先話者 を作る）:
+  //     event0 せお / event1 ひな / event2 せお。event2（せお）まで進めると lastSpeaker=せお。
+  //     event1（ひな）へ goBack で復元 → 正しい再シードなら lastSpeaker=ひな に据え直る。
+  //     復元直後に event2（せお）へ前進すると「ひな→せお」の話者交代 → nudge が発火する（true positive）。
+  //       - 正しい実装: lastSpeaker=ひな → speakerChanged=true → せお に nudge（緑）。
+  //       - 「null 固定」に壊すと: lastSpeaker=null → speakerChanged=false → nudge せず（赤）。
+  //       - 「代入削除」に壊すと: lastSpeaker は復元前の せお のまま → speakerChanged=false → nudge せず（赤）。
+  //     どちらの破壊でも「交代なのに nudge しない」で赤化するため、再シードの回帰を検出できる。
+  it('S1: goBack 復元先と異なる話者へ前進すると交代 nudge が発火する（lastSpeaker 再シードの回帰検出）', () => {
+    const r = new NovelRenderer()
+    r.setDialogStyle('novel')
+    r.setProtagonist('せお')
+    // event0 せお（質問役=左）/ event1 ひな（住人=右）/ event2 せお（質問役=左・話者交代）
+    r.setScenes([
+      scene('s', [dialog('せお', 'q1。'), dialog('ひな', 'a。'), dialog('せお', 'q2。')]),
+    ])
+    const i = internals(r)
+    i.advance() // event1 ひな（せお→ひな の交代）
+    i.advance() // event2 せお（ひな→せお の交代）。この時点で lastSpeaker=せお
+    expect(r.getSnapshot().eventIndex).toBe(2)
+
+    // event1（ひな）へ goBack。applyState が走り、lastSpeaker が復元先話者 ひな に据え直る。
+    r.goBack()
+    expect(r.getSnapshot().eventIndex).toBe(1)
+    // 復元先キャラ ひな の x は役割 x（住人=右）へ再適用される。
+    expect(layerOf(r).getSpritePosition('ひな')!.x).toBe(RESPONDER_X)
+    // 復元自体では nudge しない。
+    expect(layerOf(r).getPoseNudgeState('ひな')).toBeNull()
+
+    // 復元先（ひな）と異なる話者（せお）へ前進 → 話者交代として nudge が発火する。
+    // この assertion が再シードの本丸を踏む: 復元時に lastSpeaker=ひな へ据え直していないと、
+    // lastSpeaker が null（null 固定）または せお（代入削除）になり speakerChanged=false で nudge せず赤くなる。
+    i.advance()
+    expect(r.getSnapshot().eventIndex).toBe(2)
+    expect(layerOf(r).getPoseNudgeState('せお')).not.toBeNull()
+    expect(layerOf(r).getPoseNudgeState('せお')!.active).toBe(true)
+    // 前進先 せお の x は役割 x（質問役=左）。
+    expect(layerOf(r).getSpritePosition('せお')!.x).toBe(QUESTIONER_X)
+  })
+
   // S1-quickLoad: quickLoad（loadFromSaveData → restoreToScene → applyState）で seed したキャラが
   //   役割 x（主人公=左）へ再適用される。復元自体では nudge しない。
   it('S1: quickLoad（applyState）で役割 x（主人公=左）が再適用され、復元では nudge しない', () => {

--- a/parser/tests/integration_test.rs
+++ b/parser/tests/integration_test.rs
@@ -3789,6 +3789,33 @@ font_size: large
 "#;
     let doc_bad = parser::parse(input_bad);
     assert_eq!(doc_bad.font_size, None);
+
+    // 空引用（`font_size: ""`）でも None（#286 follow-up nit / PR #289 独立レビュー）。
+    // unquote("\"\"") は空文字を返し、空文字の parse::<u32>() が失敗して None に倒れる。
+    // バレ empty（`font_size:`）とは別経路（quote 剥がし後に空になる）なので明示的に固定する。
+    let input_empty_quote = r#"---
+engine: name-name
+chapter: 1
+title: "テスト"
+font_size: ""
+---
+
+## 1-1: シーン
+
+ナレ。
+"#;
+    let doc_empty_quote = parser::parse(input_empty_quote);
+    assert_eq!(
+        doc_empty_quote.font_size, None,
+        "font_size: \"\" は unquote 後に空文字となり parse 失敗で None になること"
+    );
+
+    // None なら emit に font_size 行が出ないこと（既存規約の再確認 / 空引用入力の往復）。
+    let emitted_empty_quote = emitter::emit(&doc_empty_quote);
+    assert!(
+        !emitted_empty_quote.contains("font_size:"),
+        "font_size が None なら emit に出ない（空引用入力でも）: {emitted_empty_quote}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 背景（PR #289 独立レビューの should）

`NovelRenderer.novel.test.ts` の既存 S1-goBack テストは **同一話者（ひな→ひな）** で goBack・前進するため、`applyState` 内の復元時 `lastSpeaker` 据え直し（`this.lastSpeaker = restoredEvt?.type==='dialog' ? restoredEvt.character : null`）を壊しても緑のまま通ってしまう。S1 の本丸（復元先話者に lastSpeaker を据え直して、復元直後の前進で誤 nudge を防ぐ／正しく交代 nudge を出す）を**弁別できていなかった**。

## 変更

### 1. S1-goBack を「異なる話者」ケースで補強（test-only / 追加）
既存テストは置換せず維持。新規 `it('S1: goBack 復元先と異なる話者へ前進すると交代 nudge が発火する（lastSpeaker 再シードの回帰検出）')` を**追加**。

- protagonist=せお, novel。イベント列 `せお → ひな → せお`（話者が交代する列）。
- event2（せお）まで advance（`lastSpeaker=せお`）→ event1（ひな）へ `goBack` で復元。
- 復元時に `lastSpeaker=ひな` へ据え直っていれば、復元直後に event2（せお）へ前進すると「ひな→せお」の話者交代として **nudge が発火する**（true positive）。これを assertion で踏む。
- 併せて復元後の役割 x（ひな=回答役=右 / せお=質問役=左）が再適用されていることも確認。

### 2. nit: `font_size: ""`（空引用）→ None のテスト（parser）
`parser/tests/integration_test.rs` の `test_document_font_size_parses_from_frontmatter` に空引用ケースを追加。`unquote("\"\"")` が空文字 → `.parse::<u32>()` 失敗 → `None`。emit 側で None は `font_size:` 行を出さないことも併せて固定（既存規約の再確認）。既存の bare empty（`font_size:`）/ 非数値（`large`）とは別経路（quote 剥がし後に空になる）を明示する。

## ミューテーション確認（回帰検出力の証明）

`NovelRenderer.ts` の `applyState` 内 `this.lastSpeaker = restoredEvt?.type==='dialog' ? restoredEvt.character : null` を一時的に壊し、新テストが赤くなることを確認（確認後すべて元に戻し、本 PR には実装変更を含まない）:

- **Mutation A（`this.lastSpeaker = null` 固定）** → 新テスト RED
  `AssertionError: expected null not to be null` @ `NovelRenderer.novel.test.ts:548` `expect(layerOf(r).getPoseNudgeState('せお')).not.toBeNull()`
- **Mutation B（代入削除＝復元前の値 せお のまま残る）** → 新テスト RED（同一 assertion・同箇所）

正しい実装では `lastSpeaker=ひな` に据え直るため `speakerChanged=true` で せお に nudge が出て **GREEN**。既存 S1-goBack（同一話者）は両ミューテーションでも緑のままで、新ケースだけが破壊を射抜く。

## 検証（全緑）

- parser: `cargo test` 224 passed（71 + 5 + 148 + 0 doc）/ `cargo fmt --check` OK
- frontend: `npm run type-check` OK / `npm run lint` clean / `npm test` **1095 passed**（1094 を割らず +1）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVhAKGhmodyL3kFBzfcooW