### PR TITLE
fix: exclude README from scriptsDir listing

### DIFF
--- a/worker/src/scripts.ts
+++ b/worker/src/scripts.ts
@@ -217,6 +217,7 @@ async function listScriptsFromTree(
         (relative.includes("/") && relative.split("/").length > 2)
       )
         return false;
+      if (relative.toLowerCase() === "readme.md") return false;
       return (
         entry.path.toLowerCase().endsWith(".md") &&
         (entry.size ?? 0) <= 64 * 1024

--- a/worker/test/scripts-multi-md.test.ts
+++ b/worker/test/scripts-multi-md.test.ts
@@ -79,6 +79,7 @@ describe("GET /api/projects/:name/scripts (scriptsDir / fast tree listing #314)"
             treeEntry("content/scripts/free/a.md", "sha-a", 100),
             treeEntry("content/scripts/main/b.md", "sha-b", 100),
             treeEntry("content/scripts/free/nested/deep.md", "sha-deep", 100),
+            treeEntry("content/scripts/readme.md", "sha-readme", 100),
             treeEntry("content/scripts/README.txt", "sha-txt", 100),
             treeEntry("docs/outside.md", "sha-outside", 100),
           ],


### PR DESCRIPTION
## Summary
- exclude `README.md` from scriptsDir fast tree listing
- keep the one-request Git tree path for theo-hayami-scale projects

Refs #314

## Verification
- npm test -- scripts-multi-md.test.ts --run
- npm run build
