### PR TITLE
fix: cache lazy scripts in IndexedDB

### DIFF
--- a/frontend/src/game/scriptContentCache.ts
+++ b/frontend/src/game/scriptContentCache.ts
@@ -1,0 +1,127 @@
+const DB_NAME = 'name-name-script-content-cache'
+const DB_VERSION = 1
+const STORE_NAME = 'scriptContents'
+const PATH_INDEX = 'byPathKey'
+
+export interface ScriptContentCacheKey {
+  projectName: string
+  ref: string
+  path: string
+  sha: string
+}
+
+interface ScriptContentCacheRecord extends ScriptContentCacheKey {
+  key: string
+  pathKey: string
+  content: string
+  updatedAt: number
+}
+
+function encodeKeyPart(part: string): string {
+  return encodeURIComponent(part)
+}
+
+function buildKey({ projectName, ref, path, sha }: ScriptContentCacheKey): string {
+  return [projectName, ref, path, sha].map(encodeKeyPart).join('|')
+}
+
+function buildPathKey({ projectName, ref, path }: Omit<ScriptContentCacheKey, 'sha'>): string {
+  return [projectName, ref, path].map(encodeKeyPart).join('|')
+}
+
+function getIndexedDB(): IDBFactory | null {
+  try {
+    return typeof indexedDB === 'undefined' ? null : indexedDB
+  } catch {
+    return null
+  }
+}
+
+function openDatabase(): Promise<IDBDatabase | null> {
+  const dbFactory = getIndexedDB()
+  if (!dbFactory) return Promise.resolve(null)
+
+  return new Promise((resolve) => {
+    const request = dbFactory.open(DB_NAME, DB_VERSION)
+    request.onupgradeneeded = () => {
+      const db = request.result
+      const store = db.objectStoreNames.contains(STORE_NAME)
+        ? request.transaction?.objectStore(STORE_NAME)
+        : db.createObjectStore(STORE_NAME, { keyPath: 'key' })
+      if (store && !store.indexNames.contains(PATH_INDEX)) {
+        store.createIndex(PATH_INDEX, 'pathKey', { unique: false })
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => resolve(null)
+    request.onblocked = () => resolve(null)
+  })
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T | null> {
+  return new Promise((resolve) => {
+    request.onsuccess = () => resolve(request.result ?? null)
+    request.onerror = () => resolve(null)
+  })
+}
+
+export async function getCachedScriptContent(
+  keyParts: ScriptContentCacheKey
+): Promise<string | null> {
+  const db = await openDatabase()
+  if (!db) return null
+
+  try {
+    const tx = db.transaction(STORE_NAME, 'readonly')
+    const store = tx.objectStore(STORE_NAME)
+    const record = await requestResult<ScriptContentCacheRecord | undefined>(
+      store.get(buildKey(keyParts))
+    )
+    return typeof record?.content === 'string' ? record.content : null
+  } catch {
+    return null
+  } finally {
+    db.close()
+  }
+}
+
+export async function putCachedScriptContent(
+  keyParts: ScriptContentCacheKey,
+  content: string
+): Promise<void> {
+  const db = await openDatabase()
+  if (!db) return
+
+  const pathKey = buildPathKey(keyParts)
+  const record: ScriptContentCacheRecord = {
+    ...keyParts,
+    key: buildKey(keyParts),
+    pathKey,
+    content,
+    updatedAt: Date.now(),
+  }
+
+  try {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    store.put(record)
+
+    // 同じ path の古い sha はベストエフォートで掃除する。
+    const index = store.index(PATH_INDEX)
+    const oldRecords = await requestResult<ScriptContentCacheRecord[]>(
+      index.getAll(IDBKeyRange.only(pathKey))
+    )
+    for (const oldRecord of oldRecords ?? []) {
+      if (oldRecord.key !== record.key) store.delete(oldRecord.key)
+    }
+  } catch {
+    // キャッシュは最適化なので、保存失敗で再生を止めない。
+  } finally {
+    db.close()
+  }
+}
+
+export const __internal = {
+  buildKey,
+  buildPathKey,
+}

--- a/frontend/src/screens/PlayerScreen.test.tsx
+++ b/frontend/src/screens/PlayerScreen.test.tsx
@@ -48,6 +48,15 @@ vi.mock('../wasm/parser', () => ({
   emitMarkdown: vi.fn(),
 }))
 
+const { getCachedScriptContentMock, putCachedScriptContentMock } = vi.hoisted(() => ({
+  getCachedScriptContentMock: vi.fn(),
+  putCachedScriptContentMock: vi.fn(),
+}))
+vi.mock('../game/scriptContentCache', () => ({
+  getCachedScriptContent: getCachedScriptContentMock,
+  putCachedScriptContent: putCachedScriptContentMock,
+}))
+
 // NovelPlayer / RPGPlayer は PixiJS に依存し、jsdom では init できないため
 // props だけ確認できる軽い擬似コンポーネントに差し替える。
 //
@@ -129,6 +138,10 @@ beforeEach(() => {
     { path: 'script.md', sha: 's', size: 1, title: null, hidden: false },
   ])
   getContentsMock.mockReset()
+  getCachedScriptContentMock.mockReset()
+  getCachedScriptContentMock.mockResolvedValue(null)
+  putCachedScriptContentMock.mockReset()
+  putCachedScriptContentMock.mockResolvedValue(undefined)
   parseMarkdownMock.mockReset()
   novelPlayerProps.mockReset()
   rpgPlayerProps.mockReset()
@@ -281,6 +294,173 @@ describe('PlayerScreen', () => {
       'content/scripts/free/a.md',
       'main'
     )
+  })
+
+  it('#314 Phase 2: entry MD が IndexedDB cache hit なら contents API を呼ばない', async () => {
+    listProjectsMock.mockResolvedValue([
+      { name: 'theo-hayami', title: 'せおはやみ', repo: 'kako-jun/theo-hayami' },
+    ])
+    listScriptsMock.mockResolvedValue([
+      { path: 'content/scripts/script.md', sha: 'entry-sha', size: 1, title: null, hidden: false },
+      { path: 'content/scripts/free/a.md', sha: 'a-sha', size: 1, title: null, hidden: false },
+    ])
+    getCachedScriptContentMock.mockImplementation(async ({ path }: { path: string }) =>
+      path === 'content/scripts/script.md' ? 'cached-entry-markdown' : null
+    )
+    getContentsMock.mockResolvedValue({
+      path: 'content/scripts/script.md',
+      sha: 'entry-sha',
+      content: 'network-entry-markdown',
+    })
+    parseMarkdownMock.mockImplementation(async (md: string) => ({
+      engine: 'name-name',
+      chapters: [
+        {
+          number: 1,
+          title: 'c',
+          hidden: false,
+          default_bgm: null,
+          scenes: [{ id: `scene-${md}`, title: md, view: 'TopDown', events: [] }],
+        },
+      ],
+    }))
+
+    render(
+      <PlayerScreen
+        projectName="theo-hayami"
+        apiBaseUrl="http://api.test"
+        isDark={false}
+        onBack={() => {}}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('novel-player')).toBeInTheDocument()
+    })
+
+    expect(getCachedScriptContentMock).toHaveBeenCalledWith({
+      projectName: 'theo-hayami',
+      ref: 'main',
+      path: 'content/scripts/script.md',
+      sha: 'entry-sha',
+    })
+    expect(getContentsMock).not.toHaveBeenCalled()
+    expect(putCachedScriptContentMock).not.toHaveBeenCalled()
+    expect(parseMarkdownMock).toHaveBeenCalledWith('cached-entry-markdown')
+    expect(screen.getByTestId('novel-player').getAttribute('data-scene-ids')).toBe(
+      'scene-cached-entry-markdown'
+    )
+  })
+
+  it('#314 Phase 2: cache miss なら contents API から取得して sha 付きで保存する', async () => {
+    listProjectsMock.mockResolvedValue([
+      { name: 'theo-hayami', title: 'せおはやみ', repo: 'kako-jun/theo-hayami' },
+    ])
+    listScriptsMock.mockResolvedValue([
+      { path: 'script.md', sha: 'listed-sha', size: 1, title: null, hidden: false },
+    ])
+    getCachedScriptContentMock.mockResolvedValue(null)
+    getContentsMock.mockResolvedValue({
+      path: 'script.md',
+      sha: 'contents-sha',
+      content: 'network-markdown',
+    })
+    parseMarkdownMock.mockResolvedValue({
+      engine: 'name-name',
+      chapters: [
+        {
+          number: 1,
+          title: 'c',
+          hidden: false,
+          default_bgm: null,
+          scenes: [{ id: 'scene-network', title: 'network', view: 'TopDown', events: [] }],
+        },
+      ],
+    })
+
+    render(
+      <PlayerScreen
+        projectName="theo-hayami"
+        apiBaseUrl="http://api.test"
+        isDark={false}
+        onBack={() => {}}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('novel-player')).toBeInTheDocument()
+    })
+
+    expect(getContentsMock).toHaveBeenCalledWith('theo-hayami', 'script.md', 'main')
+    expect(putCachedScriptContentMock).toHaveBeenCalledWith(
+      {
+        projectName: 'theo-hayami',
+        ref: 'main',
+        path: 'script.md',
+        sha: 'listed-sha',
+      },
+      'network-markdown'
+    )
+  })
+
+  it('#314 Phase 2: cache hit した lazy MD も contents API を呼ばずに解決する', async () => {
+    listProjectsMock.mockResolvedValue([
+      { name: 'theo-hayami', title: 'せおはやみ', repo: 'kako-jun/theo-hayami' },
+    ])
+    listScriptsMock.mockResolvedValue([
+      { path: 'script.md', sha: 'entry-sha', size: 1, title: null, hidden: false },
+      { path: 'content/scripts/free/a.md', sha: 'a-sha', size: 1, title: null, hidden: false },
+    ])
+    getCachedScriptContentMock.mockImplementation(async ({ path }: { path: string }) => {
+      if (path === 'script.md') return 'entry'
+      if (path === 'content/scripts/free/a.md') return 'cached-a'
+      return null
+    })
+    getContentsMock.mockResolvedValue({
+      path: 'unused.md',
+      sha: 'unused',
+      content: 'unused',
+    })
+    parseMarkdownMock.mockImplementation(async (md: string) => ({
+      engine: 'name-name',
+      chapters: [
+        {
+          number: 1,
+          title: 'c',
+          hidden: false,
+          default_bgm: null,
+          scenes:
+            md === 'entry'
+              ? [{ id: 'entry-hub', title: 'hub', view: 'TopDown', events: [] }]
+              : [{ id: 'far-scene', title: 'far', view: 'TopDown', events: [] }],
+        },
+      ],
+    }))
+
+    render(
+      <PlayerScreen
+        projectName="theo-hayami"
+        apiBaseUrl="http://api.test"
+        isDark={false}
+        onBack={() => {}}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('novel-player')).toBeInTheDocument()
+    })
+    expect(getContentsMock).not.toHaveBeenCalled()
+
+    const loadedScenes = await resolveMissingScene('far-scene')
+
+    expect(loadedScenes?.some((s) => s.id === 'far-scene')).toBe(true)
+    expect(getCachedScriptContentMock).toHaveBeenCalledWith({
+      projectName: 'theo-hayami',
+      ref: 'main',
+      path: 'content/scripts/free/a.md',
+      sha: 'a-sha',
+    })
+    expect(getContentsMock).not.toHaveBeenCalled()
   })
 
   it('#314: 未ロード scene へのジャンプ時に別 MD を追加取得して解決する', async () => {

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -6,8 +6,9 @@ import type { Event, EventDocument, EventScene } from '../types'
 import type { RPGProject } from '../types/rpg'
 import { parseMarkdown } from '../wasm/parser'
 import { findRpgSceneIndex, rpgProjectFromDoc } from '../game/rpgProjectFromDoc'
-import { ApiError, createApiClient, type ProjectInfo } from '../api/client'
+import { ApiError, createApiClient, type ProjectInfo, type ScriptInfo } from '../api/client'
 import { loadReadProgress, clearReadProgress } from '../game/readProgress'
+import { getCachedScriptContent, putCachedScriptContent } from '../game/scriptContentCache'
 
 // kako-jun/name-name#108: 一般ユーザー向けの再生専用画面。
 //   - 編集 UI / 保存 / アセット管理 / デバッグは一切表示しない
@@ -146,6 +147,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
   // script.md がまだリポに無い「未投入」状態。エラーではなく案内として扱う。
   const [unpopulated, setUnpopulated] = useState(false)
   const sortedPlayablePathsRef = useRef<string[]>([])
+  const scriptInfoByPathRef = useRef<Map<string, ScriptInfo>>(new Map())
   const entryPathRef = useRef<string | null>(null)
   const loadedDocsRef = useRef<Map<string, EventDocument>>(new Map())
   const loadingDocsRef = useRef<Map<string, Promise<EventDocument | null>>>(new Map())
@@ -162,13 +164,65 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
       const inFlight = loadingDocsRef.current.get(path)
       if (inFlight) return inFlight
 
-      const promise = api
-        .getContents(projectName, path, PUBLIC_BRANCH)
-        .then(async (c) => {
-          const parsed = await parseMarkdown(c.content || '')
+      const promise = (async () => {
+        const scriptInfo = scriptInfoByPathRef.current.get(path)
+        let markdown: string | null = null
+        let loadedFromPersistentCache = false
+
+        if (scriptInfo?.sha) {
+          markdown = await getCachedScriptContent({
+            projectName,
+            ref: PUBLIC_BRANCH,
+            path,
+            sha: scriptInfo.sha,
+          })
+          loadedFromPersistentCache = markdown !== null
+        }
+
+        if (markdown === null) {
+          const contents = await api.getContents(projectName, path, PUBLIC_BRANCH)
+          markdown = contents.content || ''
+          const sha = scriptInfo?.sha ?? contents.sha
+          if (sha) {
+            void putCachedScriptContent(
+              {
+                projectName,
+                ref: PUBLIC_BRANCH,
+                path,
+                sha,
+              },
+              markdown
+            )
+          }
+        }
+
+        try {
+          const parsed = await parseMarkdown(markdown)
           loadedDocsRef.current.set(path, parsed)
           return parsed
-        })
+        } catch (err) {
+          if (!loadedFromPersistentCache) throw err
+
+          console.warn(`PlayerScreen: cached script ${path} failed to parse; refetching`, err)
+          const contents = await api.getContents(projectName, path, PUBLIC_BRANCH)
+          const freshMarkdown = contents.content || ''
+          const sha = scriptInfo?.sha ?? contents.sha
+          if (sha) {
+            void putCachedScriptContent(
+              {
+                projectName,
+                ref: PUBLIC_BRANCH,
+                path,
+                sha,
+              },
+              freshMarkdown
+            )
+          }
+          const parsed = await parseMarkdown(freshMarkdown)
+          loadedDocsRef.current.set(path, parsed)
+          return parsed
+        }
+      })()
         .catch((err) => {
           console.warn(`PlayerScreen: failed to load script ${path}:`, err)
           return null
@@ -225,6 +279,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
       setUnpopulated(false)
       setLoadDebugInfo([])
       sortedPlayablePathsRef.current = []
+      scriptInfoByPathRef.current = new Map()
       entryPathRef.current = null
       loadedDocsRef.current = new Map()
       loadingDocsRef.current = new Map()
@@ -259,7 +314,8 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
         if (cancelled) return
 
         // 再生対象の .md パス一覧（hidden は除外）。
-        const playablePaths = (scripts ?? []).filter((s) => !s.hidden).map((s) => s.path)
+        const playableScripts = (scripts ?? []).filter((s) => !s.hidden)
+        const playablePaths = playableScripts.map((s) => s.path)
 
         if (scripts === null) {
           // --- listScripts 不能フォールバック: 単一 script.md だけで再生 ---
@@ -310,6 +366,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
         const sortedPaths = [...playablePaths].sort()
         const entryPath = sortedPaths.find((p) => basename(p) === SCRIPT_BASENAME) ?? sortedPaths[0]
         sortedPlayablePathsRef.current = sortedPaths
+        scriptInfoByPathRef.current = new Map(playableScripts.map((s) => [s.path, s]))
         entryPathRef.current = entryPath
 
         // 3. 初期表示は entry MD だけを取得・parse する (#314 Phase 1)。
@@ -337,6 +394,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
           `scripts listed: ${scripts.length}`,
           `playable paths: ${playablePaths.length}`,
           `initial loaded docs: ${loadedDocsRef.current.size}`,
+          `persistent cache: enabled`,
           `lazy loading: enabled`,
           `scenes: ${scenes.length}`,
           `events: ${flattenDocumentEvents(entryDoc).length}`,


### PR DESCRIPTION
## Summary
- add a best-effort IndexedDB cache for script Markdown bodies keyed by `projectName + ref + path + sha`
- wire PlayerScreen lazy script loading through the persistent cache before calling contents API
- keep session memory/in-flight caches from Phase 1 and fall back to network if IndexedDB is unavailable or cached Markdown fails to parse

Refs #314

## Verification
- npm test -- PlayerScreen.test.tsx --run
- npm test -- NovelPlayer.test.tsx NovelRenderer.linearAndJumpIndex.test.ts --run
- npm test -- --run
- npm run build
