### PR TITLE
fix: lazy load player scripts

### DIFF
--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -43,6 +43,8 @@ interface NovelPlayerProps {
    * `scenes` が指定されている場合は従来どおり `scenes` 優先（後方互換）。
    */
   jumpSceneIndex?: EventScene[]
+  /** 未ロード sceneId を必要時に追加解決する hook (#314)。 */
+  onResolveMissingScene?: (sceneId: string) => Promise<EventScene[] | null>
   assetBaseUrl?: string
   /** 画面比率。"16:9" / "4:3" / "9:16"。デフォルト "16:9" (#136) */
   aspectRatio?: AspectRatio | string
@@ -93,6 +95,7 @@ function NovelPlayer({
   events,
   scenes,
   jumpSceneIndex,
+  onResolveMissingScene,
   assetBaseUrl,
   aspectRatio: aspectRatioProp,
   choiceStyle,
@@ -157,6 +160,7 @@ function NovelPlayer({
       if (assetBaseUrl) {
         renderer.setAssetBaseUrl(assetBaseUrl)
       }
+      renderer.setMissingSceneResolver?.(onResolveMissingScene ?? null)
       // renderer が手動操作で autoMode を OFF にしたとき React state を同期 (#139)
       renderer.setOnAutoModeChange((on) => setAutoMode(on))
       // renderer が未読到達で skipMode を OFF にしたとき React state を同期 (#140)
@@ -343,6 +347,10 @@ function NovelPlayer({
       rendererRef.current.setEvents(events)
     }
   }, [events, scenes, jumpSceneIndex])
+
+  useEffect(() => {
+    rendererRef.current?.setMissingSceneResolver?.(onResolveMissingScene ?? null)
+  }, [onResolveMissingScene])
 
   // 「つづきから」: 初回イベントセット後に一度だけスキップモードを ON にする (#141)
   // initialSkipMode が false の間は早期 return するため ref はセットされない。

--- a/frontend/src/game/NovelRenderer.linearAndJumpIndex.test.ts
+++ b/frontend/src/game/NovelRenderer.linearAndJumpIndex.test.ts
@@ -162,6 +162,25 @@ describe('NovelRenderer.setJumpSceneIndex クロスファイル解決 (#284 M2)'
     expect(r.getAllSceneIds()).toContain('other')
   })
 
+  it('#314: 未ロード scene は resolver で追加索引を受け取り jumpToScene で到達する', async () => {
+    const entryScenes: EventScene[] = [scene('entry-hub', [narration('hub-line')])]
+    const farScene = scene('far-scene', [narration('far-line')])
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const resolver = vi.fn(async () => [...entryScenes, farScene])
+    const r = new NovelRenderer()
+    r.setEvents(flatten(entryScenes))
+    r.setJumpSceneIndex(entryScenes)
+    r.setMissingSceneResolver(resolver)
+
+    r.jumpToScene('far-scene')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(resolver).toHaveBeenCalledWith('far-scene')
+    expect(r.getAllSceneIds()).toEqual(['entry-hub', 'far-scene'])
+    expect(r.getCurrentSceneId()).toBe('far-scene')
+    expect(r.getDebugState().eventText).toContain('far-line')
+  })
+
   it('単一 script は索引が自ファイルのシーンのみ = jumpToScene の解決対象も自シーンに限る', () => {
     const selfScenes: EventScene[] = [
       scene('a', [narration('a-line')]),

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -217,6 +217,8 @@ export class NovelRenderer {
   private onEndCallback: (() => void) | null = null
   /** 動画エクスポート用 (#228)。`jumpToScene` / `setScenes` でシーンが切り替わったときに呼ぶ */
   private onSceneChangeCallback: ((sceneId: string) => void) | null = null
+  private missingSceneResolver: ((sceneId: string) => Promise<EventScene[] | null>) | null = null
+  private pendingMissingScenes = new Set<string>()
   private assetBaseUrl: string = ''
   private textureCache: Map<string, Texture> = new Map()
   /** setBackground の非同期ロード用トークン。destroy / 再入 の race 回避に使う */
@@ -665,18 +667,52 @@ export class NovelRenderer {
     this.allScenes = scenes
   }
 
+  setMissingSceneResolver(
+    resolver: ((sceneId: string) => Promise<EventScene[] | null>) | null
+  ): void {
+    this.missingSceneResolver = resolver
+  }
+
   /**
    * 指定シーンにジャンプする
    */
   jumpToScene(sceneId: string): void {
     const scene = findSceneById(this.allScenes, sceneId)
     if (!scene) {
-      console.warn(`[name-name] シーンが見つからない: ${sceneId}`)
+      if (this.missingSceneResolver) {
+        void this.resolveMissingSceneAndJump(sceneId)
+      } else {
+        console.warn(`[name-name] シーンが見つからない: ${sceneId}`)
+      }
       return
     }
+    this.startScene(sceneId, scene)
+  }
+
+  private startScene(sceneId: string, scene: EventScene): void {
     this.currentSceneId = sceneId
     this.resetAndStartEvents([...scene.events])
     this.onSceneChangeCallback?.(sceneId)
+  }
+
+  private async resolveMissingSceneAndJump(sceneId: string): Promise<void> {
+    if (!this.missingSceneResolver || this.pendingMissingScenes.has(sceneId)) return
+    this.pendingMissingScenes.add(sceneId)
+    try {
+      const scenes = await this.missingSceneResolver(sceneId)
+      if (!scenes) return
+      this.setJumpSceneIndex(scenes)
+      const scene = findSceneById(this.allScenes, sceneId)
+      if (!scene) {
+        console.warn(`[name-name] lazy load 後もシーンが見つかりません: ${sceneId}`)
+        return
+      }
+      this.startScene(sceneId, scene)
+    } catch (err) {
+      console.warn(`[name-name] シーンの追加読み込みに失敗しました: ${sceneId}`, err)
+    } finally {
+      this.pendingMissingScenes.delete(sceneId)
+    }
   }
 
   /** 現在表示中のシーンID (#228 動画エクスポート用) */

--- a/frontend/src/screens/PlayerScreen.test.tsx
+++ b/frontend/src/screens/PlayerScreen.test.tsx
@@ -8,7 +8,7 @@
 //   - データ取得失敗時にエラーメッセージが表示される
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 // #284: NovelRenderer.jumpToScene が使う実シーン解決プリミティブ。
 // PlayerScreen が連結した scenes に対してクロスファイルのジャンプが解決することを、
 // 実装で実際に使われるこの純粋関数で確認する（Pixi/NovelRenderer は jsdom で init 不可）。
@@ -60,6 +60,7 @@ vi.mock('../components/NovelPlayer', () => ({
     events: unknown
     scenes?: unknown
     jumpSceneIndex?: unknown
+    onResolveMissingScene?: (sceneId: string) => Promise<EventScene[] | null>
     assetBaseUrl?: string
   }) => {
     novelPlayerProps(props)
@@ -108,6 +109,16 @@ function lastNovelPlayerProps(): Record<string, unknown> {
   const lastCall = calls[calls.length - 1]
   expect(lastCall).toBeDefined()
   return lastCall[0] as Record<string, unknown>
+}
+
+async function resolveMissingScene(sceneId: string): Promise<EventScene[] | null> {
+  const resolver = lastNovelPlayerProps().onResolveMissingScene
+  expect(typeof resolver).toBe('function')
+  let result: EventScene[] | null = null
+  await act(async () => {
+    result = await (resolver as (id: string) => Promise<EventScene[] | null>)(sceneId)
+  })
+  return result
 }
 
 beforeEach(() => {
@@ -200,7 +211,7 @@ describe('PlayerScreen', () => {
     expect(screen.queryByRole('button', { name: 'RPG' })).toBeNull()
   })
 
-  it('#284: 複数 MD のシーンを連結して jumpSceneIndex= で NovelPlayer に渡す（エントリ先頭）', async () => {
+  it('#314: 初期ロードでは entry MD だけを取得して NovelPlayer に渡す', async () => {
     listProjectsMock.mockResolvedValue([
       { name: 'theo-hayami', title: 'せおはやみ', repo: 'kako-jun/theo-hayami' },
     ])
@@ -250,27 +261,29 @@ describe('PlayerScreen', () => {
     })
 
     const player = screen.getByTestId('novel-player')
-    // エントリ(script.md) 2 シーン + サブ 2 本 × 2 シーン = 6（hidden は除外）
-    expect(player.getAttribute('data-scene-count')).toBe('6')
+    // 初期表示では entry(script.md) の 2 シーンだけ。サブ MD は選択後に lazy load する。
+    expect(player.getAttribute('data-scene-count')).toBe('2')
 
     // 連結順: エントリ script.md のシーンが先頭
     const ids = (player.getAttribute('data-scene-ids') ?? '').split(',')
     expect(ids[0]).toBe('hub-script.md')
     expect(ids[1]).toBe('scene2-script.md')
-    // サブ MD のシーンも含まれる
-    expect(ids).toContain('hub-content/scripts/free/a.md')
-    expect(ids).toContain('hub-content/scripts/main/b.md')
-    // hidden=true の secret.md は取得・連結されない
+    expect(ids).not.toContain('hub-content/scripts/free/a.md')
+    expect(ids).not.toContain('hub-content/scripts/main/b.md')
+    // hidden=true の secret.md とサブ MD は初期取得されない
     expect(getContentsMock).not.toHaveBeenCalledWith(
       'theo-hayami',
       'content/scripts/secret.md',
       'main'
     )
-    // エントリ以外の 2 本は main ブランチで取得される
-    expect(getContentsMock).toHaveBeenCalledWith('theo-hayami', 'content/scripts/free/a.md', 'main')
+    expect(getContentsMock).not.toHaveBeenCalledWith(
+      'theo-hayami',
+      'content/scripts/free/a.md',
+      'main'
+    )
   })
 
-  it('#284: クロスファイルのジャンプが解決する（別 MD のシーン ID が解決対象に含まれる）', async () => {
+  it('#314: 未ロード scene へのジャンプ時に別 MD を追加取得して解決する', async () => {
     listProjectsMock.mockResolvedValue([
       { name: 'theo-hayami', title: 'せおはやみ', repo: 'kako-jun/theo-hayami' },
     ])
@@ -316,19 +329,25 @@ describe('PlayerScreen', () => {
       expect(screen.getByTestId('novel-player')).toBeInTheDocument()
     })
 
-    // NovelPlayer に渡された jumpSceneIndex（= NovelRenderer.allScenes に乗るもの）を取り出す。
+    // 初期索引は entry のみ。
     const scenes = lastJumpSceneIndex()
-
-    // エントリのシーンが先頭（開始シーン）
     expect(scenes[0]?.id).toBe('entry-hub')
+    expect(findSceneById(scenes, 'far-scene')).toBeUndefined()
 
-    // 実際のジャンプ解決プリミティブ findSceneById で、別 MD のシーンが解決できる
-    // = クロスファイル・ジャンプ（→ far-scene）が成立する。
-    const jumped = findSceneById(scenes, 'far-scene')
+    const loadedScenes = await resolveMissingScene('far-scene')
+    expect(loadedScenes).not.toBeNull()
+    expect(getContentsMock).toHaveBeenCalledWith('theo-hayami', 'content/scripts/free/a.md', 'main')
+
+    const jumped = findSceneById(loadedScenes ?? [], 'far-scene')
     expect(jumped).toBeDefined()
     expect(jumped?.title).toBe('far')
     // 逆方向（別 MD → エントリ）も解決できる
-    expect(findSceneById(scenes, 'entry-hub')?.title).toBe('hub')
+    expect(findSceneById(loadedScenes ?? [], 'entry-hub')?.title).toBe('hub')
+
+    getContentsMock.mockClear()
+    const cachedScenes = await resolveMissingScene('far-scene')
+    expect(cachedScenes).not.toBeNull()
+    expect(getContentsMock).not.toHaveBeenCalled()
   })
 
   it('#284: listScripts が失敗したら単一 script.md 再生にフォールバックする', async () => {
@@ -426,11 +445,16 @@ describe('PlayerScreen', () => {
 
     const player = screen.getByTestId('novel-player')
     const ids = (player.getAttribute('data-scene-ids') ?? '').split(',')
-    // エントリ + good.md の 2 シーン（bad.md は脱落するが全体は落ちない）
-    expect(ids).toContain('scene-script.md')
-    expect(ids).toContain('scene-content/scripts/good.md')
-    expect(ids).not.toContain('scene-content/scripts/bad.md')
-    expect(player.getAttribute('data-scene-count')).toBe('2')
+    // 初期表示では entry のみ。bad/good はまだ取得しない。
+    expect(ids).toEqual(['scene-script.md'])
+    expect(player.getAttribute('data-scene-count')).toBe('1')
+
+    const loadedScenes = await resolveMissingScene('scene-content/scripts/good.md')
+    const loadedIds = (loadedScenes ?? []).map((s) => s.id)
+    // lazy fallback で bad.md の失敗を飛ばし、good.md を読み込む。
+    expect(loadedIds).toContain('scene-script.md')
+    expect(loadedIds).toContain('scene-content/scripts/good.md')
+    expect(loadedIds).not.toContain('scene-content/scripts/bad.md')
     // 全体としてエラー表示にはならない
     expect(screen.queryByRole('alert')).toBeNull()
   })
@@ -460,15 +484,13 @@ describe('PlayerScreen', () => {
             title: 'c',
             hidden: false,
             default_bgm: null,
-            // 両方が id 'dup' を持つ。先頭（エントリ）のタイトルが先勝ち。
-            scenes: [
-              {
-                id: 'dup',
-                title: isEntry ? 'entry-dup' : 'later-dup',
-                view: 'TopDown',
-                events: [],
-              },
-            ],
+            // 両方が id 'dup' を持つ。later は lazy load の target も併せ持つ。
+            scenes: isEntry
+              ? [{ id: 'dup', title: 'entry-dup', view: 'TopDown', events: [] }]
+              : [
+                  { id: 'dup', title: 'later-dup', view: 'TopDown', events: [] },
+                  { id: 'later-only', title: 'later-only', view: 'TopDown', events: [] },
+                ],
           },
         ],
       }
@@ -487,7 +509,12 @@ describe('PlayerScreen', () => {
       expect(screen.getByTestId('novel-player')).toBeInTheDocument()
     })
 
-    // 重複 ID を検出して warning を出す
+    // 初期表示は entry のみなので、まだ重複は検出されない。
+    expect(warnSpy).not.toHaveBeenCalled()
+
+    const loadedScenes = await resolveMissingScene('later-only')
+
+    // lazy load で later.md を足した時点で重複 ID を検出して warning を出す
     expect(warnSpy).toHaveBeenCalled()
     const warned = warnSpy.mock.calls.some(
       (call) => typeof call[0] === 'string' && call[0].includes('dup')
@@ -495,8 +522,7 @@ describe('PlayerScreen', () => {
     expect(warned).toBe(true)
 
     // 先勝ち: findSceneById は先頭（エントリ）のシーンを返す
-    const scenes = lastJumpSceneIndex()
-    expect(findSceneById(scenes, 'dup')?.title).toBe('entry-dup')
+    expect(findSceneById(loadedScenes ?? [], 'dup')?.title).toBe('entry-dup')
   })
 
   it('RPG シーンを含むドキュメントは RPGPlayer に渡す', async () => {
@@ -616,7 +642,13 @@ describe('PlayerScreen', () => {
     //   ハブ = content/scripts/script.md、各話 = content/scripts/free|main/*.md
     listScriptsMock.mockResolvedValue([
       { path: 'content/scripts/script.md', sha: 's0', size: 1, title: null, hidden: false },
-      { path: 'content/scripts/free/ep1.md', sha: 's1', size: 1, title: null, hidden: false },
+      {
+        path: 'content/scripts/free/netami__makiya.md',
+        sha: 's1',
+        size: 1,
+        title: null,
+        hidden: false,
+      },
       { path: 'content/scripts/main/ep2.md', sha: 's2', size: 1, title: null, hidden: false },
     ])
     getContentsMock.mockImplementation(async (_name: string, path: string) => ({
@@ -627,6 +659,7 @@ describe('PlayerScreen', () => {
     // エントリ（basename === script.md）は開始シーン entry-hub を持つ。
     parseMarkdownMock.mockImplementation(async (md: string) => {
       const isEntry = md === 'content/scripts/script.md'
+      const isMakiyaNetami = md === 'content/scripts/free/netami__makiya.md'
       return {
         engine: 'name-name',
         chapters: [
@@ -637,7 +670,14 @@ describe('PlayerScreen', () => {
             default_bgm: null,
             scenes: isEntry
               ? [{ id: 'entry-hub', title: 'hub', view: 'TopDown', events: [] }]
-              : [{ id: `scene-${md}`, title: md, view: 'TopDown', events: [] }],
+              : [
+                  {
+                    id: isMakiyaNetami ? 'makiya-netami' : `scene-${md}`,
+                    title: md,
+                    view: 'TopDown',
+                    events: [],
+                  },
+                ],
           },
         ],
       }
@@ -661,23 +701,29 @@ describe('PlayerScreen', () => {
 
     // 直下 script.md は取りに行かない（解決は listScripts の basename ベース）
     expect(getContentsMock).not.toHaveBeenCalledWith('theo-hayami', 'script.md', 'main')
-    // エントリ（content/scripts/script.md）と各話を main で取得する
+    // 初期ロードではエントリ（content/scripts/script.md）だけを main で取得する
     expect(getContentsMock).toHaveBeenCalledWith('theo-hayami', 'content/scripts/script.md', 'main')
-    expect(getContentsMock).toHaveBeenCalledWith(
+    expect(getContentsMock).not.toHaveBeenCalledWith(
       'theo-hayami',
-      'content/scripts/free/ep1.md',
+      'content/scripts/free/netami__makiya.md',
       'main'
     )
 
-    // ジャンプ索引: エントリ（content/scripts/script.md）のシーンが先頭 = 開始シーン
+    // ジャンプ索引: 初期はエントリ（content/scripts/script.md）のシーンだけ
     const scenes = lastJumpSceneIndex()
     expect(scenes[0]?.id).toBe('entry-hub')
-    // 各話のシーンもクロスファイル解決の対象に含まれる
-    expect(findSceneById(scenes, 'scene-content/scripts/free/ep1.md')).toBeDefined()
-    expect(findSceneById(scenes, 'scene-content/scripts/main/ep2.md')).toBeDefined()
+    expect(findSceneById(scenes, 'makiya-netami')).toBeUndefined()
     // エントリは flatten された events= でも線形再生される（最低 1 シーン分のストリーム）
     const player = screen.getByTestId('novel-player')
-    expect(player.getAttribute('data-scene-count')).toBe('3')
+    expect(player.getAttribute('data-scene-count')).toBe('1')
+
+    const loadedScenes = await resolveMissingScene('makiya-netami')
+    expect(getContentsMock).toHaveBeenCalledWith(
+      'theo-hayami',
+      'content/scripts/free/netami__makiya.md',
+      'main'
+    )
+    expect(findSceneById(loadedScenes ?? [], 'makiya-netami')).toBeDefined()
   })
 
   it('404 以外のデータ取得失敗はエラーメッセージを表示する', async () => {

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import NovelPlayer from '../components/NovelPlayer'
 import RPGPlayer from '../components/RPGPlayer'
 import TitleOverlay from '../components/TitleOverlay'
@@ -98,6 +98,35 @@ function warnDuplicateSceneIds(scenes: EventScene[]): void {
   }
 }
 
+function buildSceneIndex(
+  entryPath: string | null,
+  sortedPaths: string[],
+  docs: Map<string, EventDocument>
+) {
+  const scenes: EventScene[] = []
+  if (entryPath) {
+    const entryDoc = docs.get(entryPath)
+    if (entryDoc) scenes.push(...flattenDocumentScenes(entryDoc))
+  }
+  for (const path of sortedPaths) {
+    if (path === entryPath) continue
+    const doc = docs.get(path)
+    if (doc) scenes.push(...flattenDocumentScenes(doc))
+  }
+  return scenes
+}
+
+function inferScriptPathsForSceneId(sceneId: string, paths: string[]): string[] {
+  const basenames = new Set<string>([`${sceneId}.md`])
+  const parts = sceneId.split('-')
+  if (parts.length >= 2) {
+    const resident = parts[0]
+    const theme = parts.slice(1).join('-')
+    basenames.add(`${theme}__${resident}.md`)
+  }
+  return paths.filter((path) => basenames.has(basename(path)))
+}
+
 function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenProps) {
   const api = useMemo(() => createApiClient({ baseUrl: apiBaseUrl }), [apiBaseUrl])
   // doc: エントリ MD のドキュメント。通常再生ストリーム（線形 events）の供給元であり、
@@ -116,11 +145,77 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
   const [loadDebugInfo, setLoadDebugInfo] = useState<string[]>([])
   // script.md がまだリポに無い「未投入」状態。エラーではなく案内として扱う。
   const [unpopulated, setUnpopulated] = useState(false)
+  const sortedPlayablePathsRef = useRef<string[]>([])
+  const entryPathRef = useRef<string | null>(null)
+  const loadedDocsRef = useRef<Map<string, EventDocument>>(new Map())
+  const loadingDocsRef = useRef<Map<string, Promise<EventDocument | null>>>(new Map())
 
   // タイトル画面の表示状態 (#141)
   const [titleDismissed, setTitleDismissed] = useState(false)
   // 「つづきから」で開始した場合 true: ゲーム開始直後にスキップモードで未読位置まで進める
   const [startWithSkip, setStartWithSkip] = useState(false)
+
+  const loadScriptDoc = useCallback(
+    async (path: string): Promise<EventDocument | null> => {
+      const cached = loadedDocsRef.current.get(path)
+      if (cached) return cached
+      const inFlight = loadingDocsRef.current.get(path)
+      if (inFlight) return inFlight
+
+      const promise = api
+        .getContents(projectName, path, PUBLIC_BRANCH)
+        .then(async (c) => {
+          const parsed = await parseMarkdown(c.content || '')
+          loadedDocsRef.current.set(path, parsed)
+          return parsed
+        })
+        .catch((err) => {
+          console.warn(`PlayerScreen: failed to load script ${path}:`, err)
+          return null
+        })
+        .finally(() => {
+          loadingDocsRef.current.delete(path)
+        })
+      loadingDocsRef.current.set(path, promise)
+      return promise
+    },
+    [api, projectName]
+  )
+
+  const resolveMissingScene = useCallback(
+    async (sceneId: string): Promise<EventScene[] | null> => {
+      const entryPath = entryPathRef.current
+      const sortedPaths = sortedPlayablePathsRef.current
+      const currentScenes = buildSceneIndex(entryPath, sortedPaths, loadedDocsRef.current)
+      if (currentScenes.some((s) => s.id === sceneId)) return currentScenes
+
+      const candidatePaths = inferScriptPathsForSceneId(sceneId, sortedPaths).filter(
+        (path) => !loadedDocsRef.current.has(path)
+      )
+      const fallbackPaths = sortedPaths.filter(
+        (path) => path !== entryPath && !loadedDocsRef.current.has(path)
+      )
+      const pathsToTry = [
+        ...candidatePaths,
+        ...fallbackPaths.filter((p) => !candidatePaths.includes(p)),
+      ]
+
+      for (const path of pathsToTry) {
+        const loaded = await loadScriptDoc(path)
+        if (!loaded) continue
+        const scenes = buildSceneIndex(entryPath, sortedPaths, loadedDocsRef.current)
+        warnDuplicateSceneIds(scenes)
+        const found = scenes.some((s) => s.id === sceneId)
+        setLoadDebugInfo((prev) => [
+          ...prev.filter((line) => !line.startsWith('lazy loaded docs:')),
+          `lazy loaded docs: ${loadedDocsRef.current.size}/${sortedPaths.length}`,
+        ])
+        if (found) return scenes
+      }
+      return null
+    },
+    [loadScriptDoc]
+  )
 
   useEffect(() => {
     let cancelled = false
@@ -129,6 +224,10 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
       setError(null)
       setUnpopulated(false)
       setLoadDebugInfo([])
+      sortedPlayablePathsRef.current = []
+      entryPathRef.current = null
+      loadedDocsRef.current = new Map()
+      loadingDocsRef.current = new Map()
       try {
         // 1. プロジェクト情報を取得（タイトル表示・assets ベース URL 解決用）
         const projects = await api.listProjects()
@@ -183,6 +282,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
           const entryDoc = await parseMarkdown(data.content || '')
           if (cancelled) return
           const entryScenes = flattenDocumentScenes(entryDoc)
+          loadedDocsRef.current.set(SCRIPT_BASENAME, entryDoc)
           setDoc(entryDoc)
           setAllScenes(entryScenes)
           setLoadDebugInfo([
@@ -209,26 +309,14 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
         // エントリ MD を解決: basename === 'script.md' を優先、無ければ sort 済み先頭。
         const sortedPaths = [...playablePaths].sort()
         const entryPath = sortedPaths.find((p) => basename(p) === SCRIPT_BASENAME) ?? sortedPaths[0]
+        sortedPlayablePathsRef.current = sortedPaths
+        entryPathRef.current = entryPath
 
-        // 3. 全 .md を並列取得 → parse。エントリ doc を分離して保持する。
-        const docByPath = new Map<string, EventDocument>()
-        const failedPaths: string[] = []
-        await Promise.all(
-          sortedPaths.map(async (path) => {
-            try {
-              const c = await api.getContents(projectName, path, PUBLIC_BRANCH)
-              const parsed = await parseMarkdown(c.content || '')
-              docByPath.set(path, parsed)
-            } catch (err) {
-              // 個別 .md の取得・parse 失敗は全体を落とさずスキップ。
-              console.warn(`PlayerScreen: failed to load script ${path}:`, err)
-              failedPaths.push(path)
-            }
-          })
-        )
+        // 3. 初期表示は entry MD だけを取得・parse する (#314 Phase 1)。
+        //    サブ MD は選択先 sceneId が未ロードだった時点で resolver が差分取得する。
+        const entryDoc = await loadScriptDoc(entryPath)
         if (cancelled) return
 
-        const entryDoc = docByPath.get(entryPath) ?? null
         if (!entryDoc) {
           // エントリ MD だけは必須。取得・parse できなければ再生不能。
           throw new Error(`PlayerScreen: entry script not loadable: ${entryPath}`)
@@ -238,17 +326,9 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
         //    供給元はエントリ doc (#284 S1)。
         setDoc(entryDoc)
 
-        // ジャンプ解決索引 = 全 .md の全シーン。連結順は **エントリ先頭** →
-        //    残りのサブ MD（sort 済み path 順）。先頭シーン＝開始シーンの整合を取る。
-        const scenes: EventScene[] = [
-          ...flattenDocumentScenes(entryDoc),
-          ...sortedPaths
-            .filter((p) => p !== entryPath)
-            .flatMap((p) => {
-              const d = docByPath.get(p)
-              return d ? flattenDocumentScenes(d) : []
-            }),
-        ]
+        // 初期ジャンプ解決索引は entry のシーンだけ。未ロード target は NovelRenderer の
+        // missingSceneResolver が必要時に追加する (#314)。
+        const scenes = buildSceneIndex(entryPath, sortedPaths, loadedDocsRef.current)
         warnDuplicateSceneIds(scenes)
         if (cancelled) return
         setAllScenes(scenes)
@@ -256,9 +336,8 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
           `entry: ${entryPath}`,
           `scripts listed: ${scripts.length}`,
           `playable paths: ${playablePaths.length}`,
-          `loaded docs: ${docByPath.size}`,
-          `failed docs: ${failedPaths.length}`,
-          ...(failedPaths.length > 0 ? [`failed: ${failedPaths.slice(0, 5).join(', ')}`] : []),
+          `initial loaded docs: ${loadedDocsRef.current.size}`,
+          `lazy loading: enabled`,
           `scenes: ${scenes.length}`,
           `events: ${flattenDocumentEvents(entryDoc).length}`,
         ])
@@ -278,7 +357,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
     return () => {
       cancelled = true
     }
-  }, [api, projectName])
+  }, [api, loadScriptDoc, projectName])
 
   // 通常再生ストリーム = エントリ doc を線形に flatten した Event[] (#284 M2)。
   // これを NovelPlayer に events= で渡すことで多シーンの線形自動進行が成立する。
@@ -372,6 +451,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
               // ※ scenes= は使わない（setScenes は再生を scenes[0] だけに差し替えてしまう）。
               events={novelEvents}
               jumpSceneIndex={allScenes}
+              onResolveMissingScene={resolveMissingScene}
               assetBaseUrl={assetBaseUrl}
               aspectRatio={doc?.aspect_ratio}
               choiceStyle={doc?.choice_style ?? null}


### PR DESCRIPTION
## Summary\n\n- change /play initial loading to fetch/parse only the entry MD instead of all playable MD files\n- add a missing-scene resolver so choosing an unloaded scene fetches/parses the needed MD on demand\n- keep session memory cache for loaded MDs and in-flight requests\n- infer theo-hayami style paths such as makiya-netami -> netami__makiya.md, then fall back to scanning unloaded MDs\n- keep IndexedDB/sha persistent caching as a later phase documented on #314\n\nRefs #314\n\n## Verification\n\n- npm test -- PlayerScreen.test.tsx NovelRenderer.linearAndJumpIndex.test.ts --run\n- npm test -- NovelPlayer.test.tsx --run\n- npm test -- --run\n- npm run build