### PR TITLE
Fix Android mobile player viewport height

### DIFF
--- a/frontend/src/screens/PlayerScreen.test.tsx
+++ b/frontend/src/screens/PlayerScreen.test.tsx
@@ -179,6 +179,39 @@ afterEach(() => {
 })
 
 describe('PlayerScreen', () => {
+  it('#341: visualViewport.height を PlayerScreen の高さに使う', () => {
+    const originalVisualViewport = window.visualViewport
+    listProjectsMock.mockReturnValue(new Promise(() => {}))
+
+    const visualViewport = new EventTarget() as VisualViewport
+    Object.defineProperty(visualViewport, 'height', {
+      configurable: true,
+      value: 615,
+    })
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: visualViewport,
+    })
+
+    const { container } = render(
+      <PlayerScreen
+        projectName="friday-1930"
+        apiBaseUrl="http://api.test"
+        isDark={false}
+        onBack={() => {}}
+      />
+    )
+
+    const root = container.firstElementChild as HTMLElement
+    expect(root.style.height).toBe('615px')
+    expect(root.style.minHeight).toBe('615px')
+
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: originalVisualViewport,
+    })
+  })
+
   it('main ブランチから章データを取得して NovelPlayer に渡す', async () => {
     listProjectsMock.mockResolvedValue([
       { name: 'friday-1930', title: '友達 1930', repo: 'kako-jun/friday-1930' },

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -8,6 +8,7 @@ import { parseMarkdown } from '../wasm/parser'
 import { findRpgSceneIndex, rpgProjectFromDoc } from '../game/rpgProjectFromDoc'
 import { ApiError, createApiClient, type ProjectInfo, type ScriptInfo } from '../api/client'
 import { loadReadProgress, clearReadProgress } from '../game/readProgress'
+import { useVisualViewportHeight } from '../utils/useVisualViewportHeight'
 import {
   getCachedParsedScriptDocument,
   getCachedScriptContent,
@@ -134,6 +135,7 @@ function inferScriptPathsForSceneId(sceneId: string, paths: string[]): string[] 
 }
 
 function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenProps) {
+  const viewportHeight = useVisualViewportHeight()
   const api = useMemo(() => createApiClient({ baseUrl: apiBaseUrl }), [apiBaseUrl])
   // doc: エントリ MD のドキュメント。通常再生ストリーム（線形 events）の供給元であり、
   // かつ RPG 判定・aspect_ratio / choice_style / font_family 等の per-game 設定の
@@ -467,7 +469,10 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
   const [hasSaveData, setHasSaveData] = useState(() => loadReadProgress(projectName).size > 0)
 
   return (
-    <div className={`flex flex-col h-screen ${isDark ? 'dark bg-gray-900' : 'bg-white'}`}>
+    <div
+      className={`flex flex-col overflow-hidden ${isDark ? 'dark bg-gray-900' : 'bg-white'}`}
+      style={{ height: viewportHeight, minHeight: viewportHeight }}
+    >
       <header
         className={`border-b ${isDark ? 'border-gray-700 bg-gray-900' : 'border-blue-200 bg-blue-50'}`}
       >

--- a/frontend/src/utils/useVisualViewportHeight.ts
+++ b/frontend/src/utils/useVisualViewportHeight.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+
+function readVisualViewportHeight(): string {
+  if (typeof window === 'undefined') return '100dvh'
+
+  const height = window.visualViewport?.height
+  if (typeof height === 'number' && Number.isFinite(height) && height > 0) {
+    return `${height}px`
+  }
+
+  return '100dvh'
+}
+
+/**
+ * Android Chrome の下部 URL バーは layout viewport ではなく visual viewport を覆う。
+ * PlayerScreen の外枠を実表示領域へ収めるため、resize/scroll の両方に追従する。
+ */
+export function useVisualViewportHeight(): string {
+  const [height, setHeight] = useState(readVisualViewportHeight)
+
+  useEffect(() => {
+    const update = () => setHeight(readVisualViewportHeight())
+    const visualViewport = window.visualViewport
+
+    update()
+    window.addEventListener('resize', update)
+    visualViewport?.addEventListener('resize', update)
+    visualViewport?.addEventListener('scroll', update)
+
+    return () => {
+      window.removeEventListener('resize', update)
+      visualViewport?.removeEventListener('resize', update)
+      visualViewport?.removeEventListener('scroll', update)
+    }
+  }, [])
+
+  return height
+}


### PR DESCRIPTION
## Summary
- use `visualViewport.height` for the PlayerScreen outer height so Android Chrome bottom URL bars do not cover the game bottom edge
- keep the existing flex/letterbox NovelPlayer layout inside that visible viewport
- add a PlayerScreen regression test for the visual viewport height path

## Tests
- `npm test -- --run src/screens/PlayerScreen.test.tsx`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm test -- --run`

Closes #341