### PR TITLE
Fade portraits during scene jumps

### DIFF
--- a/frontend/src/game/CharacterLayer.test.ts
+++ b/frontend/src/game/CharacterLayer.test.ts
@@ -1975,6 +1975,38 @@ describe('CharacterLayer 立ち絵 transition semantics (#337)', () => {
   })
 })
 
+describe('CharacterLayer scene transition fade', () => {
+  it('clearForSceneTransition は標準立ち絵を即時破棄せず fade-out に入れる', () => {
+    const layer = new CharacterLayer(800, 450)
+    layer.show('せお', 'normal', '左', '/assets', { instant: true })
+
+    layer.clearForSceneTransition()
+
+    const seo = asInternals(layer).characters.get('せお')
+    expect(seo).toBeDefined()
+    expect(seo!.fadeAnimation).toMatchObject({
+      toAlpha: 0,
+      destroyOnComplete: true,
+    })
+    expect(layer.getCharacterStates()).toEqual([])
+  })
+
+  it('scene transition fade-out 中に同名キャラが再 show されると fade-in に戻る', () => {
+    const layer = new CharacterLayer(800, 450)
+    layer.show('せお', 'normal', '左', '/assets', { instant: true })
+    layer.clearForSceneTransition()
+
+    layer.show('せお', 'normal', '左', '/assets')
+
+    const seo = asInternals(layer).characters.get('せお')
+    expect(seo).toBeDefined()
+    expect(seo!.fadeAnimation).toMatchObject({
+      toAlpha: 1,
+      destroyOnComplete: false,
+    })
+  })
+})
+
 // =====================================================================================
 // #308: 立ち絵の足元 Y 比率 per-game 上書き（setCharacterYRatio）。
 //   既定 1.0（後方互換）。CharacterLayer が null/NaN/±Inf→1.0、範囲外→[0,2] クランプを一元所有する。

--- a/frontend/src/game/CharacterLayer.ts
+++ b/frontend/src/game/CharacterLayer.ts
@@ -2147,6 +2147,28 @@ export class CharacterLayer extends Container {
   }
 
   /**
+   * 通常の scene jump 用クリア。
+   *
+   * セーブ復元・seek・destroy の clear() は中間状態を作らず即時破棄する。一方で通常再生の
+   * Choice → jumpToScene では、前シーンの立ち絵が一瞬で消えると演出として不自然なので、
+   * 標準立ち絵だけ fade-out に入れる。次シーン先頭で同じ人物が再 show された場合は show() 側の
+   * 「退場フェード中の同名キャラ再 show」経路で fade-in に戻るため、メニュー間の主人公は瞬断しない。
+   */
+  clearForSceneTransition(): void {
+    const names = Array.from(this.characters.keys())
+    for (const name of names) {
+      const state = this.characters.get(name)
+      if (!state) continue
+      if (state.renderOnly) {
+        this.destroyCharacterState(state)
+        this.characters.delete(name)
+        continue
+      }
+      this.remove(name)
+    }
+  }
+
+  /**
    * テクスチャをロードして Sprite に適用する。
    *
    * `onReady` (#293): テクスチャの用意が済んだ（または素早く諦めた）タイミングで**必ず1回だけ**

--- a/frontend/src/game/NovelRenderer.linearAndJumpIndex.test.ts
+++ b/frontend/src/game/NovelRenderer.linearAndJumpIndex.test.ts
@@ -52,6 +52,24 @@ interface RendererInternals {
   eventIndex: number
   resolvedEvents: Event[]
   advance(): void
+  characterLayer: {
+    show(
+      character: string,
+      expression: string,
+      position: string,
+      assetBaseUrl: string,
+      options?: { instant?: boolean }
+    ): void
+    characters: Map<
+      string,
+      {
+        fadeAnimation: null | {
+          toAlpha: number
+          destroyOnComplete: boolean
+        }
+      }
+    >
+  }
 }
 function internals(r: NovelRenderer): RendererInternals {
   return r as unknown as RendererInternals
@@ -141,6 +159,24 @@ describe('NovelRenderer.setJumpSceneIndex クロスファイル解決 (#284 M2)'
     r.jumpToScene('far-scene')
     expect(r.getCurrentSceneId()).toBe('far-scene')
     expect(r.getDebugState().eventText).toContain('far-line-a')
+  })
+
+  it('通常の jumpToScene は前シーン立ち絵を即時 clear せず fade-out へ入れる', () => {
+    const entryScenes: EventScene[] = [scene('entry-hub', [narration('hub-line')])]
+    const jumpIndex: EventScene[] = [...entryScenes, scene('far-scene', [narration('far-line')])]
+    const r = new NovelRenderer()
+    r.setEvents(flatten(entryScenes))
+    r.setJumpSceneIndex(jumpIndex)
+    internals(r).characterLayer.show('せお', 'normal', '左', '', { instant: true })
+
+    r.jumpToScene('far-scene')
+
+    const seo = internals(r).characterLayer.characters.get('せお')
+    expect(seo).toBeDefined()
+    expect(seo!.fadeAnimation).toMatchObject({
+      toAlpha: 0,
+      destroyOnComplete: true,
+    })
   })
 
   it('setJumpSceneIndex は再生ストリーム（resolvedEvents / 現在位置）を置換しない', () => {

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -857,7 +857,11 @@ export class NovelRenderer {
     } else {
       this.clearBackground()
     }
-    this.characterLayer.clear()
+    if (options?.preserveBackgroundForTransition) {
+      this.characterLayer.clearForSceneTransition()
+    } else {
+      this.characterLayer.clear()
+    }
     this.blackoutOverlay.visible = false
     this.currentBgmPath = null
     // シーン遷移時にダイアログを明示的にクリアする（前シーンの残留テキスト防止 #217）


### PR DESCRIPTION
## Summary
- Keep scene-jump portrait clearing on the animated path instead of immediate CharacterLayer.clear().
- Add clearForSceneTransition() so standard portraits fade out during normal Choice/jumpToScene transitions while render-only elements are still discarded.
- Preserve the expected menu behavior: if the same character is shown at the start of the next scene, the pending fade-out is reversed to fade-in instead of blinking away.
- Add regression tests for CharacterLayer and jumpToScene wiring.

## Verification
- npm --prefix frontend run type-check
- npm --prefix frontend test -- --run