### PR TITLE
fix: hide stale dialog indicator while typing

### DIFF
--- a/frontend/src/game/DialogBox.test.ts
+++ b/frontend/src/game/DialogBox.test.ts
@@ -66,6 +66,7 @@ const TEXT_X_WITH_PORTRAIT = PORTRAIT_X + PORTRAIT_SIZE + PORTRAIT_MARGIN
 interface DialogBoxInternals {
   portraitFrame: { visible: boolean } | null
   dialogText: { x: number; text: string; visible: boolean; style: { fill: unknown } }
+  indicator: { visible: boolean }
   portraitSprite: { visible: boolean; texture: unknown } | null
   currentPortraitToken: number
   rubyEntries: Array<{ placement: unknown; text: { x: number; style: { fill: unknown } } }>
@@ -232,6 +233,37 @@ describe('DialogBox typewriter (Issue #150 / #194)', () => {
     const i = asInternals(box)
     expect(i.dialogText.text).toBe('')
     expect(box.isTyping()).toBe(true)
+    box.dispose()
+  })
+
+  it('新しい setDialog でタイプ開始した瞬間に前のインジケータを隠す', () => {
+    const box = makeRpgBox()
+    const i = asInternals(box)
+
+    box.setDialog('長老', 'first')
+    box.skipTypewriter()
+    box.setIndicatorVisible(true)
+    expect(i.indicator.visible).toBe(true)
+
+    box.setDialog('村人', 'second')
+    expect(box.isTyping()).toBe(true)
+    expect(i.indicator.visible).toBe(false)
+    box.dispose()
+  })
+
+  it('novel progressive で文を足した瞬間に前の位置のインジケータを隠す', () => {
+    const box = makeRpgBox()
+    box.setNovelMode(true)
+    const i = asInternals(box)
+
+    box.setNovelDialogProgressive(null, 'first', 0)
+    box.skipTypewriter()
+    box.setIndicatorVisible(true)
+    expect(i.indicator.visible).toBe(true)
+
+    box.setNovelDialogProgressive(null, 'firstsecond', 'first'.length)
+    expect(box.isTyping()).toBe(true)
+    expect(i.indicator.visible).toBe(false)
     box.dispose()
   })
 })

--- a/frontend/src/game/DialogBox.ts
+++ b/frontend/src/game/DialogBox.ts
@@ -601,6 +601,7 @@ export class DialogBox extends Container {
     const lines = wordwrap(plainText, maxTextWidth, font)
     this.typewriter = startTypewriter(lines.join('\n'))
     this.dialogText.text = ''
+    this.indicator.visible = false
     this.rubyPlacements = computeRubyPlacements(runs, lines)
     this.rubyBuildToken += 1
     const rubyToken = this.rubyBuildToken
@@ -677,6 +678,7 @@ export class DialogBox extends Container {
     this.typewriter = startTypewriterFrom(fullText, fromCount)
     // 既出分（fromCount 文字）は即時表示する。残りは ticker がタイプする。
     this.dialogText.text = this.visibleDialogText(this.typewriter)
+    this.indicator.visible = false
     // novel 配置用に累積テキストの wrap 結果を保持する (#292)。
     this.novelWrappedLines = lines
     this.rubyPlacements = computeRubyPlacements(runs, lines)


### PR DESCRIPTION
## Summary\n\n- hide the dialog indicator synchronously when a new ADV/novel line starts typing\n- prevents the previous indicator position from being visible for one frame\n- add DialogBox regression tests for ADV and novel progressive display\n\nCloses #324\n\n## Verification\n\n- npm test -- DialogBox.test.ts --run\n- npm test -- NovelRenderer.novel.test.ts --run\n- npm run build