### PR TITLE
立ち絵など拡張子省略のキャラ画像を webp→png の順で解決する (#376)

### DIFF
--- a/docs/spec/llll-ll-media-impl-gaps.md
+++ b/docs/spec/llll-ll-media-impl-gaps.md
@@ -60,7 +60,7 @@
 - `[暗転解除]` ✓
 - `[待機: ms]` ✓
 - `[アニメ: target=<char>, x/y/scale/rotation/duration/easing]` ✓（位置・スケール・回転すべて利用）
-- `**Name** (path/to/expression, 右):` 形式で `assets/images/{path}/{expression}.png` を立ち絵として読み込み ✓
+- `**Name** (path/to/expression, 右):` 形式で立ち絵を読み込み ✓。パスは**拡張子省略**で、エンジンが `assets/images/{path}/{expression}.webp` を先に試し、無ければ `.png` にフォールバックして解決する（#376。軽量 webp を name-name-api の 1 MiB 制限内に収めるため。背景は `[背景: ...]` と拡張子明記なので対象外）
 - `**Name** → new-expression:` の表情変更（2コマ idle に流用） ✓
 - `[SE: shape-enter.wav]` ✓
 

--- a/frontend/src/game/CharacterLayer.test.ts
+++ b/frontend/src/game/CharacterLayer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { Assets, Texture } from 'pixi.js'
+import { Assets, Sprite, Texture } from 'pixi.js'
 import {
   CHARACTER_Y_RATIO,
   CharacterLayer,
@@ -13,7 +13,7 @@ import { CURSOR_DEFAULTS } from './textEffect'
 import { NovelRenderer } from './NovelRenderer'
 import { ASPECT_RATIOS } from './constants'
 import { __setDocumentForTest, resetFontLoaderCache } from './FontLoader'
-import { saveSlotToGameState } from './novelLayout'
+import { saveSlotToGameState, resolveCharacterImageUrls } from './novelLayout'
 import { SaveManager, type SaveSlotData } from './SaveManager'
 
 interface FadeAnimationLike {
@@ -3383,5 +3383,223 @@ describe('CharacterLayer クロスフェード中の character_height_ratios 再
     // クロスフェード開始時点のスケールを保ち続ける（新 sprite に引きずられて崩れない）。
     const oldScaleAfterLoad = chars.get(oldKey)!.sprite.scale.x
     expect(oldScaleAfterLoad).toBeCloseTo(beforeScale, 10)
+  })
+})
+
+// =====================================================================================
+// #376: loadTexture の webp→png フォールバック（loadFirstAvailableTexture 経由）。
+//   候補は resolveCharacterImageUrls が作る [.webp, .png]。loadTexture は先頭から Assets.load し、
+//   最初に成功した Texture を使う。全滅時のみ console.warn（joined URL・最後のエラー）で false を返す。
+//   onReady は 成功 / フォールバック成功 / 全滅 / assetBaseUrl 空 いずれでも finally でちょうど 1 回
+//   発火する（#293 セマンティクス）。
+//
+//   loadTexture は private。戻り値 Promise<boolean>・onReady 発火回数・console.warn・どの URL を
+//   load したかは全て CPU 側で観測できるので、show() の非公開経路に頼らず cast で直接叩いて縛る
+//   （show() は boolean を露出しないため。jsdom の canvas 未実装は迂回不要＝観測点が CPU 側で完結）。
+//   texture は既存 showImage/#294 テストと同流儀の plain object で足りる（Sprite.texture は dynamic
+//   でない値には .on を張らないので plain object を代入・読み戻しできる）。
+// =====================================================================================
+describe('CharacterLayer loadTexture webp→png フォールバック (#376)', () => {
+  afterEach(() => {
+    // Assets.load / console.warn の spy を毎テスト後に戻す（assert が throw しても後続へ漏らさない）。
+    vi.restoreAllMocks()
+  })
+
+  interface LoadTextureInternals {
+    loadTexture: (
+      sprite: Sprite,
+      characterName: string,
+      expression: string,
+      assetBaseUrl: string,
+      label?: unknown,
+      fit?: boolean,
+      onReady?: () => void
+    ) => Promise<boolean>
+  }
+  function asLoadable(layer: CharacterLayer): LoadTextureInternals {
+    return layer as unknown as LoadTextureInternals
+  }
+
+  // 期待 URL は候補列を作る当の関数 resolveCharacterImageUrls で組み立てて陳腐化を防ぐ（doctrine 規律4）。
+  // loadTexture が内部で使うのと同一の候補なので、生の URL 文字列を直書きしていない。
+  const BASE = '/assets'
+  const EXPR = 'spino/soften'
+  const [WEBP_URL, PNG_URL] = resolveCharacterImageUrls(BASE, EXPR)
+
+  // 偽 texture（{width,height} で sprite.texture 代入・scale 計算に足りる。__tag で webp/png を弁別する）。
+  const fakeTexture = (tag: 'webp' | 'png'): unknown => ({ width: 100, height: 200, __tag: tag })
+  const textureTag = (sprite: Sprite): string | undefined =>
+    (sprite.texture as unknown as { __tag?: string }).__tag
+
+  // 観点7: webp 成功 → webp だけを load して使う（png は試さない）・warn なし・onReady 1 回・戻り値 true。
+  it('webp 成功なら webp だけを load して使う（png は試さない・warn なし・onReady 1 回・true）', async () => {
+    const loadSpy = vi
+      .spyOn(Assets, 'load')
+      .mockImplementation((url: unknown) =>
+        String(url).endsWith('.webp')
+          ? (Promise.resolve(fakeTexture('webp')) as never)
+          : (Promise.resolve(fakeTexture('png')) as never)
+      )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const layer = new CharacterLayer(800, 450)
+    const sprite = new Sprite()
+    let onReadyCount = 0
+    const result = await asLoadable(layer).loadTexture(
+      sprite,
+      'spino',
+      EXPR,
+      BASE,
+      undefined,
+      false,
+      () => {
+        onReadyCount++
+      }
+    )
+    expect(result).toBe(true)
+    // webp が先頭で成功したので png は試されない（1 回のみ・webp URL）。
+    expect(loadSpy).toHaveBeenCalledTimes(1)
+    expect(loadSpy).toHaveBeenNthCalledWith(1, WEBP_URL)
+    expect(loadSpy).not.toHaveBeenCalledWith(PNG_URL)
+    // 使われた texture は webp。
+    expect(textureTag(sprite)).toBe('webp')
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(onReadyCount).toBe(1)
+  })
+
+  // 観点8: webp 失敗 → png 成功。png Texture へフォールバックし warn なし・onReady 1 回・戻り値 true。
+  it('webp が失敗し png が成功すれば png へフォールバックする（warn なし・onReady 1 回・true）', async () => {
+    const loadSpy = vi
+      .spyOn(Assets, 'load')
+      .mockImplementation((url: unknown) =>
+        String(url).endsWith('.webp')
+          ? (Promise.reject(new Error('webp 413')) as never)
+          : (Promise.resolve(fakeTexture('png')) as never)
+      )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const layer = new CharacterLayer(800, 450)
+    const sprite = new Sprite()
+    let onReadyCount = 0
+    const result = await asLoadable(layer).loadTexture(
+      sprite,
+      'spino',
+      EXPR,
+      BASE,
+      undefined,
+      false,
+      () => {
+        onReadyCount++
+      }
+    )
+    expect(result).toBe(true)
+    // webp → png の順で試し、png で成功する。
+    expect(loadSpy).toHaveBeenCalledTimes(2)
+    expect(loadSpy).toHaveBeenNthCalledWith(1, WEBP_URL)
+    expect(loadSpy).toHaveBeenNthCalledWith(2, PNG_URL)
+    // フォールバック先の png texture が使われる。
+    expect(textureTag(sprite)).toBe('png')
+    // webp が落ちても png が拾えたので警告は出さない。
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(onReadyCount).toBe(1)
+  })
+
+  // 観点9: 全滅（webp/png とも reject）→ console.warn が joined URL（' , ' 区切り）で 1 回・
+  //   第 2 引数は最後（png）のエラー・戻り値 false・onReady 1 回。
+  it('webp/png とも失敗なら warn（joined URL・最後のエラー）を 1 回出し false を返す（onReady 1 回）', async () => {
+    const webpErr = new Error('webp fail')
+    const pngErr = new Error('png fail')
+    const loadSpy = vi
+      .spyOn(Assets, 'load')
+      .mockImplementation((url: unknown) =>
+        String(url).endsWith('.webp')
+          ? (Promise.reject(webpErr) as never)
+          : (Promise.reject(pngErr) as never)
+      )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const layer = new CharacterLayer(800, 450)
+    const sprite = new Sprite()
+    let onReadyCount = 0
+    const result = await asLoadable(layer).loadTexture(
+      sprite,
+      'spino',
+      EXPR,
+      BASE,
+      undefined,
+      false,
+      () => {
+        onReadyCount++
+      }
+    )
+    expect(result).toBe(false)
+    // 先頭から順に両方試す。
+    expect(loadSpy).toHaveBeenCalledTimes(2)
+    expect(loadSpy).toHaveBeenNthCalledWith(1, WEBP_URL)
+    expect(loadSpy).toHaveBeenNthCalledWith(2, PNG_URL)
+    // warn は 1 回だけ。メッセージは joined URL（' , ' 区切り）、第 2 引数は最後（png）のエラー。
+    const expectedMsg = '[name-name] 立ち絵の読み込みに失敗: ' + [WEBP_URL, PNG_URL].join(' , ')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith(expectedMsg, pngErr)
+    expect(onReadyCount).toBe(1)
+  })
+
+  // 観点10: assetBaseUrl 空 → Assets.load を呼ばず即 true・onReady 1 回（描画不能でテキストを詰まらせない）。
+  it('assetBaseUrl が空ならロードせず即 true・onReady 1 回（Assets.load を呼ばない）', async () => {
+    const loadSpy = vi.spyOn(Assets, 'load')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const layer = new CharacterLayer(800, 450)
+    const sprite = new Sprite()
+    let onReadyCount = 0
+    const result = await asLoadable(layer).loadTexture(
+      sprite,
+      'spino',
+      EXPR,
+      '',
+      undefined,
+      false,
+      () => {
+        onReadyCount++
+      }
+    )
+    expect(result).toBe(true)
+    expect(loadSpy).not.toHaveBeenCalled()
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(onReadyCount).toBe(1)
+  })
+
+  // 観点11: onReady はどの経路でも複数回発火しない。成功 / フォールバック / 全滅の 3 経路を通し、
+  //   各経路で onReady 呼び出しがちょうど 1 回であることを縛る（#293 の finally ちょうど 1 回）。
+  it('onReady は成功・フォールバック・全滅のいずれの経路でもちょうど 1 回だけ発火する', async () => {
+    const layer = new CharacterLayer(800, 450)
+
+    // 成功経路（webp 成功）。
+    let successCount = 0
+    vi.spyOn(Assets, 'load').mockResolvedValue(fakeTexture('webp') as never)
+    await asLoadable(layer).loadTexture(new Sprite(), 'a', EXPR, BASE, undefined, false, () => {
+      successCount++
+    })
+    expect(successCount).toBe(1)
+    vi.restoreAllMocks()
+
+    // フォールバック経路（webp 失敗 → png 成功）。
+    let fallbackCount = 0
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(Assets, 'load').mockImplementation((url: unknown) =>
+      String(url).endsWith('.webp')
+        ? (Promise.reject(new Error('x')) as never)
+        : (Promise.resolve(fakeTexture('png')) as never)
+    )
+    await asLoadable(layer).loadTexture(new Sprite(), 'b', EXPR, BASE, undefined, false, () => {
+      fallbackCount++
+    })
+    expect(fallbackCount).toBe(1)
+    vi.restoreAllMocks()
+
+    // 全滅経路（webp/png とも失敗）。
+    let failCount = 0
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(Assets, 'load').mockRejectedValue(new Error('all fail'))
+    await asLoadable(layer).loadTexture(new Sprite(), 'c', EXPR, BASE, undefined, false, () => {
+      failCount++
+    })
+    expect(failCount).toBe(1)
   })
 })

--- a/frontend/src/game/CharacterLayer.ts
+++ b/frontend/src/game/CharacterLayer.ts
@@ -31,9 +31,31 @@ import {
   type UnderlineParams,
 } from './underline'
 // 色パーサ・2D 位置・URL 解決は novelLayout.ts（色/幾何の純関数置き場）に集約 (#273 / #274)。
-import { parseColorToNumber, resolvePositionWithOverride, resolveAssetUrl } from './novelLayout'
+import {
+  parseColorToNumber,
+  resolvePositionWithOverride,
+  resolveAssetUrl,
+  resolveCharacterImageUrls,
+} from './novelLayout'
 import { startTypewriter, tickTypewriter, type TypewriterState } from './typewriter'
 import { hasOwn, safeAssign } from './ownProperty'
+
+/**
+ * URL 候補を先頭から順に Assets.load し、最初に成功した読み込み結果を返す (#376)。
+ * webp→png フォールバック用。すべて失敗したら最後のエラーで reject する。
+ * 候補が 1 本だけなら従来通り単純ロードと等価。
+ */
+async function loadFirstAvailableTexture(urls: string[]): Promise<unknown> {
+  let lastError: unknown
+  for (const url of urls) {
+    try {
+      return await Assets.load(url)
+    } catch (err) {
+      lastError = err
+    }
+  }
+  throw lastError
+}
 
 /** キャラクターの画面上の配置位置（screenWidth に対する比率） */
 const CHARACTER_X_RATIO: Record<string, number> = {
@@ -2422,11 +2444,12 @@ export class CharacterLayer extends Container {
     }
 
     const cleanExpression = expression.replace(/^\//, '')
-    const url = `${assetBaseUrl}/images/${cleanExpression}.png`
+    const urls = resolveCharacterImageUrls(assetBaseUrl, cleanExpression)
 
     return (
-      Assets.load(url)
-        .then((texture) => {
+      loadFirstAvailableTexture(urls)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- 候補順ロードのため戻り値を unknown で束ねる。texture は従来 Assets.load が返す Texture と同一 (#376)
+        .then((texture: any) => {
           // destroy 後に解決した場合は反映しない（UAF 防止）。ただし ready 通知 (#293) は
           // finally で発火させ、テキスト側の待ちを必ず解く（sprite が消えても永久待ちにしない）。
           if (sprite.destroyed) return false
@@ -2475,7 +2498,7 @@ export class CharacterLayer extends Container {
           return true
         })
         .catch((err) => {
-          console.warn('[name-name] 立ち絵の読み込みに失敗: ' + url, err)
+          console.warn('[name-name] 立ち絵の読み込みに失敗: ' + urls.join(' , '), err)
           return false
         })
         // 成功/失敗/破棄いずれでも ready を1回だけ通知する (#293)。これでテキスト reveal が

--- a/frontend/src/game/CharacterLayer.ts
+++ b/frontend/src/game/CharacterLayer.ts
@@ -4,7 +4,7 @@
  * PixiJS Container 上でキャラクター立ち絵の表示・表情変更・退場を管理する。
  */
 
-import { Assets, Container, Graphics, Sprite, Text, TextStyle, Ticker } from 'pixi.js'
+import { Assets, Container, Graphics, Sprite, Text, Texture, TextStyle, Ticker } from 'pixi.js'
 import type { Easing } from '../types'
 import { applyEasing, resolveDelta } from './easing'
 import { ensureFontLoaded } from './FontLoader'
@@ -45,11 +45,11 @@ import { hasOwn, safeAssign } from './ownProperty'
  * webp→png フォールバック用。すべて失敗したら最後のエラーで reject する。
  * 候補が 1 本だけなら従来通り単純ロードと等価。
  */
-async function loadFirstAvailableTexture(urls: string[]): Promise<unknown> {
+async function loadFirstAvailableTexture(urls: string[]): Promise<Texture> {
   let lastError: unknown
   for (const url of urls) {
     try {
-      return await Assets.load(url)
+      return await Assets.load<Texture>(url)
     } catch (err) {
       lastError = err
     }
@@ -2448,8 +2448,7 @@ export class CharacterLayer extends Container {
 
     return (
       loadFirstAvailableTexture(urls)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- 候補順ロードのため戻り値を unknown で束ねる。texture は従来 Assets.load が返す Texture と同一 (#376)
-        .then((texture: any) => {
+        .then((texture) => {
           // destroy 後に解決した場合は反映しない（UAF 防止）。ただし ready 通知 (#293) は
           // finally で発火させ、テキスト側の待ちを必ず解く（sprite が消えても永久待ちにしない）。
           if (sprite.destroyed) return false

--- a/frontend/src/game/novelLayout.test.ts
+++ b/frontend/src/game/novelLayout.test.ts
@@ -4,6 +4,7 @@ import {
   parseHexColor,
   parseColorToNumber,
   resolveAssetUrl,
+  resolveCharacterImageUrls,
   saveSlotToGameState,
   resolveFontFamily,
   formatCounterText,
@@ -256,6 +257,78 @@ describe('resolveAssetUrl', () => {
     expect(resolveAssetUrl('/assets', 'sounds', '/bgm.mp3')).toBe('/assets/sounds/bgm.mp3')
     // 二重スラッシュは 1 つだけ落ちる（元 replace(/^\//) の挙動）
     expect(resolveAssetUrl('/assets', 'sounds', '//bgm.mp3')).toBe('/assets/sounds//bgm.mp3')
+  })
+})
+
+// =====================================================================================
+// #376: resolveCharacterImageUrls（立ち絵の webp→png フォールバック候補列）。
+//   拡張子なしは [.webp, .png] の 2 候補（webp 先）、明示指定は 1 本だけ（多重拡張子を作らない）、
+//   拡張子判定は大小無視。各候補は resolveAssetUrl 経由なので images/ prefix と先頭 / 除去が効く。
+//   期待 URL は資料値の直書きでなく resolveAssetUrl で組み立てて陳腐化を防ぐ（doctrine 規律4）。
+// =====================================================================================
+describe('resolveCharacterImageUrls (#376)', () => {
+  // 観点1: 拡張子なしは webp→png の 2 候補で、[0]=webp / [1]=png・各 URL は resolveAssetUrl 経由。
+  it('拡張子なしは [.webp, .png] の 2 候補（webp が [0]・png が [1]）', () => {
+    const base = 'https://x'
+    const urls = resolveCharacterImageUrls(base, 'spino/soften')
+    expect(urls).toEqual([
+      resolveAssetUrl(base, 'images', 'spino/soften.webp'),
+      resolveAssetUrl(base, 'images', 'spino/soften.png'),
+    ])
+    expect(urls.length).toBe(2)
+    expect(urls[0].endsWith('.webp')).toBe(true)
+    expect(urls[1].endsWith('.png')).toBe(true)
+  })
+
+  // 観点2: 先頭 / 付きパス → resolveAssetUrl の先頭スラッシュ除去が効き images// にならない。
+  it('先頭 / 付きパスは resolveAssetUrl が先頭スラッシュを 1 つ落とす（images// にならない）', () => {
+    const base = 'https://x'
+    const urls = resolveCharacterImageUrls(base, '/spino/x')
+    expect(urls).toEqual([
+      resolveAssetUrl(base, 'images', '/spino/x.webp'),
+      resolveAssetUrl(base, 'images', '/spino/x.png'),
+    ])
+    // 具体形の確認: images// の二重スラッシュを作らない。
+    expect(urls[0]).toBe('https://x/images/spino/x.webp')
+    expect(urls[1]).toBe('https://x/images/spino/x.png')
+    expect(urls[0]).not.toContain('images//')
+    expect(urls[1]).not.toContain('images//')
+  })
+
+  // 観点3: .webp 明示指定は 1 本のみ（png を追加しない）。
+  it('.webp 明示指定は 1 本のみ（png を足さない）', () => {
+    const base = 'https://x'
+    const urls = resolveCharacterImageUrls(base, 'spino/soften.webp')
+    expect(urls).toEqual([resolveAssetUrl(base, 'images', 'spino/soften.webp')])
+    expect(urls.length).toBe(1)
+  })
+
+  // 観点4: .png 明示指定は 1 本のみ（webp を追加しない・.png.png の多重拡張子を作らない）。
+  it('.png 明示指定は 1 本のみ（webp を足さない・.png.png にしない）', () => {
+    const base = 'https://x'
+    const urls = resolveCharacterImageUrls(base, 'spino/soften.png')
+    expect(urls).toEqual([resolveAssetUrl(base, 'images', 'spino/soften.png')])
+    expect(urls.length).toBe(1)
+    expect(urls[0].endsWith('.png.png')).toBe(false)
+  })
+
+  // 観点5: 拡張子判定は toLowerCase() で大小無視。.WEBP / .PNG / .Png / .WebP はすべて明示扱い＝1 本。
+  it.each(['a/b.WEBP', 'a/b.PNG', 'a/b.Png', 'a/b.WebP'])(
+    '拡張子判定は大小無視: %s は明示指定扱いで 1 本のみ（元の大小を保持した URL）',
+    (path) => {
+      const base = 'https://x'
+      const urls = resolveCharacterImageUrls(base, path)
+      // 明示扱いなので候補は 1 本。URL は cleanPath をそのまま（大小を潰さず）連結する。
+      expect(urls).toEqual([resolveAssetUrl(base, 'images', path)])
+      expect(urls.length).toBe(1)
+    }
+  )
+
+  // 観点6: baseUrl は末尾スラッシュなし前提で /images/ を 1 つの / で挟んで連結する。
+  it('baseUrl 末尾スラッシュなし前提で https://x/images/... に連結する', () => {
+    const urls = resolveCharacterImageUrls('https://cdn.example.com', 'hero/smile')
+    expect(urls[0]).toBe('https://cdn.example.com/images/hero/smile.webp')
+    expect(urls[1]).toBe('https://cdn.example.com/images/hero/smile.png')
   })
 })
 

--- a/frontend/src/game/novelLayout.ts
+++ b/frontend/src/game/novelLayout.ts
@@ -273,6 +273,30 @@ export function resolveAssetUrl(baseUrl: string, kind: AssetKind, path: string):
 }
 
 /**
+ * 立ち絵（拡張子を省略したキャラ画像）を配信 URL に解決する候補列を優先順で返す (#376)。
+ *
+ * エンジンは従来 `${base}/images/{path}/{expr}.png` と `.png` 固定で読み込んでいたが、
+ * 2倍解像度 PNG が name-name-api の 1 MiB 安全上限を超えて 413 になる作品向けに、
+ * **軽量 webp を先に試し、無ければ png にフォールバック**する。呼び出し側（CharacterLayer.loadTexture）は
+ * 返った候補を先頭から Assets.load し、最初に成功した Texture を使う。
+ *
+ * - 拡張子なし（従来の立ち絵パス `char/expr`）→ `[.webp, .png]` の 2 候補。
+ * - 既に `.webp` / `.png` が付いている（明示指定）→ その 1 本だけ（`.png.png` のような多重拡張子を避ける）。
+ *
+ * 背景・単独画像・portrait は呼び出し側が拡張子を明記するのでここは通らない（それらは resolveAssetUrl を直接使う）。
+ */
+export function resolveCharacterImageUrls(baseUrl: string, cleanPath: string): string[] {
+  const lower = cleanPath.toLowerCase()
+  if (lower.endsWith('.webp') || lower.endsWith('.png')) {
+    return [resolveAssetUrl(baseUrl, 'images', cleanPath)]
+  }
+  return [
+    resolveAssetUrl(baseUrl, 'images', `${cleanPath}.webp`),
+    resolveAssetUrl(baseUrl, 'images', `${cleanPath}.png`),
+  ]
+}
+
+/**
  * セーブスロットデータ (`SaveSlotData`) を復元用の `NovelGameState` に変換する純粋関数。
  *
  * 元 `NovelRenderer.loadFromSaveData` 内に直書きされていた state 構築ブロックと同一の


### PR DESCRIPTION
## 関連 Issue
closes #376

## 背景
- name-name-api の raw asset 配信は 1ファイル **1 MiB が安全上限**（超えると 413）。この安全弁は**維持**する。
- エンジンは立ち絵を `**Name** (path/expression, 位置)` から `assets/images/{path}/{expression}.png` と **`.png` 固定**で読み込んでいたため、2倍解像度 PNG が 1 MiB を超えると表示できなかった（theo-hayami の住人立ち絵で発生）。軽量 webp を置いても `.png` 固定なので参照されなかった。

## 変更内容
拡張子が省略されたキャラ画像パスを **`.webp` を先に試し、無ければ `.png` にフォールバック**して解決するようにした。これで作品は 1 MiB 制限内の軽量 webp 立ち絵を使える。

- **`frontend/src/game/novelLayout.ts`**: 純粋関数 `resolveCharacterImageUrls(baseUrl, cleanPath): string[]` を追加（`resolveAssetUrl` の直後）。拡張子なし→`[.webp, .png]` の2候補、`.webp`/`.png` 明示（大小無視）→その1本のみ（`.png.png` 等の多重拡張子を回避）。
- **`frontend/src/game/CharacterLayer.ts`**: module-scope `loadFirstAvailableTexture(urls)`（候補を先頭から `Assets.load` し最初の成功を返す・全滅時は最後のエラーで reject）を追加。`loadTexture` を `resolveCharacterImageUrls` + `loadFirstAvailableTexture` に差し替え。スケール処理（fit / character_height_ratio / fitLabelToSprite）と onReady の finally 1回発火（#293）は不変。全滅時のみ warn。
- **`docs/spec/llll-ll-media-impl-gaps.md`**: 立ち絵の画像解決を webp→png フォールバックに更新。
- **テスト14件**（`novelLayout.test.ts` 9・`CharacterLayer.test.ts` 5）: 候補列の境界（拡張子なし/明示/大小/多重拡張子回避/先頭スラッシュ）＋ロード挙動（webp成功・webp失敗→png成功・全滅warn・空baseUrl・onReady各経路ちょうど1回）。

## スコープ / 非変更
- frontend のキャラ画像 URL 解決のみ。**worker / 1 MiB 制限は一切変更していない**。
- 背景（`[背景: ...]`）・単独画像（`[画像: ...]`）・DialogBox portrait は拡張子明記なので対象外・非変更。

## 検証
- `npm run type-check` / `npm run lint`: 緑
- `npm test -- --run`（全テスト）: **64 files / 1677 tests passed**

## 関連
- 作品側の webp 化: theo-hayami #22（本 PR がデプロイされてから webp 立ち絵が参照される）