### PR TITLE
fix: シナリオスライダ実機ポリッシュ（薄さ/初回タップ/即解除/影削除/中央一致） (#350)

### DIFF
--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -55,6 +55,7 @@ import {
   resolveFontFamily,
   formatCounterText,
   computeSeekBarPosition,
+  PLAYER_BUTTON_CENTER_FROM_BOTTOM_PX,
   describeEventForDebug,
   findSceneById,
   resolveSceneTitle,
@@ -413,6 +414,9 @@ export class NovelRenderer {
    *  フェード退避に繋ぐ（onAutoModeChange と同じ配線パターン）。 */
   private onSeekActiveChange: ((active: boolean) => void) | null = null
 
+  /** SeekBar の縦位置をキャンバス表示倍率に追従させる ResizeObserver (#350)。 */
+  private seekBarResizeObserver: ResizeObserver | null = null
+
   // ---- 画面効果 (#143) ----
   /** flash/fade 用全画面オーバーレイ Graphics */
   private effectOverlay: Graphics | null = null
@@ -534,7 +538,13 @@ export class NovelRenderer {
       this.seekToTextEventDisplayIndex(displayIndex)
     })
     // active 変化を React 側へ伝え、丸ボタン行をフェード退避させる (#350)。
-    this.seekBar.setOnActiveChange((active) => this.onSeekActiveChange?.(active))
+    this.seekBar.setOnActiveChange((active) => {
+      // 起こすタップ（inactive→active）でも本文を送らないよう、この native pointerdown の後続
+      // handleAdvance を 1 回抑止する (#350)。シーク無しの「操作可能化だけ」のタップでも、同フレームの
+      // canvas pointerdown で dialogue が進むのを防ぐ（onSeek 経路と同じ suppressNextAdvance を使う）。
+      if (active) this.suppressNextAdvance = true
+      this.onSeekActiveChange?.(active)
+    })
     this.app.stage.addChild(this.seekBar)
     // #350: 通常時も控えめに常時表示する（モバイルはホバー不可・Issue「ボタンより背面に見える」を満たす）。
     // active はスライダの実操作（SeekBar.handleClick 内の activate）だけで入る。デスクトップのホバーで
@@ -544,6 +554,14 @@ export class NovelRenderer {
     if (this.app.canvas) {
       const canvas = this.app.canvas as HTMLCanvasElement
       canvas.addEventListener('mouseleave', this.handleCanvasMouseLeave)
+      // #350: スライダのつまみ中心を「丸ボタンの実中央（固定 CSS px）」へ合わせる。Pixi 論理座標は
+      // キャンバスの表示倍率でスケールするため、表示高さ≠論理高さだと丸ボタン中央からズレる。実倍率を
+      // canvas.clientHeight から求めて補正し、resize/回転にも追従する（ResizeObserver 未対応環境は初期同期のみ）。
+      this.syncSeekBarVerticalToButtons()
+      if (typeof ResizeObserver !== 'undefined') {
+        this.seekBarResizeObserver = new ResizeObserver(() => this.syncSeekBarVerticalToButtons())
+        this.seekBarResizeObserver.observe(canvas)
+      }
     }
 
     // シーンカウンター
@@ -1288,6 +1306,8 @@ export class NovelRenderer {
     this.app.canvas.removeEventListener('pointerdown', this.handleAdvance)
     this.app.canvas.removeEventListener('wheel', this.handleWheel)
     this.app.canvas.removeEventListener('mouseleave', this.handleCanvasMouseLeave)
+    this.seekBarResizeObserver?.disconnect()
+    this.seekBarResizeObserver = null
     window.removeEventListener('keydown', this.handleKeyDown)
     if (this.waitTimer) {
       this.time.clearTimeout(this.waitTimer)
@@ -1911,6 +1931,23 @@ export class NovelRenderer {
   }
 
   /**
+   * SeekBar のつまみ中心を下部丸ボタンの実中央（固定 CSS px）に一致させる (#350)。
+   * 丸ボタンは DOM の固定 px（`bottom` + 半径 = PLAYER_BUTTON_CENTER_FROM_BOTTOM_PX）でスケールしない。
+   * スライダは Pixi 論理座標で表示倍率に応じてスケールするため、`canvas.clientHeight / screenHeight` の
+   * 実倍率で割って「画面下端から常に固定 CSS px」に来る論理 Y を算出して渡す。これで表示高さが論理と
+   * 異なる端末でもボタン中央を貫く。clientHeight 不明（0/未測定）のときは触らない（constructor 既定のまま）。
+   */
+  private syncSeekBarVerticalToButtons(): void {
+    const canvas = this.app?.canvas as HTMLCanvasElement | undefined
+    if (!canvas) return
+    const clientH = canvas.clientHeight
+    if (!(clientH > 0)) return
+    const scale = clientH / this.screenHeight
+    const logicalFromBottom = PLAYER_BUTTON_CENTER_FROM_BOTTOM_PX / scale
+    this.seekBar.setVerticalCenter(this.screenHeight - logicalFromBottom)
+  }
+
+  /**
    * 暗転オーバーレイの表示を切り替え、SeekBar の可視ゲートと同期する (#350)。
    * 暗転中はスライダを隠す（z 順は変えず可視性ゲートで対処し、黒の上に薄いスライダ線が残らない）。
    * active も SeekBar 側で解除する。GameState の永続 isBlackout から導出する transient な見た目同期で、
@@ -1937,6 +1974,9 @@ export class NovelRenderer {
       this.suppressNextAdvance = false
       return
     }
+    // ここに到達 = スライダ以外への通常タップ/送り。SeekBar が active なら即 inactive へ戻して
+    // 丸ボタンを復帰させる（無操作タイマー満了を待たない） (#350)。inactive 時は no-op。
+    this.seekBar.deactivate()
     this.audioManager.ensureContext()
     if (this.backlogOverlay.visible) {
       this.backlogOverlay.hide()

--- a/frontend/src/game/SeekBar.test.ts
+++ b/frontend/src/game/SeekBar.test.ts
@@ -2,15 +2,14 @@
  * SeekBar（シナリオスライダ）の active 状態・無操作タイマー・書き出し抑制の単体テスト (#350)。
  *
  * 検証方針（CLAUDE.md ルール7 / 設計に従う）:
- *  - jsdom で観測可能な状態のみ縛る: isActive() / alpha / shadow.visible / thumb.scale.x /
+ *  - jsdom で観測可能な状態のみ縛る: isActive() / alpha / thumb.scale.x /
  *    thumb.y / thumb.visible / visible / onActiveChange の発火回数と引数。
  *  - 実 Pixi 描画・computed style・pointer-events 実効・EventSystem の DOM 先行発火の実 race は
  *    観測不能なので実ブラウザ（blink）に委ね、ここでは書かない。
  *  - タイマーは実 setTimeout / fake timers でなく **virtual モードの TimeController を注入**し、
  *    `tick()` で決定論的に進める。リークは `getPendingTimerCount()` で検証する。
  *  - 期待値は SeekBar / novelLayout の export 定数のみで組み、2800 や 0.5 を直書きしない。
- *  - shadow / thumb は private graphics なので internals キャストで読む（emit でなく公開メソッド・
- *    状態で駆動する設計どおり）。
+ *  - thumb / clickRegion は private graphics なので internals キャストで読む（公開メソッド・状態で駆動）。
  */
 import { describe, it, expect, vi } from 'vitest'
 import { SeekBar, ACTIVE_THUMB_SCALE, INACTIVE_ALPHA, INACTIVITY_MS } from './SeekBar'
@@ -27,27 +26,26 @@ function virtualTime(): TimeController {
   return t
 }
 
-/** private graphics（shadow / thumb）を読むための internals ビュー。 */
+/** private graphics（thumb / clickRegion）を読むための internals ビュー。 */
 interface SeekBarInternals {
-  shadow: { visible: boolean }
   thumb: { visible: boolean; y: number; scale: { x: number } }
+  clickRegion: { emit: (event: string, ...args: unknown[]) => boolean }
 }
 function internals(sb: SeekBar): SeekBarInternals {
   return sb as unknown as SeekBarInternals
 }
 
 describe('SeekBar 初期状態・active 遷移 (#350 B 群)', () => {
-  // B-1: 控えめ常時表示の回帰固定。初期は inactive で alpha=INACTIVE_ALPHA・影なし・つまみ等倍・可視。
-  it('B-1: 初期は inactive（alpha=INACTIVE_ALPHA・影なし・つまみ等倍・常時可視）', () => {
+  // B-1: 控えめ常時表示の回帰固定。初期は inactive で alpha=INACTIVE_ALPHA・つまみ等倍・可視。
+  it('B-1: 初期は inactive（alpha=INACTIVE_ALPHA・つまみ等倍・常時可視）', () => {
     const sb = new SeekBar(SCREEN_W, SCREEN_H, virtualTime())
     expect(sb.isActive()).toBe(false)
     expect(sb.alpha).toBe(INACTIVE_ALPHA)
-    expect(internals(sb).shadow.visible).toBe(false)
     expect(internals(sb).thumb.scale.x).toBe(1)
     expect(sb.visible).toBe(true)
   })
 
-  // B-2: activate で active 見た目（alpha=1・影表示・つまみ拡大）になり onActiveChange(true) を 1 回呼ぶ。
+  // B-2: activate で active 見た目（alpha=1・つまみ拡大）になり onActiveChange(true) を 1 回呼ぶ。
   it('B-2: activate で active 見た目になり onActiveChange(true) を 1 回呼ぶ', () => {
     const sb = new SeekBar(SCREEN_W, SCREEN_H, virtualTime())
     const cb = vi.fn()
@@ -55,7 +53,6 @@ describe('SeekBar 初期状態・active 遷移 (#350 B 群)', () => {
     sb.activate()
     expect(sb.isActive()).toBe(true)
     expect(sb.alpha).toBe(1)
-    expect(internals(sb).shadow.visible).toBe(true)
     expect(internals(sb).thumb.scale.x).toBe(ACTIVE_THUMB_SCALE)
     expect(cb).toHaveBeenCalledTimes(1)
     expect(cb).toHaveBeenCalledWith(true)
@@ -83,7 +80,6 @@ describe('SeekBar 初期状態・active 遷移 (#350 B 群)', () => {
     sb.deactivate()
     expect(sb.isActive()).toBe(false)
     expect(sb.alpha).toBe(INACTIVE_ALPHA)
-    expect(internals(sb).shadow.visible).toBe(false)
     expect(internals(sb).thumb.scale.x).toBe(1)
     expect(cb).toHaveBeenCalledTimes(1)
     expect(cb).toHaveBeenCalledWith(false)
@@ -301,5 +297,36 @@ describe('SeekBar setBlackoutHidden（暗転中の非表示） (#350 C 群)', ()
     // blackout も解除 → 両方 false で表示。
     sb.setBlackoutHidden(false)
     expect(sb.visible).toBe(true)
+  })
+})
+
+describe('SeekBar タップ挙動・縦位置追従 (#350 追修正)', () => {
+  // 初回タップ（inactive）は active 化だけでシークせず、active 中の以降のタップでシークする。
+  it('初回タップは active 化のみ（シークしない）、active 中のタップでシークする', () => {
+    const sb = new SeekBar(SCREEN_W, SCREEN_H, virtualTime())
+    sb.update(2, 5) // total>0 にしてシーク可能に
+    const seekCb = vi.fn()
+    sb.setOnSeek(seekCb)
+    const region = internals(sb).clickRegion
+    const ev = { globalX: SCREEN_W / 2 }
+
+    // inactive での初回タップ: 前面化だけ・シークしない
+    region.emit('pointerdown', ev)
+    expect(sb.isActive()).toBe(true)
+    expect(seekCb).not.toHaveBeenCalled()
+
+    // active 中の以降のタップ: シークする
+    region.emit('pointerdown', ev)
+    expect(seekCb).toHaveBeenCalledTimes(1)
+  })
+
+  // setVerticalCenter でつまみ中心 Y が更新される（表示倍率追従のための再配置）。
+  it('setVerticalCenter でつまみ中心 Y が更新される', () => {
+    const sb = new SeekBar(SCREEN_W, SCREEN_H, virtualTime())
+    sb.update(1, 4)
+    // 既定はボタン中央（screenHeight - PLAYER_BUTTON_CENTER_FROM_BOTTOM_PX）
+    expect(internals(sb).thumb.y).toBe(SCREEN_H - PLAYER_BUTTON_CENTER_FROM_BOTTOM_PX)
+    sb.setVerticalCenter(600)
+    expect(internals(sb).thumb.y).toBe(600)
   })
 })

--- a/frontend/src/game/SeekBar.ts
+++ b/frontend/src/game/SeekBar.ts
@@ -6,8 +6,9 @@
  * 動画プレイヤー的な見た目のスクラブバー。
  *
  * #350: つまみ中心を下部丸ボタンの中央を貫く高さへ上げ（`computeSeekBarGeometry`）、通常時も
- * 控えめに常時表示する。スライダの実操作（タップ/ドラッグ）で `active` に入り、つまみ拡大＋背面に
- * 影を敷いて前面感を出す（ホバーでは入らない）。active は **GameState に持たない transient な演出/UI
+ * 控えめに常時表示する。スライダの実操作（タップ/ドラッグ）で `active` に入り、つまみを拡大して
+ * 前面感を出す（ホバーでは入らない）。初回タップ（inactive→active）は「操作可能化」だけでシークせず、
+ * active 中の以降のタップ/ドラッグでシークする。active は **GameState に持たない transient な演出/UI
  * 状態**（ADR 0002）。一定時間無操作で inactive に戻す。動画書き出し中は `setExportSuppressed(true)`、
  * 暗転中は `setBlackoutHidden(true)` で非表示にし（表示可否は `updateVisibility` に一元化）、録画や
  * 黒画面にスライダが焼き込まれない・残らないようにする。
@@ -31,24 +32,14 @@ const BAR_RADIUS = 3
 /** つまみの半径 */
 const THUMB_RADIUS = 7
 
-/** active 時のつまみ拡大率 (#350)。丸ボタン退避中にスライダを前面に感じさせる。 */
+/** active 時のつまみ拡大率 (#350)。スライダを前面に感じさせる。 */
 export const ACTIVE_THUMB_SCALE = 1.6
 /** 通常（inactive）時のコンテナ不透明度 (#350)。控えめに常時表示しつつボタンより背面に見せる。 */
-export const INACTIVE_ALPHA = 0.5
-/** 操作（タップ/ドラッグ/ホバー）が止まってから inactive に戻すまでの時間 (ms) (#350)。 */
+export const INACTIVE_ALPHA = 0.2
+/** 操作（タップ/ドラッグ）が止まってから inactive に戻すまでの時間 (ms) (#350)。 */
 export const INACTIVITY_MS = 2800
 
-/** active 時にスライダ背面へ敷く影（半透明黒の矩形）の見た目 (#350)。ChoiceOverlay の影実装が手本。 */
-const SHADOW_COLOR = 0x000000
-const SHADOW_ALPHA = 0.45
-/** 影のずれ（右下方向、px） */
-const SHADOW_OFFSET = 3
-/** 影帯の左右パディング（バー両端より少し外へ広げる、px） */
-const SHADOW_PAD_X = 10
-
 export class SeekBar extends Container {
-  /** active 時にスライダ背面へ敷く影。最背面の子。 */
-  private shadow: Graphics
   private barBg: Graphics
   private barFill: Graphics
   private thumb: Graphics
@@ -101,21 +92,6 @@ export class SeekBar extends Container {
     this.barWidth = geom.barWidth
     this.barY = geom.barY
     this.thumbCenterY = geom.thumbCenterY
-
-    // 影（active 時のみ表示）。最背面に置き、スライダ全体を浮かせて見せる。
-    // pixi-filters 依存は避け、半透明黒の矩形を背面に重ねる方式（ChoiceOverlay が手本）。
-    this.shadow = new Graphics()
-    const bandHeight = THUMB_RADIUS * 2 * ACTIVE_THUMB_SCALE + 10
-    this.shadow.roundRect(
-      this.barX - SHADOW_PAD_X + SHADOW_OFFSET,
-      this.thumbCenterY - bandHeight / 2 + SHADOW_OFFSET,
-      this.barWidth + SHADOW_PAD_X * 2,
-      bandHeight,
-      bandHeight / 2
-    )
-    this.shadow.fill({ color: SHADOW_COLOR, alpha: SHADOW_ALPHA })
-    this.shadow.visible = false
-    this.addChild(this.shadow)
 
     // 透明ヒットエリア（タップ/ドラッグ開始の検出を広めに取る）。つまみ中心の上下に余裕を持たせる。
     const hitHeight = THUMB_RADIUS * 2 * ACTIVE_THUMB_SCALE + 16
@@ -211,6 +187,29 @@ export class SeekBar extends Container {
   }
 
   /**
+   * つまみ中心 Y（論理 px）を更新して縦位置を再配置する (#350)。
+   *
+   * 下部丸ボタンは DOM の固定 CSS px（`bottom` + 半径）で配置され、キャンバスの表示倍率で
+   * スケールしない。一方このスライダは Pixi 論理座標で描かれ表示倍率でスケールするため、表示高さが
+   * 論理高さと異なると丸ボタン中央からズレる。NovelRenderer が `canvas.clientHeight` から実倍率を
+   * 求め、ボタンの実中央（固定 CSS px）に一致する論理 Y を算出して渡す。resize/回転でも追従させる。
+   */
+  setVerticalCenter(thumbCenterY: number): void {
+    if (!Number.isFinite(thumbCenterY)) return
+    this.thumbCenterY = thumbCenterY
+    this.barY = thumbCenterY - BAR_HEIGHT / 2
+    this.thumb.y = thumbCenterY
+
+    const hitHeight = THUMB_RADIUS * 2 * ACTIVE_THUMB_SCALE + 16
+    this.clickRegion.clear()
+    this.clickRegion.rect(this.barX, thumbCenterY - hitHeight / 2, this.barWidth, hitHeight)
+    this.clickRegion.fill({ color: 0x000000, alpha: 0 })
+
+    this.drawBar(this.barBg, BAR_BG_COLOR, this.barWidth, 0.6)
+    this.updateVisual()
+  }
+
+  /**
    * 現在位置と合計を更新する
    */
   update(current: number, total: number): void {
@@ -232,10 +231,9 @@ export class SeekBar extends Container {
     this.onActiveChange?.(active)
   }
 
-  /** active/inactive に応じて見た目（不透明度・影・つまみ拡大）を反映する (#350)。 */
+  /** active/inactive に応じて見た目（不透明度・つまみ拡大）を反映する (#350)。 */
   private applyActiveVisual(): void {
     this.alpha = this._active ? 1 : INACTIVE_ALPHA
-    this.shadow.visible = this._active
     const scale = this._active ? ACTIVE_THUMB_SCALE : 1
     this.thumb.scale.set(scale)
   }
@@ -276,8 +274,11 @@ export class SeekBar extends Container {
   }
 
   private handleClick = (e: FederatedPointerEvent): void => {
-    // スライダ操作（タップ/ドラッグ開始）で active に入る (#350)。
+    const wasActive = this._active
+    // スライダの実操作で active に入る (#350)。初回タップ（inactive→active）は「操作可能化」だけ
+    // にしてシークしない。すでに active のとき（2回目以降のタップ/ドラッグ）だけシークする。
     this.activate()
+    if (!wasActive) return
 
     if (this._total <= 0) return
 


### PR DESCRIPTION
## 関連 Issue
Refs #350（実機フィードバックによる追修正。本 PR で #350 を再クローズ）

## 背景
#350（PR #353）マージ後、kako-jun が実機（スマホ）で確認して挙げた5点を修正。

## 変更内容
1. **濃さ**: `INACTIVE_ALPHA` 0.5→0.2。常時表示を控えめにする（50% は濃すぎた）。
2. **初回タップ＝起こすだけ**: 半透明(inactive)状態の最初のタップは active 化のみでシークしない。active 中の以降のタップ/ドラッグでシークする（Issue 本文『表示するためのタップ後に操作』に合致）。起こすタップで本文が送られないよう、`onActiveChange(true)` でも `suppressNextAdvance` を立てる。
3. **即解除**: active 中にスライダ以外をタップしたら、無操作タイマー満了を待たず即 inactive へ戻す（`handleAdvance` の通常経路で `seekBar.deactivate()`）。
4. **影バンド廃止**: active 時にスライダ背面へ敷いていた黒い半透明矩形を削除（スライダ自体で範囲が分かる）。
5. **縦位置ズレ修正**: スライダのつまみ中心を丸ボタンの実中央（固定 CSS px）に合わせる。丸ボタンは DOM 固定 px でスケールせず、スライダは Pixi 論理座標で表示倍率にスケールするため、表示高さ≠論理高さだとズレていた。`canvas.clientHeight/screenHeight` の実倍率から論理 Y を補正（`SeekBar.setVerticalCenter`）、`ResizeObserver` で resize/回転にも追従。

## 検証（実ブラウザ・9:16・表示540×960＝論理800と異なる倍率）
- ⑤ つまみ中心 CSS Y == 丸ボタン中央 CSS Y（**delta 0px**。補正前は約6px 上ズレ）
- ② 初回 native pointerdown: active 化のみ／本文送りなし(advanced 0)／つまみ移動なし
- ③ active→スライダ外タップで即 inactive
- ①④ alpha=0.2 の控えめ表示・黒箱なし（通常/active とも）をスクショ目視
- `npm run type-check` 緑 / `npm run lint` 緑 / `npx vitest run` 全緑（60 files / 1370 tests）。SeekBar.test の影アサーション除去、初回タップ・setVerticalCenter のテスト追加。