### PR TITLE
fix: cache parsed script documents

### DIFF
--- a/frontend/src/game/scriptContentCache.ts
+++ b/frontend/src/game/scriptContentCache.ts
@@ -1,7 +1,11 @@
 const DB_NAME = 'name-name-script-content-cache'
-const DB_VERSION = 1
-const STORE_NAME = 'scriptContents'
+import type { EventDocument } from '../types'
+
+const DB_VERSION = 2
+const CONTENT_STORE_NAME = 'scriptContents'
+const DOCUMENT_STORE_NAME = 'scriptDocuments'
 const PATH_INDEX = 'byPathKey'
+export const PARSED_SCRIPT_DOCUMENT_SCHEMA_VERSION = 1
 
 export interface ScriptContentCacheKey {
   projectName: string
@@ -17,12 +21,24 @@ interface ScriptContentCacheRecord extends ScriptContentCacheKey {
   updatedAt: number
 }
 
+interface ParsedScriptDocumentCacheRecord extends ScriptContentCacheKey {
+  key: string
+  pathKey: string
+  schemaVersion: number
+  document: EventDocument
+  updatedAt: number
+}
+
 function encodeKeyPart(part: string): string {
   return encodeURIComponent(part)
 }
 
 function buildKey({ projectName, ref, path, sha }: ScriptContentCacheKey): string {
   return [projectName, ref, path, sha].map(encodeKeyPart).join('|')
+}
+
+function buildDocumentKey(keyParts: ScriptContentCacheKey, schemaVersion: number): string {
+  return `${buildKey(keyParts)}|schema:${schemaVersion}`
 }
 
 function buildPathKey({ projectName, ref, path }: Omit<ScriptContentCacheKey, 'sha'>): string {
@@ -45,17 +61,27 @@ function openDatabase(): Promise<IDBDatabase | null> {
     const request = dbFactory.open(DB_NAME, DB_VERSION)
     request.onupgradeneeded = () => {
       const db = request.result
-      const store = db.objectStoreNames.contains(STORE_NAME)
-        ? request.transaction?.objectStore(STORE_NAME)
-        : db.createObjectStore(STORE_NAME, { keyPath: 'key' })
-      if (store && !store.indexNames.contains(PATH_INDEX)) {
-        store.createIndex(PATH_INDEX, 'pathKey', { unique: false })
-      }
+      ensureStore(db, request.transaction, CONTENT_STORE_NAME)
+      ensureStore(db, request.transaction, DOCUMENT_STORE_NAME)
     }
     request.onsuccess = () => resolve(request.result)
     request.onerror = () => resolve(null)
     request.onblocked = () => resolve(null)
   })
+}
+
+function ensureStore(
+  db: IDBDatabase,
+  transaction: IDBTransaction | null,
+  storeName: string
+): IDBObjectStore | null {
+  const store = db.objectStoreNames.contains(storeName)
+    ? transaction?.objectStore(storeName)
+    : db.createObjectStore(storeName, { keyPath: 'key' })
+  if (store && !store.indexNames.contains(PATH_INDEX)) {
+    store.createIndex(PATH_INDEX, 'pathKey', { unique: false })
+  }
+  return store ?? null
 }
 
 function requestResult<T>(request: IDBRequest<T>): Promise<T | null> {
@@ -72,8 +98,8 @@ export async function getCachedScriptContent(
   if (!db) return null
 
   try {
-    const tx = db.transaction(STORE_NAME, 'readonly')
-    const store = tx.objectStore(STORE_NAME)
+    const tx = db.transaction(CONTENT_STORE_NAME, 'readonly')
+    const store = tx.objectStore(CONTENT_STORE_NAME)
     const record = await requestResult<ScriptContentCacheRecord | undefined>(
       store.get(buildKey(keyParts))
     )
@@ -102,8 +128,8 @@ export async function putCachedScriptContent(
   }
 
   try {
-    const tx = db.transaction(STORE_NAME, 'readwrite')
-    const store = tx.objectStore(STORE_NAME)
+    const tx = db.transaction(CONTENT_STORE_NAME, 'readwrite')
+    const store = tx.objectStore(CONTENT_STORE_NAME)
     store.put(record)
 
     // 同じ path の古い sha はベストエフォートで掃除する。
@@ -121,7 +147,66 @@ export async function putCachedScriptContent(
   }
 }
 
+export async function getCachedParsedScriptDocument(
+  keyParts: ScriptContentCacheKey,
+  schemaVersion = PARSED_SCRIPT_DOCUMENT_SCHEMA_VERSION
+): Promise<EventDocument | null> {
+  const db = await openDatabase()
+  if (!db) return null
+
+  try {
+    const tx = db.transaction(DOCUMENT_STORE_NAME, 'readonly')
+    const store = tx.objectStore(DOCUMENT_STORE_NAME)
+    const record = await requestResult<ParsedScriptDocumentCacheRecord | undefined>(
+      store.get(buildDocumentKey(keyParts, schemaVersion))
+    )
+    return record?.schemaVersion === schemaVersion && record.document ? record.document : null
+  } catch {
+    return null
+  } finally {
+    db.close()
+  }
+}
+
+export async function putCachedParsedScriptDocument(
+  keyParts: ScriptContentCacheKey,
+  document: EventDocument,
+  schemaVersion = PARSED_SCRIPT_DOCUMENT_SCHEMA_VERSION
+): Promise<void> {
+  const db = await openDatabase()
+  if (!db) return
+
+  const pathKey = buildPathKey(keyParts)
+  const record: ParsedScriptDocumentCacheRecord = {
+    ...keyParts,
+    key: buildDocumentKey(keyParts, schemaVersion),
+    pathKey,
+    schemaVersion,
+    document,
+    updatedAt: Date.now(),
+  }
+
+  try {
+    const tx = db.transaction(DOCUMENT_STORE_NAME, 'readwrite')
+    const store = tx.objectStore(DOCUMENT_STORE_NAME)
+    store.put(record)
+
+    const index = store.index(PATH_INDEX)
+    const oldRecords = await requestResult<ParsedScriptDocumentCacheRecord[]>(
+      index.getAll(IDBKeyRange.only(pathKey))
+    )
+    for (const oldRecord of oldRecords ?? []) {
+      if (oldRecord.key !== record.key) store.delete(oldRecord.key)
+    }
+  } catch {
+    // キャッシュは最適化なので、保存失敗で再生を止めない。
+  } finally {
+    db.close()
+  }
+}
+
 export const __internal = {
   buildKey,
+  buildDocumentKey,
   buildPathKey,
 }

--- a/frontend/src/screens/PlayerScreen.test.tsx
+++ b/frontend/src/screens/PlayerScreen.test.tsx
@@ -48,12 +48,21 @@ vi.mock('../wasm/parser', () => ({
   emitMarkdown: vi.fn(),
 }))
 
-const { getCachedScriptContentMock, putCachedScriptContentMock } = vi.hoisted(() => ({
+const {
+  getCachedParsedScriptDocumentMock,
+  getCachedScriptContentMock,
+  putCachedParsedScriptDocumentMock,
+  putCachedScriptContentMock,
+} = vi.hoisted(() => ({
+  getCachedParsedScriptDocumentMock: vi.fn(),
   getCachedScriptContentMock: vi.fn(),
+  putCachedParsedScriptDocumentMock: vi.fn(),
   putCachedScriptContentMock: vi.fn(),
 }))
 vi.mock('../game/scriptContentCache', () => ({
+  getCachedParsedScriptDocument: getCachedParsedScriptDocumentMock,
   getCachedScriptContent: getCachedScriptContentMock,
+  putCachedParsedScriptDocument: putCachedParsedScriptDocumentMock,
   putCachedScriptContent: putCachedScriptContentMock,
 }))
 
@@ -138,8 +147,12 @@ beforeEach(() => {
     { path: 'script.md', sha: 's', size: 1, title: null, hidden: false },
   ])
   getContentsMock.mockReset()
+  getCachedParsedScriptDocumentMock.mockReset()
+  getCachedParsedScriptDocumentMock.mockResolvedValue(null)
   getCachedScriptContentMock.mockReset()
   getCachedScriptContentMock.mockResolvedValue(null)
+  putCachedParsedScriptDocumentMock.mockReset()
+  putCachedParsedScriptDocumentMock.mockResolvedValue(undefined)
   putCachedScriptContentMock.mockReset()
   putCachedScriptContentMock.mockResolvedValue(undefined)
   parseMarkdownMock.mockReset()
@@ -352,6 +365,58 @@ describe('PlayerScreen', () => {
     )
   })
 
+  it('#314 Phase 3: parse済み entry MD cache hit なら contents API も parseMarkdown も呼ばない', async () => {
+    listProjectsMock.mockResolvedValue([
+      { name: 'theo-hayami', title: 'せおはやみ', repo: 'kako-jun/theo-hayami' },
+    ])
+    listScriptsMock.mockResolvedValue([
+      { path: 'content/scripts/script.md', sha: 'entry-sha', size: 1, title: null, hidden: false },
+    ])
+    getCachedParsedScriptDocumentMock.mockResolvedValue({
+      engine: 'name-name',
+      chapters: [
+        {
+          number: 1,
+          title: 'c',
+          hidden: false,
+          default_bgm: null,
+          scenes: [{ id: 'scene-parsed-cache', title: 'cached', view: 'TopDown', events: [] }],
+        },
+      ],
+    })
+    getContentsMock.mockResolvedValue({
+      path: 'content/scripts/script.md',
+      sha: 'entry-sha',
+      content: 'network-entry-markdown',
+    })
+
+    render(
+      <PlayerScreen
+        projectName="theo-hayami"
+        apiBaseUrl="http://api.test"
+        isDark={false}
+        onBack={() => {}}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('novel-player')).toBeInTheDocument()
+    })
+
+    expect(getCachedParsedScriptDocumentMock).toHaveBeenCalledWith({
+      projectName: 'theo-hayami',
+      ref: 'main',
+      path: 'content/scripts/script.md',
+      sha: 'entry-sha',
+    })
+    expect(getCachedScriptContentMock).not.toHaveBeenCalled()
+    expect(getContentsMock).not.toHaveBeenCalled()
+    expect(parseMarkdownMock).not.toHaveBeenCalled()
+    expect(screen.getByTestId('novel-player').getAttribute('data-scene-ids')).toBe(
+      'scene-parsed-cache'
+    )
+  })
+
   it('#314 Phase 2: cache miss なら contents API から取得して sha 付きで保存する', async () => {
     listProjectsMock.mockResolvedValue([
       { name: 'theo-hayami', title: 'せおはやみ', repo: 'kako-jun/theo-hayami' },
@@ -401,6 +466,7 @@ describe('PlayerScreen', () => {
       },
       'network-markdown'
     )
+    expect(putCachedParsedScriptDocumentMock).toHaveBeenCalled()
   })
 
   it('#314 Phase 2: cache hit した lazy MD も contents API を呼ばずに解決する', async () => {

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -8,7 +8,12 @@ import { parseMarkdown } from '../wasm/parser'
 import { findRpgSceneIndex, rpgProjectFromDoc } from '../game/rpgProjectFromDoc'
 import { ApiError, createApiClient, type ProjectInfo, type ScriptInfo } from '../api/client'
 import { loadReadProgress, clearReadProgress } from '../game/readProgress'
-import { getCachedScriptContent, putCachedScriptContent } from '../game/scriptContentCache'
+import {
+  getCachedParsedScriptDocument,
+  getCachedScriptContent,
+  putCachedParsedScriptDocument,
+  putCachedScriptContent,
+} from '../game/scriptContentCache'
 
 // kako-jun/name-name#108: 一般ユーザー向けの再生専用画面。
 //   - 編集 UI / 保存 / アセット管理 / デバッグは一切表示しない
@@ -166,23 +171,32 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
 
       const promise = (async () => {
         const scriptInfo = scriptInfoByPathRef.current.get(path)
+        const cacheKey = scriptInfo?.sha
+          ? {
+              projectName,
+              ref: PUBLIC_BRANCH,
+              path,
+              sha: scriptInfo.sha,
+            }
+          : null
         let markdown: string | null = null
         let loadedFromPersistentCache = false
 
-        if (scriptInfo?.sha) {
-          markdown = await getCachedScriptContent({
-            projectName,
-            ref: PUBLIC_BRANCH,
-            path,
-            sha: scriptInfo.sha,
-          })
+        if (cacheKey) {
+          const cachedDoc = await getCachedParsedScriptDocument(cacheKey)
+          if (cachedDoc) {
+            loadedDocsRef.current.set(path, cachedDoc)
+            return cachedDoc
+          }
+
+          markdown = await getCachedScriptContent(cacheKey)
           loadedFromPersistentCache = markdown !== null
         }
 
         if (markdown === null) {
           const contents = await api.getContents(projectName, path, PUBLIC_BRANCH)
           markdown = contents.content || ''
-          const sha = scriptInfo?.sha ?? contents.sha
+          const sha = cacheKey?.sha ?? contents.sha
           if (sha) {
             void putCachedScriptContent(
               {
@@ -199,6 +213,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
         try {
           const parsed = await parseMarkdown(markdown)
           loadedDocsRef.current.set(path, parsed)
+          if (cacheKey) void putCachedParsedScriptDocument(cacheKey, parsed)
           return parsed
         } catch (err) {
           if (!loadedFromPersistentCache) throw err
@@ -206,7 +221,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
           console.warn(`PlayerScreen: cached script ${path} failed to parse; refetching`, err)
           const contents = await api.getContents(projectName, path, PUBLIC_BRANCH)
           const freshMarkdown = contents.content || ''
-          const sha = scriptInfo?.sha ?? contents.sha
+          const sha = cacheKey?.sha ?? contents.sha
           if (sha) {
             void putCachedScriptContent(
               {
@@ -220,6 +235,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
           }
           const parsed = await parseMarkdown(freshMarkdown)
           loadedDocsRef.current.set(path, parsed)
+          if (cacheKey) void putCachedParsedScriptDocument(cacheKey, parsed)
           return parsed
         }
       })()


### PR DESCRIPTION
## Summary
- add an IndexedDB cache for parsed EventDocument objects with a schema-versioned key
- load scripts through parsed-doc cache before Markdown-body cache and contents API
- update lazy script loading tests to cover parse-cache hits and parsed-cache writes

Refs #314

## Verification
- npm test -- PlayerScreen.test.tsx --run
- npm test -- --run
- npm run build
