### PR TITLE
fix: スクロール選択肢が描画されないマスク回帰を修正 (#339)

### DIFF
--- a/frontend/src/game/ChoiceOverlay.ts
+++ b/frontend/src/game/ChoiceOverlay.ts
@@ -202,7 +202,9 @@ export class ChoiceOverlay extends Container {
       const mask = new Graphics()
       mask.rect(0, this.viewportY, this.screenWidth, viewportHeight)
       mask.fill(0xffffff)
-      mask.renderable = false
+      // PixiJS v8 ではオブジェクトを `.mask` に割り当てた時点で通常描画から自動的に
+      // 除外される。ここで renderable=false を付けるとステンシルにマスク形状が書き込まれず、
+      // クリップ領域が空になって選択肢が一切描画されなくなる (#339 regression)。
       this.addChild(mask)
       contentContainer.mask = mask
       this.on('pointerdown', this.handleDragStart)


### PR DESCRIPTION
## 背景

#339 のスクロール対応 (fcc948e) が、実機（PixiJS v8.18.1 / 9:16=450×800）で**多件選択肢を一切描画しない**回帰を起こしていた。スクロール経路に入ると画面が真っ黒になり、1件も選べない＝#339 の受け入れ条件「全テーマを選択できる」を満たせていなかった。

## 原因

`ChoiceOverlay.show()` のスクロール経路で、`contentContainer.mask` に使う Graphics に `mask.renderable = false` を付けていた。

PixiJS v8 では、オブジェクトを `.mask` に割り当てた時点で**通常描画から自動的に除外される**。そこへさらに `renderable=false` を付けると、ステンシルにマスク形状が書き込まれず、**クリップ領域が空**になって配下の全要素が消える。

jsdom は WebGL を描画しないため、既存のスクロール系テスト22件はシーングラフ上の座標・スクロール量だけを検証しており、この描画回帰を緑のまま見逃していた。

## 修正

`mask.renderable = false` を削除（v8 がマスクを自動で非描画にするため白矩形は出ない）。1行削除＋理由コメント。

## 検証（dev + Playwright 実描画）

- **n=3（非スクロール）**: 中央寄せで正常表示（リグレッションなし）
- **n=12**: トップに選択肢表示 → ホイールで最下部までスクロール → テーマ12到達・選択可、マスクが上下端で正しくクリップ
- **n=20**: 同上、テーマ10〜20までスクロールで到達
- 修正前は n=12 / n=20 で画面が真っ黒（添付の切り分け済み）
- `vitest run ChoiceOverlay.test.ts` 22件パス / `tsc -b --noEmit` パス

Closes #339