### PR TITLE
fix: 本文を verbatim 描画にし glyph 統一(#315)を撤去 (#356)

### DIFF
--- a/frontend/src/game/DialogBox.test.ts
+++ b/frontend/src/game/DialogBox.test.ts
@@ -29,7 +29,6 @@ import {
   NOVEL_TEXT_MARGIN_X,
   NOVEL_TEXT_TOP_RATIO,
   NOVEL_TEXT_MARGIN_BOTTOM,
-  normalizeDashGlyphsForDisplay,
 } from './DialogBox'
 import { ensureFontLoaded } from './FontLoader'
 
@@ -162,23 +161,23 @@ describe('DialogBox portrait (Issue #73 / #194)', () => {
   })
 })
 
-describe('DialogBox dash glyph display normalization (#315)', () => {
-  it('表示用に下寄りのダッシュ・罫線系を中央線 glyph に寄せる', () => {
-    expect(normalizeDashGlyphsForDisplay('あ——い−−うーーえ')).toBe('あ──い──う──え')
-  })
-
-  it('novel/borderless だけ本文表示のダッシュを中央線 glyph に寄せ、adv は原文のまま', () => {
+describe('DialogBox 本文は verbatim で描く（glyph 統一しない・#356 / 旧 #315 撤去）', () => {
+  it('novel/borderless でも本文の長音符・ダッシュ・罫線を書き換えない', () => {
+    // 旧 #315 は borderless で [‐‑‒–—―−ー]→─ の glyph 統一を掛け、長音符 ー(U+30FC) まで
+    // 罫線 ─ に潰していた。エンジンは原稿を書き換えない（表記統一は原稿側の責務）。
     const novel = makeRpgBox()
     novel.setNovelMode(true)
-    novel.setDialog(null, 'あ——い')
+    novel.setDialog(null, 'コーヒーと──余韻') // 長音符 ー ×2 + 余韻の中央罫線 ── を含む
     novel.skipTypewriter()
-    expect(asInternals(novel).dialogText.text).toBe('あ──い')
+    expect(asInternals(novel).dialogText.text).toBe('コーヒーと──余韻') // verbatim（ー も ── もそのまま）
     novel.dispose()
+  })
 
+  it('adv でも同様に本文を書き換えない', () => {
     const adv = makeRpgBox()
-    adv.setDialog(null, 'あ——い')
+    adv.setDialog(null, 'コーヒーと——余韻')
     adv.skipTypewriter()
-    expect(asInternals(adv).dialogText.text).toBe('あ——い')
+    expect(asInternals(adv).dialogText.text).toBe('コーヒーと——余韻')
     adv.dispose()
   })
 })

--- a/frontend/src/game/DialogBox.ts
+++ b/frontend/src/game/DialogBox.ts
@@ -142,11 +142,6 @@ const DEFAULT_MS_PER_CHAR = 30
 /** 枠なしモードの DropShadow 設定 */
 const BORDERLESS_DROP_SHADOW = { color: 0x000000, blur: 8, distance: 3, alpha: 1 } as const
 
-/** novel/borderless 本文で下寄りに見えやすいダッシュ・罫線系を表示用に中央線へ寄せる (#315)。 */
-export function normalizeDashGlyphsForDisplay(text: string): string {
-  return text.replace(/[‐‑‒–—―−ー]/g, '─')
-}
-
 /**
  * クリッカー（インジケータ）の種別 (#292)。
  *  - `next`     : 同ページにまだ続く文がある（次は文の送り）。
@@ -1294,8 +1289,9 @@ export class DialogBox extends Container {
   }
 
   private visibleDialogText(state: TypewriterState): string {
-    const text = visibleText(state)
-    return this.borderless ? normalizeDashGlyphsForDisplay(text) : text
+    // 本文は verbatim で描く (#356)。ダッシュ・長音符などの glyph 統一はエンジンで行わない
+    // （原稿＝単一情報源を描画層が書き換えない）。表記統一が要るなら原稿側で揃える。
+    return visibleText(state)
   }
 
   /**


### PR DESCRIPTION
## 目的

borderless(=novel) 本文の **glyph 統一を撤去し、本文を verbatim 描画**する。エンジンは原稿＝単一情報源を書き換えない。表記統一は原稿側の責務。

Fixes #356

## 背景（バグ）

`DialogBox.normalizeDashGlyphsForDisplay` が borderless 本文に `text.replace(/[‐‑‒–—―−ー]/g, '─')` を掛けていた。文字クラスに**長音符 `ー`(U+30FC) が混入**しており、普通のカタカナ語の語末長音まで罫線 `─`(U+2500) に潰していた（原稿は正常なのに描画で別記号化）。旧 #315 の「余韻の横棒2つを、原稿でどう書いても表示で1形に合流させる」意図が誤仕様で、巻き添えで長音符が死んでいた。theo-hayami で発覚。

## 変更

- `frontend/src/game/DialogBox.ts`: `normalizeDashGlyphsForDisplay` を削除。`visibleDialogText` は borderless でも `visibleText(state)` を verbatim で返す。
- `frontend/src/game/DialogBox.test.ts`: 長音符潰しを期待値に固定していた #315 テストを削除し、「borderless/adv とも本文を書き換えない（`コーヒーと──余韻` が verbatim）」を担保するテストへ置換。

## 影響範囲

- `dialog_style: novel`(=borderless) は spec 上「protagonist 指定作品にだけ適用＝**実質 theo のみ**」。他に novel モードの原稿は無く（リポ横断で確認）、既存 adv 作品は元から未適用。よって描画が変わるのは theo だけ。
- theo は余韻バーを原稿側で `─`(U+2500) に統一する（**theo-hayami#18**）。両輪で「余韻＝連結中央線・長音符＝`ー`」が verbatim に揃う。

## 検証

- [x] `type-check`（tsc -b --noEmit）緑
- [x] `vitest run src/game` = **1237/1237** 緑（新 verbatim テスト含む・罫線置換に依存する他テストなし）
- [ ] **実機**: theo 原稿統一(theo-hayami#18)とマージ後、name-name プレイヤーで語末長音符が `ー`・余韻バーが連結中央線で出ることをライブ目視

## 関連

- theo-hayami#16（発覚元）/ theo-hayami#18（原稿統一 PR）
- 旧 #315（撤去対象の導入元）
