### PR TITLE
プレイヤーに特定scene/scriptへの直接ディープリンクを追加

### DIFF
--- a/docs/adr/0002-deterministic-state-and-debuggability.md
+++ b/docs/adr/0002-deterministic-state-and-debuggability.md
@@ -117,6 +117,46 @@ renderer.startFrom({
 `import.meta.env.DEV` の場合のみ有効。本番では無視する。
 実装: 純粋パーサ `frontend/src/game/debugQuery.ts` の `parseDebugQuery(search)` が `{script}` / `{scene}` / `null` を返し、`NovelPlayer.tsx` が `setScenes` 後に DEV ガード付きで `playScript`/`startFrom` を呼ぶ。`debug_script` 優先。vitest 20 ケース。**これで #220 の全 Phase（1 playScript / 2 startFrom / 3 URL クエリ）が完了。**
 
+### 5. `?scene=` ディープリンク + confinement（在圏）+ 終劇（`storyEnded`）（#386、production 対応）✅ 実装済み（2026-07-04）
+
+Phase 3 の `debug_scene` は開発環境限定のデバッグ起点だった。production でも常時有効な
+「特定シーンへの直接ディープリンク」は別系統として追加する。両者の違い:
+
+| | `debug_scene`（#220 Phase 3） | `?scene=`（#386） |
+| --- | --- | --- |
+| 有効ビルド | DEV のみ（`import.meta.env.DEV`。production は配線ごと tree-shake） | production 含め常時 |
+| 指定できる状態 | scene + flags + eventIndex + textIndex | scene（sceneId）のみ |
+| 用途 | バグ再現・デバッグ起点の共有 | 特定シーンの直接埋め込み（theo-hayami の会話劇セル1本を外部ページに埋め込む用途） |
+| パーサ | `debugQuery.ts` の `parseDebugQuery` | `sceneQuery.ts` の `parseSceneQuery` |
+| 遷移範囲 | 無制限（通常のハブ経由フローと同じ） | 対象ファイル自身に confinement（在圏）される |
+
+`NovelPlayer` は両方を配線するが、`initialSceneId`（`?scene=` 由来）を `debug_scene` ブロックより
+前に評価するため、DEV で両方指定された場合は `debug_scene` が後勝ちで優先される（デバッグ目的の
+上書きを production 経路より優先させる）。
+
+`?scene=` 単独埋め込みは対象ファイル外（hub・他ファイル）への choice ジャンプを許さない
+（theo-hayami #20: 他ファイルへの遷移は choice ではなく埋め込み外側の HTML リンクで行う設計）。
+`PlayerScreen` が対象ファイル自身の sceneId 一覧（entry doc/hub 自身は除く）を
+`NovelRenderer.setConfinedSceneIds` に渡し、`jumpToScene`（唯一の choke point）はこの集合外への
+遷移を検知すると通常のシーン遷移をせず `endStory()` を呼ぶ。`?scene=` が hub 自身の sceneId を
+指した場合は confinement を組まず無制限フローにフォールバックする（hub → 各お題への通常 choice
+遷移を壊さないため）。
+
+`endStory()` は `NovelGameState.storyEnded` という**宣言的フラグ**を true にする。この設計は
+本 ADR の核心（演出の中間状態を持たない・完全にシリアライズ可能）にそのまま従う: 背景・立ち絵の
+フェードアウト自体は一度きりの見た目でしかなく、状態として確定するのは「背景も立ち絵もない
+終劇後」という終端値だけである。`getSnapshot()`/`applyState()` は他のフィールドと同様に
+`storyEnded` をそのまま往復し（goBack/seekTo/startFrom/loadFromSaveData いずれも即時反映、
+フェードの再生はしない）。ただしセーブだけは例外で、`saveSlotToGameState` は常に `false` を返す
+（セーブは終劇状態を持ち越さない設計。終劇後の eventIndex をそのままセーブすると、ロード時に
+「`storyEnded=false` なのに choice イベント位置で止まっている」行き止まりになるため）。
+`quickSave()`/`openSaveMenu()` は `storyEnded` 中は no-op（終劇後のセーブによる行き止まり防止）、
+`quickLoad()`/`openLoadMenu()` は許可する（脱出手段として維持）。
+
+実装: `frontend/src/game/sceneQuery.ts`（`parseSceneQuery`）、`frontend/src/game/sceneConfinement.ts`
+（`isSceneIdConfined`）、`NovelRenderer.setConfinedSceneIds`/`endStory`/`setOnStoryEndedChange`、
+`PlayerScreen.findConfinedSceneIds`。
+
 ## Consequences（影響）
 
 ### 利点
@@ -135,7 +175,10 @@ renderer.startFrom({
 ## 関連
 
 - `GameState.ts`: `NovelGameState` 定義
-- `NovelRenderer.ts`: `applyState`、`restoreToScene`（`startFrom`/`loadFromSaveData` 共通コア）、`seekTo`、`advance`、`jumpToScene`
-- `docs/architecture.md`: 「状態管理: NovelGameState」セクション
+- `NovelRenderer.ts`: `applyState`、`restoreToScene`（`startFrom`/`loadFromSaveData` 共通コア）、`seekTo`、`advance`、`jumpToScene`、`setConfinedSceneIds`、`endStory`
+- `frontend/src/game/sceneQuery.ts` / `frontend/src/game/sceneConfinement.ts`: `?scene=` パーサ・confinement 判定（#386）
+- `docs/architecture.md`: 「状態管理: NovelGameState」セクション、「production 向けシーン直接ディープリンク `?scene=`」セクション
+- `docs/guide/debugger.md`: `debug_scene`（DEV 専用）の使い方ガイド
 - Issue #220: `playScript` / `startFrom` 実装
 - Issue #256: `startFrom` / `loadFromSaveData` の状態復元コア共通化（`restoreToScene`）
+- Issue #386: `?scene=` ディープリンク + confinement + 終劇（`storyEnded`）

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,6 +128,34 @@ basename が `script.md`** のもの（無ければ先頭）を選ぶ。
 重複は warn）。なおエントリ doc のみが RPG 判定・`aspect_ratio`/`choice_style`/`font_family`/
 `font_size`/`dialog_style`/`protagonist` の供給元（サブ MD の RPG シーンは未対応）。
 
+#### production 向けシーン直接ディープリンク `?scene=`（#386）
+
+`?scene=<sceneId>` は production ビルドでも常時有効な、特定シーンへの直接埋め込み用の入口。
+`import.meta.env.DEV` 限定の `debug_scene`（[デバッグガイド](./guide/debugger.md) 参照。flags/
+eventIndex/textIndex も指定できるデバッグ起点）とは別系統で、こちらは sceneId 単体のみを受け取る
+最小限のパーサ（`frontend/src/game/sceneQuery.ts` の `parseSceneQuery`）。theo-hayami の
+「1 セル 1 URL＝1 遅延埋め込み」設計のための経路で、他 .md の会話劇セルを 1 本だけ外部ページに
+埋め込むときに使う。
+
+`PlayerScreen` が `?scene=` を読み、対象 sceneId が属する script を（上記の missing scene
+resolver 経由で）事前解決・ロードしてから `NovelPlayer` に `initialSceneId` として渡す。
+`NovelPlayer` はマウント時に一度だけ `renderer.startFrom({ sceneId: initialSceneId })` を呼ぶ
+（DEV 専用の `debug_scene` ブロックより前に評価するため、DEV で両方指定されると `debug_scene`
+側が後勝ちで優先される）。無効・未解決の sceneId は現行どおりエントリ（ハブ）から開始する。
+
+**confinement（在圏）+ 終劇**: 単独埋め込みは対象 script ファイルの外（hub・他ファイル）へ
+choice で漏れてはいけない（theo-hayami #20: 他ファイルへの遷移は choice ではなく埋め込み外側の
+HTML リンクで行う設計）。`PlayerScreen` の `findConfinedSceneIds(targetSceneId, docs, entryPath)`
+が対象 sceneId が属する script ファイル自身の sceneId 一覧を算出し（entry doc/hub 自身は候補から
+除外）、`NovelPlayer` → `NovelRenderer.setConfinedSceneIds` に渡す。`jumpToScene`（唯一の
+choke point）はこの集合外への遷移を検知すると通常のシーン遷移をせず `endStory()` を呼び、
+`NovelGameState.storyEnded` を true にする（背景・立ち絵はフェードアウトし、DOM 側は控えめな
+"to be continued..." を表示する）。`?scene=` が hub 自身の sceneId を指した場合は
+`findConfinedSceneIds` が null を返し、confinement を組まず無制限フローにフォールバックする
+（hub → 各お題への通常 choice 遷移を壊さないため）。`storyEnded` の設計上の位置づけ
+（ADR 0002 の「演出の中間状態を持たない」規律との関係）は
+[ADR 0002](./adr/0002-deterministic-state-and-debuggability.md) を参照。
+
 ### 再生時
 
 ```
@@ -236,6 +264,7 @@ interface NovelGameState {
   isBlackout: boolean; // 暗転中か
   characters: Array<{ name: string; expression: string; position: string }>; // 立ち絵のみ。タイトル/ラベル/画像は演出表示(renderOnly)で除外(#274)
   currentBgmPath: string | null; // 再生中のBGM
+  storyEnded: boolean; // 終劇状態（#386）。confinement（在圏）外への choice ジャンプで true になる宣言的フラグ。演出の中間状態ではない
 }
 ```
 
@@ -259,6 +288,8 @@ interface NovelGameState {
 | `applyState(state)`                                     | スナップショットから画面を復元                                                                                                                   |
 | `playScript(steps)`                                     | 操作列（`advance`/`choice`/`wait`）を決定論的にリプレイ（#220 Phase 1、デバッグ/テスト用。再生中 msPerChar=0、完了・例外時に復元、再入は throw） |
 | `startFrom({sceneId, flags?, eventIndex?, textIndex?})` | 任意シーン+フラグ状態から開始（#220 Phase 2、デバッグ/テスト用。history リセット、flags 置換、不正 sceneId は完全 no-op）                        |
+| `setConfinedSceneIds(ids \| null)`                       | confinement（在圏）一覧を設定する（#386）。null（既定）なら制限なし。設定すると `jumpToScene` はこの集合外への遷移を通常のシーン遷移にせず `endStory()`（終劇）にする。呼び出し元は `PlayerScreen`（`?scene=` ディープリンク単独埋め込み時のみ） |
+| `setOnStoryEndedChange(cb)`                              | 終劇状態の変化コールバックを登録する（#386）。`NovelPlayer` が "to be continued..." の DOM 表示に使う                                              |
 
 ## レンダリングパイプライン
 

--- a/docs/guide/debugger.md
+++ b/docs/guide/debugger.md
@@ -5,6 +5,13 @@ Name×Name のノベルプレイヤーは、**任意のシーン・状態を URL
 
 エディタ／プレイヤーの基本操作は [操作ガイド](./controls.md)・[エディタガイド](./editor.md) を参照。
 
+> **`?scene=` との違い**: このページで扱う `debug_scene` 系クエリは DEV ビルド限定のデバッグ起点。
+> production でも常時有効な特定シーンへの直接ディープリンクは `?scene=<sceneId>`（#386）で、
+> 別系統・別パーサ（`sceneQuery.ts`）。sceneId 単体のみ指定でき、対象ファイル自身に
+> confinement（在圏）されて hub 等の圏外へは「終劇」扱いになる。詳細は
+> [`docs/architecture.md`](../architecture.md) の「production 向けシーン直接ディープリンク
+> `?scene=`」セクションと [ADR 0002](../adr/0002-deterministic-state-and-debuggability.md) を参照。
+
 ## URL クエリで起点を指定する（DEV ビルド限定）
 
 `import.meta.env.DEV` のときだけ有効。production ビルドでは配線ごと tree-shake され、URL を付けても何も起きない（`NovelPlayer.tsx`）。また `scenes` を渡す経路（`setScenes`）でのみ動く。

--- a/frontend/src/components/NovelPlayer.test.tsx
+++ b/frontend/src/components/NovelPlayer.test.tsx
@@ -34,6 +34,8 @@ const { rendererInstances, MockRenderer } = vi.hoisted(() => {
     setOnAutoModeChange = vi.fn()
     setOnSkipModeChange = vi.fn()
     setOnSeekActiveChange = vi.fn()
+    setOnStoryEndedChange = vi.fn()
+    setConfinedSceneIds = vi.fn()
     setDocKey = vi.fn()
     setChoiceStyle = vi.fn()
     setFontFamily = vi.fn()

--- a/frontend/src/components/NovelPlayer.test.tsx
+++ b/frontend/src/components/NovelPlayer.test.tsx
@@ -462,3 +462,94 @@ describe('NovelPlayer speakerNudge の renderer 転送 (#382)', () => {
     expect(r.setSpeakerNudge).toHaveBeenCalledWith(true)
   })
 })
+
+// --- #386: `?scene=` ディープリンク（initialSceneId）+ confinement + 終劇表示 ---
+//
+// PlayerScreen が解決した initialSceneId / confinedSceneIds をそのまま renderer に配線する
+// ことと、renderer.setOnStoryEndedChange 経由で届く終劇状態が "to be continued..." の
+// DOM 表示に反映されることを検証する。DEV 限定の debug_scene（#220）との優先順位
+// （initialSceneId → debug_scene の順に startFrom が呼ばれ、後勝ちで debug 側が効く）も含む。
+describe('NovelPlayer `?scene=` ディープリンク + confinement + 終劇表示 (#386)', () => {
+  const lastRenderer = () => rendererInstances[rendererInstances.length - 1]
+  const storyEndedText = () => screen.queryByText('to be continued...')
+
+  it('G1: initialSceneId を渡すと mount 時に renderer.startFrom({ sceneId }) が1回だけ呼ばれる', async () => {
+    render(<NovelPlayer events={[]} initialSceneId="scene-x" />)
+    await flushAsync()
+    const r = lastRenderer()
+    expect(r.startFrom).toHaveBeenCalledTimes(1)
+    expect(r.startFrom).toHaveBeenCalledWith({ sceneId: 'scene-x' })
+  })
+
+  it('G2: initialSceneId 未指定なら startFrom は呼ばれない', async () => {
+    render(<NovelPlayer events={[]} />)
+    await flushAsync()
+    expect(lastRenderer().startFrom).not.toHaveBeenCalled()
+  })
+
+  it('G3: initialSceneId={null} でも startFrom は呼ばれない', async () => {
+    render(<NovelPlayer events={[]} initialSceneId={null} />)
+    await flushAsync()
+    expect(lastRenderer().startFrom).not.toHaveBeenCalled()
+  })
+
+  it('G4: confinedSceneIds を渡すと mount 時に renderer.setConfinedSceneIds がその配列で呼ばれる', async () => {
+    render(<NovelPlayer events={[]} confinedSceneIds={['a', 'b']} />)
+    await flushAsync()
+    expect(lastRenderer().setConfinedSceneIds).toHaveBeenCalledWith(['a', 'b'])
+  })
+
+  it('G5: confinedSceneIds 未指定なら renderer.setConfinedSceneIds が null で呼ばれる（無制限＝後方互換）', async () => {
+    render(<NovelPlayer events={[]} />)
+    await flushAsync()
+    expect(lastRenderer().setConfinedSceneIds).toHaveBeenCalledWith(null)
+  })
+
+  it('G6: mount 直後（onStoryEndedChange 未発火）は "to be continued..." が現れない', async () => {
+    render(<NovelPlayer events={[]} />)
+    await flushAsync()
+    expect(storyEndedText()).toBeNull()
+  })
+
+  it('G7: onStoryEndedChange(true) が発火した時だけ "to be continued..." が表示される', async () => {
+    render(<NovelPlayer events={[]} />)
+    await flushAsync()
+    const cb = lastRenderer().setOnStoryEndedChange.mock.calls[0][0] as (ended: boolean) => void
+    act(() => cb(true))
+    expect(storyEndedText()).not.toBeNull()
+  })
+
+  it('G8: onStoryEndedChange(false) では "to be continued..." は現れない', async () => {
+    render(<NovelPlayer events={[]} />)
+    await flushAsync()
+    const cb = lastRenderer().setOnStoryEndedChange.mock.calls[0][0] as (ended: boolean) => void
+    act(() => cb(false))
+    expect(storyEndedText()).toBeNull()
+  })
+
+  it('G9: onStoryEndedChange(true) の後に false で発火し直すと "to be continued..." が消える', async () => {
+    render(<NovelPlayer events={[]} />)
+    await flushAsync()
+    const cb = lastRenderer().setOnStoryEndedChange.mock.calls[0][0] as (ended: boolean) => void
+    act(() => cb(true))
+    expect(storyEndedText()).not.toBeNull()
+    act(() => cb(false))
+    expect(storyEndedText()).toBeNull()
+  })
+
+  it('G10: DEV モードで `?scene=` 由来の initialSceneId と `?debug_scene=` が同時指定された場合、debug_scene 側の startFrom が後勝ちする', async () => {
+    window.history.pushState({}, '', '?debug_scene=dbg-scene')
+    try {
+      render(<NovelPlayer events={[]} initialSceneId="prod-scene" />)
+      await flushAsync()
+      const r = lastRenderer()
+      // initialSceneId(#386) が先に startFrom され、その後 DEV 限定の debug_scene(#220) が
+      // 上書きする（NovelPlayer 側のコメント通り、デバッグ目的の上書きを優先させる設計）。
+      expect(r.startFrom).toHaveBeenNthCalledWith(1, { sceneId: 'prod-scene' })
+      expect(r.startFrom).toHaveBeenNthCalledWith(2, { sceneId: 'dbg-scene' })
+      expect(r.startFrom).toHaveBeenCalledTimes(2)
+    } finally {
+      window.history.pushState({}, '', '/')
+    }
+  })
+})

--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -46,6 +46,15 @@ interface NovelPlayerProps {
   jumpSceneIndex?: EventScene[]
   /** 未ロード sceneId を必要時に追加解決する hook (#314)。 */
   onResolveMissingScene?: (sceneId: string) => Promise<EventScene[] | null>
+  /**
+   * production でも有効な起点シーン指定 (#386)。`?scene=<sceneId>` の解決結果を
+   * 呼び出し側（PlayerScreen）が渡す。渡す時点で対象 sceneId は `jumpSceneIndex` に
+   * 含まれている前提（クロスファイルの事前ロードは呼び出し側の責務）。
+   * マウント時に一度だけ `renderer.startFrom({ sceneId: initialSceneId })` を呼ぶ。
+   * 不正/未解決（jumpSceneIndex に無い）sceneId は startFrom 内で no-op になり、
+   * 通常のエントリ再生（events）にフォールバックする。null/undefined で指定なし。
+   */
+  initialSceneId?: string | null
   assetBaseUrl?: string
   /** 画面比率。"16:9" / "4:3" / "9:16"。デフォルト "16:9" (#136) */
   aspectRatio?: AspectRatio | string
@@ -113,6 +122,7 @@ function NovelPlayer({
   scenes,
   jumpSceneIndex,
   onResolveMissingScene,
+  initialSceneId,
   assetBaseUrl,
   aspectRatio: aspectRatioProp,
   choiceStyle,
@@ -246,9 +256,19 @@ function NovelPlayer({
         }
         renderer.setEvents(events)
       }
+      // production でも有効な起点シーン指定 (#386)。sceneId が属する script の事前ロードは
+      // PlayerScreen 側の責務（呼び出し時点で jumpSceneIndex に反映済みの前提）。ここでは
+      // 既存の startFrom(#220) をそのまま呼ぶだけで、renderer 側に新規ロジックは持ち込まない。
+      // 不正/未解決 sceneId は startFrom 内で no-op（現行どおりエントリ再生にフォールバック）。
+      if (initialSceneId) {
+        renderer.startFrom({ sceneId: initialSceneId })
+      }
+
       // URL クエリによるデバッグ起点指定 (#220 Phase 3)。
       // DEV ビルドでのみ有効。production ではこのブロックごと tree-shake される。
       // debug_scene は sceneId 前提。scenes / jumpSceneIndex のどちらの索引でも解決する。
+      // initialSceneId(#386) より後に評価するため、dev では debug_scene が指定時に優先される
+      // （デバッグ目的の上書きを production 経路より優先させる）。
       if (import.meta.env.DEV) {
         const debug = parseDebugQuery(window.location.search)
         if (debug && 'script' in debug) {

--- a/frontend/src/components/NovelPlayer.tsx
+++ b/frontend/src/components/NovelPlayer.tsx
@@ -55,6 +55,15 @@ interface NovelPlayerProps {
    * 通常のエントリ再生（events）にフォールバックする。null/undefined で指定なし。
    */
   initialSceneId?: string | null
+  /**
+   * `?scene=` ディープリンク単独埋め込みの confinement（在圏）一覧 (#386)。
+   * `initialSceneId` が属する script ファイル自身の sceneId 一覧を呼び出し側
+   * （PlayerScreen）が渡す。渡された場合、その集合の外への choice ジャンプ
+   * （hub や他ファイルへの「別の問いを聞く」等）は通常のシーン遷移にならず、
+   * 終劇（"to be continued..." 表示）になる（NovelRenderer.jumpToScene 参照）。
+   * null/undefined で制限なし（通常のハブ経由フロー、後方互換）。
+   */
+  confinedSceneIds?: string[] | null
   assetBaseUrl?: string
   /** 画面比率。"16:9" / "4:3" / "9:16"。デフォルト "16:9" (#136) */
   aspectRatio?: AspectRatio | string
@@ -123,6 +132,7 @@ function NovelPlayer({
   jumpSceneIndex,
   onResolveMissingScene,
   initialSceneId,
+  confinedSceneIds,
   assetBaseUrl,
   aspectRatio: aspectRatioProp,
   choiceStyle,
@@ -166,6 +176,10 @@ function NovelPlayer({
   // 演出/UI の transient 状態なので GameState には持たない（ADR 0002・renderer 側も transient）。
   const [seekActive, setSeekActive] = useState(false)
 
+  // 終劇状態 (#386)。renderer の onStoryEndedChange で同期する（GameState 上の宣言的フラグ
+  // NovelGameState.storyEnded のミラー）。true の間だけ「to be continued...」を表示する。
+  const [storyEnded, setStoryEnded] = useState(false)
+
   // デバッグ HUD の展開状態 (#310)。右下ボタン列の「D」ボタンで開閉する。
   // 既定は畳んだ状態（#301 の collapsed 既定 true を引き継ぐ＝open 既定 false）。
   // 状態は localStorage（旧 DebugOverlay と同じキー意味）に best-effort で永続化する。
@@ -197,12 +211,17 @@ function NovelPlayer({
         renderer.setAssetBaseUrl(assetBaseUrl)
       }
       renderer.setMissingSceneResolver?.(onResolveMissingScene ?? null)
+      // `?scene=` ディープリンク単独埋め込みの confinement (#386)。setEvents/setJumpSceneIndex/
+      // startFrom より前に設定し、以降のどの choice ジャンプも圏外判定の対象にする。
+      renderer.setConfinedSceneIds(confinedSceneIds ?? null)
       // renderer が手動操作で autoMode を OFF にしたとき React state を同期 (#139)
       renderer.setOnAutoModeChange((on) => setAutoMode(on))
       // renderer が未読到達で skipMode を OFF にしたとき React state を同期 (#140)
       renderer.setOnSkipModeChange((on) => setSkipMode(on))
       // スライダ操作中（active）は下部丸ボタン行をフェード退避させる (#350)
       renderer.setOnSeekActiveChange((active) => setSeekActive(active))
+      // 終劇状態が変化したら "to be continued..." の表示を同期する (#386)
+      renderer.setOnStoryEndedChange((ended) => setStoryEnded(ended))
       if (docKey) {
         renderer.setDocKey(docKey)
       }
@@ -605,6 +624,27 @@ function NovelPlayer({
           </button>
         )}
       </div>
+      {/* 終劇表示 (#386): confinement 外への choice ジャンプで NovelRenderer.endStory() が
+          発火した後に出す、控えめな "to be continued..." 表示。中央の大演出にはせず、
+          右下ボタン行より少し上（SLOT_BASE_PX + SLOT_GAP_PX ぶん）に小さく置く。
+          話者名・選択肢UIと区別するため斜体・低コントラストにする。背景/立ち絵のフェード
+          アウト自体は NovelRenderer 側（PixiJS）が行い、これはその後に重ねる DOM 側の文字。
+          pointer-events-none: タップしても何も起きない（advance は storyEnded で no-op のため
+          二重の安全策だが、見た目のヒットテストにも参加させない）。 */}
+      {storyEnded && (
+        <div className="absolute inset-0 m-auto pointer-events-none" style={gameBoxStyle}>
+          <p
+            className="absolute text-white/60 text-sm italic select-none"
+            style={{
+              right: `${SLOT_BASE_PX}px`,
+              bottom: `${SLOT_BASE_PX + SLOT_GAP_PX}px`,
+              fontFamily: fontFamily || undefined,
+            }}
+          >
+            to be continued...
+          </p>
+        </div>
+      )}
       <SettingsOverlay
         open={settingsOpen}
         onClose={() => setSettingsOpen(false)}

--- a/frontend/src/game/GameState.ts
+++ b/frontend/src/game/GameState.ts
@@ -77,6 +77,16 @@ export interface NovelGameState {
   isBlackout: boolean
   characters: Array<{ name: string; expression: string; position: string }>
   currentBgmPath: string | null
+  /**
+   * 終劇状態 (#386)。`?scene=` ディープリンク単独埋め込みの confinement（在圏）外へ
+   * choice でジャンプしようとしたときに true になる、宣言的なフラグ。
+   * 演出の中間状態ではない（ADR 0002 / 規律3）: フェード演出自体はこのフラグの発火に
+   * 付随する一度きりの見た目でしかなく、GameState としては「背景も立ち絵もない
+   * 終劇後」という終端状態を指す。goBack/seekTo/セーブ復元（applyState）はすべて
+   * このフラグをそのまま宣言的に反映する（フェードのやり直しはしない）。
+   * 通常のハブ経由フロー（confinement 無効）では常に false。
+   */
+  storyEnded: boolean
 }
 
 /**

--- a/frontend/src/game/NovelRenderer.confinement.test.ts
+++ b/frontend/src/game/NovelRenderer.confinement.test.ts
@@ -1,0 +1,215 @@
+/**
+ * NovelRenderer の confinement（在圏）判定 + 終劇（endStory）のテスト (#386)。
+ *
+ * `?scene=` ディープリンク単独埋め込みで `setConfinedSceneIds` が設定されているとき、
+ * `jumpToScene` がその集合の外への遷移を通常のシーン遷移ではなく終劇として扱う挙動を検証する。
+ * `startFrom.test.ts` / `backgroundCrossfade.test.ts` と同じく
+ * `new NovelRenderer()` → `setScenes(...)` の最小構成で行い、PixiJS 実描画は対象外
+ * （CLAUDE.md ルール7 の実機 golden path に委ねる）。
+ *
+ * 背景/立ち絵の非同期アセット読込を伴う状態は `loadFromSaveData.test.ts` と同じ理由で
+ * jsdom 検証の対象外とする（実機 golden path に委ねる）。backgroundPath/backgroundColor は
+ * アセット読込を経由せず同期的に確定するフィールドなので、これらだけを対象に
+ * 「endStory 後は全部クリアされる」ことを検証する（video/characters は既定値のまま据え置き、
+ * 純粋な状態遷移の検証として弱いが doctrine 通りの割り切り）。
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { Assets, Texture } from 'pixi.js'
+import { NovelRenderer } from './NovelRenderer'
+import { defaultTimeController } from './TimeController'
+import type { Event, EventScene } from '../types'
+
+// --- fixture helpers（startFrom.test.ts と同じスタイル） ---
+
+function narration(...lines: string[]): Event {
+  return { Narration: { text: lines } }
+}
+
+function scene(id: string, events: Event[]): EventScene {
+  return { id, title: id, view: 'TopDown', events }
+}
+
+/** confinement 検証用の内部アクセサ */
+interface RendererInternals {
+  setBackground(
+    path: string,
+    fade?: unknown,
+    brightness?: number | null,
+    opts?: { instant?: boolean }
+  ): void
+  setBackgroundColor(color: string): void
+  initialized: boolean
+}
+
+function internals(r: NovelRenderer): RendererInternals {
+  return r as unknown as RendererInternals
+}
+
+// entry: 在圏に含める / in-scene: 在圏に含める / out-scene: allScenes には実在するが圏外
+const SCENES: EventScene[] = [
+  scene('entry', [narration('start')]),
+  scene('in-scene', [narration('inside')]),
+  scene('out-scene', [narration('outside but exists in allScenes')]),
+]
+
+function makeRenderer(scenes: EventScene[]): NovelRenderer {
+  const r = new NovelRenderer()
+  r.setScenes(scenes)
+  return r
+}
+
+describe('NovelRenderer confinement / endStory (#386)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    defaultTimeController.setMode('live')
+  })
+
+  // ===== A. 後方互換: confinement 未設定 =====
+
+  it('17: confinement 未設定（既定 null）時、圏外相当の sceneId でも jumpToScene は通常遷移する（後方互換の核）', () => {
+    const r = makeRenderer(SCENES)
+    r.jumpToScene('out-scene')
+    expect(r.getCurrentSceneId()).toBe('out-scene')
+    expect(r.getSnapshot().storyEnded).toBe(false)
+  })
+
+  // ===== B. 在圏ジャンプは通常遷移 =====
+
+  it('18: confinement 設定後、在圏 scene への jumpToScene は通常遷移する', () => {
+    const r = makeRenderer(SCENES)
+    r.setConfinedSceneIds(['entry', 'in-scene'])
+    r.jumpToScene('in-scene')
+    expect(r.getCurrentSceneId()).toBe('in-scene')
+    expect(r.getSnapshot().storyEnded).toBe(false)
+  })
+
+  // ===== C. 圏外ジャンプ（allScenes に実在）は終劇 =====
+
+  it('19: confinement 設定後、圏外（allScenes に実在）sceneId への jumpToScene は storyEnded=true にする', () => {
+    const r = makeRenderer(SCENES)
+    r.setConfinedSceneIds(['entry', 'in-scene'])
+    r.jumpToScene('out-scene')
+    expect(r.getSnapshot().storyEnded).toBe(true)
+  })
+
+  it('20: 圏外ジャンプで console.warn は呼ばれない（シーン未発見扱いにしない）', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const r = makeRenderer(SCENES)
+    r.setConfinedSceneIds(['entry', 'in-scene'])
+    r.jumpToScene('out-scene')
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('21: 圏外かつ allScenes に存在しない sceneId への jumpToScene も終劇になり、missingSceneResolver は呼ばれない', () => {
+    const resolver = vi.fn().mockResolvedValue(null)
+    const r = makeRenderer(SCENES)
+    r.setConfinedSceneIds(['entry', 'in-scene'])
+    r.setMissingSceneResolver(resolver)
+    r.jumpToScene('totally-unknown-scene')
+    expect(r.getSnapshot().storyEnded).toBe(true)
+    expect(resolver).not.toHaveBeenCalled()
+  })
+
+  it('24: 終劇後も currentSceneId は変化しない（endStory は startScene を経由しない）', () => {
+    const r = makeRenderer(SCENES)
+    r.setConfinedSceneIds(['entry', 'in-scene'])
+    r.jumpToScene('out-scene')
+    expect(r.getCurrentSceneId()).toBe('entry')
+  })
+
+  // ===== D. 終劇後の入力無効化 =====
+
+  it('22: 終劇後、advance() を呼んでも eventIndex/textIndex 等のスナップショットは変化しない', () => {
+    const r = makeRenderer(SCENES)
+    r.setConfinedSceneIds(['entry'])
+    r.jumpToScene('out-scene')
+    const before = r.getSnapshot()
+    r.advance()
+    r.advance()
+    expect(r.getSnapshot()).toEqual(before)
+  })
+
+  // ===== E. 終劇後の宣言的終端状態 =====
+
+  it('23: 終劇後、getSnapshot() の backgroundPath/backgroundColor が null にクリアされる', () => {
+    const r = makeRenderer(SCENES)
+    // アセット読込を経由しない同期フィールドだけを事前に非 null にしておく
+    // （実際のテクスチャロードは jsdom 検証対象外・loadFromSaveData.test.ts と同じ割り切り）。
+    internals(r).setBackground('bg.png')
+    internals(r).setBackgroundColor('#112233')
+    expect(r.getSnapshot().backgroundPath).toBe('bg.png')
+    expect(r.getSnapshot().backgroundColor).toBe('#112233')
+
+    r.setConfinedSceneIds(['entry'])
+    r.jumpToScene('out-scene')
+
+    const s = r.getSnapshot()
+    expect(s.backgroundPath).toBeNull()
+    expect(s.backgroundColor).toBeNull()
+    // video/characters はアセット読込を経由するため事前に非 null 化していないが、
+    // 終劇後に「なし」であることは変わらず確認できる。
+    expect(s.video).toBeNull()
+    expect(s.characters).toEqual([])
+  })
+
+  // ===== F. 二重発火防止 =====
+
+  it('25: 終劇トリガーを2回連続しても、onStoryEndedChange コールバックは1回しか発火しない', () => {
+    const cb = vi.fn()
+    const r = makeRenderer(SCENES)
+    r.setOnStoryEndedChange(cb)
+    r.setConfinedSceneIds(['entry'])
+    r.jumpToScene('out-scene')
+    r.jumpToScene('out-scene') // 2回目（二重発火防止で早期 return するはず）
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(cb).toHaveBeenCalledWith(true)
+  })
+
+  // ===== G. 終劇からの復帰（startScene の安全弁） =====
+
+  it('26: 終劇後に在圏 scene へ jumpToScene すると storyEnded=false に戻り、callback が false で発火する', () => {
+    const cb = vi.fn()
+    const r = makeRenderer(SCENES)
+    r.setOnStoryEndedChange(cb)
+    r.setConfinedSceneIds(['entry', 'in-scene'])
+    r.jumpToScene('out-scene') // 圏外 → 終劇（storyEnded=true, cb(true)）
+    expect(r.getSnapshot().storyEnded).toBe(true)
+    cb.mockClear()
+
+    r.jumpToScene('in-scene') // 在圏 → 通常遷移。startScene の安全弁で false に戻る
+    expect(r.getSnapshot().storyEnded).toBe(false)
+    expect(r.getCurrentSceneId()).toBe('in-scene')
+    expect(cb).toHaveBeenCalledWith(false)
+  })
+
+  // ===== H. race: 背景ロード中の endStory =====
+
+  it('27: setBackground の非同期ロード中に endStory() が発火しても、後で元 promise が resolve しても backgroundPath は null のまま', async () => {
+    const r = makeRenderer(SCENES)
+    r.setAssetBaseUrl('/assets')
+    r.getTimeController().setMode('virtual')
+    internals(r).initialized = true
+    r.setConfinedSceneIds(['entry'])
+
+    let resolveLoad!: (texture: Texture) => void
+    vi.spyOn(Assets, 'load').mockReturnValue(
+      new Promise<Texture>((resolve) => {
+        resolveLoad = resolve
+      }) as never
+    )
+
+    // アセットキャッシュに無い背景 → Assets.load が pending のまま bgLoadToken を確保する。
+    internals(r).setBackground('pending.png')
+    expect(r.getSnapshot().backgroundPath).toBe('pending.png')
+
+    // 圏外ジャンプで endStory() が発火。bgLoadToken を進めて古いロードを無効化し、
+    // backgroundPath を即座に null に確定する。
+    r.jumpToScene('out-scene')
+    expect(r.getSnapshot().backgroundPath).toBeNull()
+
+    // 古い pending.png の読み込みが後から解決しても、endStory 後の状態を上書きしない。
+    resolveLoad(Texture.WHITE)
+    await Promise.resolve()
+    expect(r.getSnapshot().backgroundPath).toBeNull()
+  })
+})

--- a/frontend/src/game/NovelRenderer.confinement.test.ts
+++ b/frontend/src/game/NovelRenderer.confinement.test.ts
@@ -115,6 +115,8 @@ describe('NovelRenderer confinement / endStory (#386)', () => {
   })
 
   it('21: 圏外かつ allScenes に存在しない sceneId への jumpToScene も終劇になり、missingSceneResolver は呼ばれない', () => {
+    // このパスは Q1 の DEV console.warn（typo 診断）を踏むため silence する（テスト32 と同様・実行ログのノイズ防止）。
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const resolver = vi.fn().mockResolvedValue(null)
     const r = makeRenderer(SCENES)
     r.setConfinedSceneIds(['entry', 'in-scene'])
@@ -122,6 +124,7 @@ describe('NovelRenderer confinement / endStory (#386)', () => {
     r.jumpToScene('totally-unknown-scene')
     expect(r.getSnapshot().storyEnded).toBe(true)
     expect(resolver).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
   })
 
   it('24: 終劇後も currentSceneId は変化しない（endStory は startScene を経由しない）', () => {

--- a/frontend/src/game/NovelRenderer.confinement.test.ts
+++ b/frontend/src/game/NovelRenderer.confinement.test.ts
@@ -39,6 +39,11 @@ interface RendererInternals {
   ): void
   setBackgroundColor(color: string): void
   initialized: boolean
+  history: unknown[]
+  currentBgmPath: string | null
+  shakeTimer: number | null
+  effectTimer: number | null
+  effectOverlay: { alpha: number; visible: boolean } | null
 }
 
 function internals(r: NovelRenderer): RendererInternals {
@@ -48,6 +53,15 @@ function internals(r: NovelRenderer): RendererInternals {
 // entry: 在圏に含める / in-scene: 在圏に含める / out-scene: allScenes には実在するが圏外
 const SCENES: EventScene[] = [
   scene('entry', [narration('start')]),
+  scene('in-scene', [narration('inside')]),
+  scene('out-scene', [narration('outside but exists in allScenes')]),
+]
+
+// goBack/seekTo 回帰用: entry に複数イベントを持たせ、advance で history を複数積めるようにする
+// （pushSnapshot は「次のイベントへ」進んだときだけ発火するため、1 イベント/1 行の SCENES では
+// history.length が 1 のままになり goBack の history.pop() 分岐に届かない）。
+const SCENES_MULTI_EVENT: EventScene[] = [
+  scene('entry', [narration('one'), narration('two'), narration('three')]),
   scene('in-scene', [narration('inside')]),
   scene('out-scene', [narration('outside but exists in allScenes')]),
 ]
@@ -212,4 +226,109 @@ describe('NovelRenderer confinement / endStory (#386)', () => {
     await Promise.resolve()
     expect(r.getSnapshot().backgroundPath).toBeNull()
   })
+
+  // ===== I. 終劇後の goBack/seekTo 無効化 (#386 レビュー M1) =====
+  //
+  // endStory() は pushSnapshot() を呼ばない（新しいシーンへ進んだわけではないため）。
+  // そのため history の末尾には、confinement 違反前の最後のテキストイベント
+  // （storyEnded: false のスナップショット）がそのまま残っている。goBack()/seekTo() を
+  // storyEnded でガードしないと、終劇後にこれらを呼ぶと applyState() が storyEnded を
+  // false に巻き戻し、"to be continued..." が消えて背景/立ち絵/BGM が直前の状態に
+  // 戻ってしまう（終劇の無効化）。
+
+  it('28: 終劇後に goBack() を呼んでも storyEnded は true のまま維持される（M1 回帰）', async () => {
+    const r = makeRenderer(SCENES_MULTI_EVENT)
+    // entry (one/two/three の3イベント) を2回 advance して history を複数積む。
+    await r.playScript([{ type: 'advance' }, { type: 'advance' }])
+    expect(internals(r).history.length).toBeGreaterThan(1)
+
+    r.setConfinedSceneIds(['entry'])
+    r.jumpToScene('out-scene') // 圏外 → 終劇
+    expect(r.getSnapshot().storyEnded).toBe(true)
+    const historyLenAfterEnd = internals(r).history.length
+
+    r.goBack()
+    expect(r.getSnapshot().storyEnded).toBe(true)
+    // 早期 return で history.pop() にも到達しない（history 自体も不変）。
+    expect(internals(r).history.length).toBe(historyLenAfterEnd)
+  })
+
+  it('29: 終劇後に seekTo() を呼んでも storyEnded は true のまま維持される（M1 回帰: SeekBar ドラッグでの巻き戻し防止）', async () => {
+    const r = makeRenderer(SCENES_MULTI_EVENT)
+    await r.playScript([{ type: 'advance' }, { type: 'advance' }])
+    expect(internals(r).history.length).toBeGreaterThan(1)
+
+    r.setConfinedSceneIds(['entry'])
+    r.jumpToScene('out-scene') // 圏外 → 終劇
+    expect(r.getSnapshot().storyEnded).toBe(true)
+
+    r.seekTo(0) // history の先頭（storyEnded: false の時点）へ戻ろうとする
+    expect(r.getSnapshot().storyEnded).toBe(true)
+  })
+
+  // ===== J. 終劇後の BGM 停止 (#386 レビュー M2) =====
+  //
+  // resetAndStartEvents()（通常のシーン遷移）は毎回 stopBgm(0) + currentBgmPath=null するが、
+  // endStory() にはこれが無かった。終劇は物語上の終端で以後 Bgm イベントは来ないため、
+  // 一度このバグを踏むと BGM が永久に鳴り続ける（初見訪問者にはセーブが無く止める手段がない）。
+  // playBgm() 自体は AudioContext/アセット読込を伴い jsdom 対象外のため、他のテストと同じく
+  // 追跡フィールド（currentBgmPath）だけ直接セットし、stopBgm 呼び出しはスパイで検証する。
+
+  it('30: endStory() は BGM を停止し currentBgmPath を null にする（M2 回帰）', () => {
+    const r = makeRenderer(SCENES)
+    const stopBgmSpy = vi.spyOn(r.getAudioManager(), 'stopBgm').mockImplementation(() => {})
+    internals(r).currentBgmPath = 'bgm/loop.mp3'
+    expect(r.getSnapshot().currentBgmPath).toBe('bgm/loop.mp3')
+
+    r.setConfinedSceneIds(['entry'])
+    r.jumpToScene('out-scene')
+
+    expect(stopBgmSpy).toHaveBeenCalled()
+    expect(r.getSnapshot().currentBgmPath).toBeNull()
+  })
+
+  // ===== K. 終劇後の画面効果クリア (#386 レビュー S1) =====
+  //
+  // Shake/Flash/Fade は fire-and-forget なタイマー演出。これらを仕込んだ直後の text から
+  // confinement 外への choice が続くシーンでは、endStory() 後もタイマー/オーバーレイが
+  // 残ってしまう（特に Fade で画面を色で覆う演出中だと、その色が "to be continued..." 画面に
+  // 残留する）。applyState() の画面効果リセットブロックと同じロジックを endStory() にも
+  // 適用したことを検証する。
+
+  it('31: endStory() は shakeTimer/effectTimer をクリアし effectOverlay を隠す（S1 回帰）', () => {
+    const r = makeRenderer(SCENES)
+    // Shake/Flash/Fade の fire-and-forget な内部状態を直接仕込む（実際のトリガーは
+    // processDirective 経由だが、ここでは endStory 側の後始末だけを対象にする）。
+    internals(r).shakeTimer = 12345
+    internals(r).effectTimer = 67890
+    internals(r).effectOverlay = { alpha: 0.6, visible: true }
+
+    r.setConfinedSceneIds(['entry'])
+    r.jumpToScene('out-scene')
+
+    expect(internals(r).shakeTimer).toBeNull()
+    expect(internals(r).effectTimer).toBeNull()
+    expect(internals(r).effectOverlay).toEqual({ alpha: 0, visible: false })
+  })
+
+  // ===== L. confinement 圏外 + 未知 sceneId の dev 診断 (#386 レビュー Q1) =====
+  //
+  // fail-closed（圏外は理由を問わず終劇）という設計自体は維持しつつ、原稿の typo で
+  // どこにも存在しない sceneId が「正常な終劇（例: hub への遷移）」に偽装されて気づかれない
+  // 事故を、開発時にだけ検知できるようにする。production の挙動・見た目は変えない
+  // （console.warn は import.meta.env.DEV でのみ評価される）。
+
+  it('32: 圏外かつ allScenes にも存在しない sceneId は DEV で console.warn される（Q1: typo が正常な終劇に偽装されない）', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const r = makeRenderer(SCENES)
+    r.setConfinedSceneIds(['entry', 'in-scene'])
+
+    r.jumpToScene('typo-scene-id')
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('typo-scene-id'))
+    // fail-closed の挙動自体は不変（警告があっても終劇にはなる）。
+    expect(r.getSnapshot().storyEnded).toBe(true)
+  })
+  // 「圏外だが allScenes に実在する sceneId は console.warn されない」は既存テスト20が担保する
+  // （out-scene は allScenes に実在するため、本テストの 'typo-scene-id' と対照的な既存カバレッジ）。
 })

--- a/frontend/src/game/NovelRenderer.loadFromSaveData.test.ts
+++ b/frontend/src/game/NovelRenderer.loadFromSaveData.test.ts
@@ -24,6 +24,7 @@
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { NovelRenderer } from './NovelRenderer'
+import type { NovelGameState } from './GameState'
 import type { Event, EventScene, FlagValue } from '../types'
 import { SaveManager, SaveSlotData } from './SaveManager'
 
@@ -53,6 +54,7 @@ function makeRenderer(scenes: EventScene[]): NovelRenderer {
 interface RendererInternals {
   history: unknown[]
   justSelectedChoice: boolean
+  applyState(state: NovelGameState): void
 }
 
 function internals(r: NovelRenderer): RendererInternals {
@@ -389,5 +391,34 @@ describe('NovelRenderer.loadFromSaveData (#256)', () => {
     r.quickLoad()
     expect(warnSpy).not.toHaveBeenCalled()
     expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  // ===== K. 終劇状態 (#386) =====
+  //
+  // SaveSlotData / saveSlotToGameState は storyEnded を持たない設計（novelLayout.ts 参照）。
+  // このセクションは「終劇後もセーブ自体が起きない（quickSave が false を返す）」
+  // 「万一 storyEnded=true な GameState からセーブ相当のロードをしても常に false に
+  // 復元される」という #386 修正後の正しい挙動を確認する。
+
+  it('30: storyEnded=true の状態から quickLoad しても、saveSlotToGameState により常に storyEnded=false で復元される', () => {
+    // quickLoad 前に「終劇済み」の状態を人為的に作る（confinement 外ジャンプの再現は
+    // NovelRenderer.confinement.test.ts の責務なので、ここでは applyState 直接キャストで作る。
+    // 本番導線には無い経路であることは startFrom.test.ts #29 と同様）。
+    seedQuickSave(craftSave({ sceneId: 'a', eventIndex: 0 }))
+    const r = makeRenderer(SCENES)
+    internals(r).applyState({ ...r.getSnapshot(), storyEnded: true })
+    expect(r.getSnapshot().storyEnded).toBe(true)
+
+    r.quickLoad()
+
+    expect(r.getSnapshot().storyEnded).toBe(false)
+  })
+
+  it('31: 終劇後（storyEnded=true）は quickSave() が false を返す（保存自体が起きない・行き止まり防止）', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'a' })
+    internals(r).applyState({ ...r.getSnapshot(), storyEnded: true })
+
+    expect(r.quickSave()).toBe(false)
   })
 })

--- a/frontend/src/game/NovelRenderer.startFrom.test.ts
+++ b/frontend/src/game/NovelRenderer.startFrom.test.ts
@@ -12,7 +12,7 @@
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { NovelRenderer } from './NovelRenderer'
-import type { StartFromOptions } from './GameState'
+import type { NovelGameState, StartFromOptions } from './GameState'
 import type { Event, EventScene, FlagValue } from '../types'
 
 // --- fixture helpers（playScript.test.ts と同じスタイル） ---
@@ -51,6 +51,7 @@ interface RendererInternals {
   waitingForWait: boolean
   waitTimer: number | null
   advance(): void
+  applyState(state: NovelGameState): void
 }
 
 function internals(r: NovelRenderer): RendererInternals {
@@ -333,5 +334,26 @@ describe('NovelRenderer.startFrom (#220)', () => {
     const r = makeRenderer(SCENES)
     const over = internals(r).resolvedEvents.length + 100
     expect(() => r.startFrom({ sceneId: 'start', eventIndex: over })).not.toThrow()
+  })
+
+  // ===== K. 終劇状態 (#386) =====
+
+  it('28: startFrom 開始直後は getSnapshot().storyEnded === false', () => {
+    const r = makeRenderer(SCENES)
+    r.startFrom({ sceneId: 'start' })
+    expect(r.getSnapshot().storyEnded).toBe(false)
+  })
+
+  it('29: storyEnded=true を含む NovelGameState を applyState 直接キャストで復元すると true になり callback が発火する（本番導線には無い経路。goBack/seekTo/セーブ復元は通常のシーン遷移か quickLoad 経由でしか applyState を呼ばず、いずれも storyEnded=false のスナップショット/セーブしか渡さない）', () => {
+    const cb = vi.fn()
+    const r = makeRenderer(SCENES)
+    r.setOnStoryEndedChange(cb)
+    r.startFrom({ sceneId: 'start' })
+    const endedState: NovelGameState = { ...r.getSnapshot(), storyEnded: true }
+
+    internals(r).applyState(endedState)
+
+    expect(r.getSnapshot().storyEnded).toBe(true)
+    expect(cb).toHaveBeenCalledWith(true)
   })
 })

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -790,6 +790,17 @@ export class NovelRenderer {
     // choke point。scene の存在チェックより前に判定する（allScenes に実在する hub 等でも
     // 圏外なら即終劇＝lazy load すら試みない）。
     if (!isSceneIdConfined(sceneId, this.confinedSceneIds)) {
+      // #386 レビュー Q1（dev 診断のみ・production の挙動/見た目は不変）:
+      // fail-closed（圏外は理由を問わず終劇）という設計は維持する。ただし「圏外だが
+      // 実在するシーン（例: hub。意図した終劇）」と「原稿の typo でどこにも存在しない
+      // sceneId（正常な終劇に偽装された事故）」を区別できないと、typo が気づかれない
+      // まま「正常な終劇」として素通りしてしまう。allScenes（entry + 圏内 script の
+      // 全シーン）にも見つからない場合だけ、開発時に気づけるよう警告を残す。
+      if (import.meta.env.DEV && !findSceneById(this.allScenes, sceneId)) {
+        console.warn(
+          `[name-name] confinement: sceneId "${sceneId}" は allScenes にも存在しません。終劇として扱いますが、原稿の typo の可能性があります（意図した圏外遷移なら無視してください）。`
+        )
+      }
       this.endStory()
       return
     }
@@ -861,6 +872,30 @@ export class NovelRenderer {
     this.choiceOverlay.hide()
     this.dialogBox.clearText()
 
+    // 画面効果の後始末 (#386 レビュー S1)。Shake/Flash/Fade は fire-and-forget なので、
+    // これらを仕込んだ直後の text から confinement 外への choice が続くと、そのタイマーが
+    // endStory() 後も生き続けて "to be continued..." 画面に効果（Fade の色かぶり等）が
+    // 残ってしまう。applyState() の画面効果リセットブロックと同じロジックをそのまま流用する。
+    if (this.shakeTimer) {
+      this.time.clearTimeout(this.shakeTimer)
+      this.shakeTimer = null
+    }
+    this.app.stage.position.set(0, 0)
+    if (this.effectTimer) {
+      this.time.clearInterval(this.effectTimer)
+      this.effectTimer = null
+    }
+    if (this.effectOverlay) {
+      this.effectOverlay.alpha = 0
+      this.effectOverlay.visible = false
+    }
+
+    // BGM を止める (#386 レビュー M2)。終劇は物語上の終端で、以後 BGM を止める Bgm イベントは
+    // 二度と来ないため、ここで止めないと BGM が永久に鳴り続ける（初見訪問者はセーブが無いため
+    // 止める手段がない）。見た目のフェードと揃えて BACKGROUND_CROSSFADE_MS でフェードアウトする。
+    this.audioManager.stopBgm(BACKGROUND_CROSSFADE_MS)
+    this.currentBgmPath = null
+
     // 宣言的な終端状態を即座に確定する（背景/色地/動画/立ち絵はすべて「なし」）。
     // 見た目のフェードはこの下で別途アニメさせるが、GameState としては最初からこの値。
     this.currentBackgroundPath = null
@@ -879,6 +914,28 @@ export class NovelRenderer {
   }
 
   /**
+   * 複数の背景 entry に「alpha 0 へフェードアウト → 完了後に破棄」の fadeAnimation を
+   * 一括で仕込む (#386 セルフレビュー nit)。`crossfadeToBackgroundEntry`（次背景を追加する
+   * クロスフェード）と `fadeOutBackgroundEntries`（次背景を追加しない終劇演出）の両方が
+   * 「旧背景を消す」部分としてこの手続きを共有する（重複実装の解消）。
+   */
+  private beginFadeOutEntries(
+    entries: BackgroundEntry[],
+    startMs: number,
+    durationMs: number
+  ): void {
+    for (const entry of entries) {
+      entry.fadeAnimation = {
+        startMs,
+        durationMs,
+        fromAlpha: entry.sprite.alpha,
+        toAlpha: 0,
+        destroyOnComplete: true,
+      }
+    }
+  }
+
+  /**
    * 現在の背景画像 entry 群をフェードアウトさせる (#386 終劇演出)。
    * `crossfadeToBackgroundEntry` の「旧背景を消す」半分だけを取り出した形（次背景を
    * 追加しない）。完了後は `updateBackgroundFadeFrame` の `destroyOnComplete` で自動的に
@@ -889,15 +946,7 @@ export class NovelRenderer {
     if (this.bgEntries.length === 0) return
     this.stopBackgroundCrossfade()
     const startMs = this.time.now()
-    for (const entry of this.bgEntries) {
-      entry.fadeAnimation = {
-        startMs,
-        durationMs,
-        fromAlpha: entry.sprite.alpha,
-        toAlpha: 0,
-        destroyOnComplete: true,
-      }
-    }
+    this.beginFadeOutEntries(this.bgEntries, startMs, durationMs)
     this.updateBackgroundFadeFrame()
     this.ensureBackgroundCrossfadeTicker()
   }
@@ -1925,6 +1974,12 @@ export class NovelRenderer {
    * 1つ前の表示イベントに戻る（スナップショットベースの宣言的復元）
    */
   goBack(): void {
+    // #386: 終劇後は無効化する。endStory() は pushSnapshot() を呼ばないため、
+    // history の末尾には confinement 違反前の最後のテキストイベント（storyEnded: false の
+    // スナップショット）が残ったままになる。ここをガードしないと goBack で applyState が
+    // storyEnded を false に巻き戻し、"to be continued..." が消えて背景/立ち絵/BGM が
+    // 直前の状態に戻ってしまう（終劇の無効化）。
+    if (this.storyEnded) return
     if (this.resolvedEvents.length === 0) return
     if (this.waitingForChoice || this.waitingForWait) return
 
@@ -1970,6 +2025,8 @@ export class NovelRenderer {
    * 履歴の任意位置にジャンプする（シークバーから呼ばれる）
    */
   seekTo(historyIndex: number): void {
+    // #386: goBack() と同じ理由で終劇後は無効化する（SeekBar ドラッグでの巻き戻し防止）。
+    if (this.storyEnded) return
     if (historyIndex < 0 || historyIndex >= this.history.length) return
     if (this.waitingForChoice || this.waitingForWait) return
 
@@ -2895,15 +2952,7 @@ export class NovelRenderer {
     const startMs = this.time.now()
     const durationMs = BACKGROUND_CROSSFADE_MS
     const previous = [...this.bgEntries]
-    for (const entry of previous) {
-      entry.fadeAnimation = {
-        startMs,
-        durationMs,
-        fromAlpha: entry.sprite.alpha,
-        toAlpha: 0,
-        destroyOnComplete: true,
-      }
-    }
+    this.beginFadeOutEntries(previous, startMs, durationMs)
     next.sprite.alpha = 0
     next.fadeAnimation = {
       startMs,

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -41,6 +41,7 @@ import { SaveLoadOverlay } from './SaveLoadOverlay'
 import { BacklogOverlay } from './BacklogOverlay'
 import { SeekBar } from './SeekBar'
 import { computeDisplayIndex, findHistoryIndexForDisplayIndex } from './seekMapping'
+import { isSceneIdConfined } from './sceneConfinement'
 import { Event, EventScene } from '../types'
 import { ASPECT_RATIOS, type AspectRatio, parseAspectRatio } from './constants'
 import {
@@ -248,6 +249,23 @@ export class NovelRenderer {
   private onSceneChangeCallback: ((sceneId: string) => void) | null = null
   private missingSceneResolver: ((sceneId: string) => Promise<EventScene[] | null>) | null = null
   private pendingMissingScenes = new Set<string>()
+  /**
+   * `?scene=` ディープリンク単独埋め込みの confinement（在圏）一覧 (#386)。
+   * null なら制限なし（通常のハブ経由フロー）。非 null のときは `jumpToScene` がこの
+   * 集合の外への遷移を検出し、通常のシーン遷移ではなく `endStory()`（終劇）にする。
+   * `setConfinedSceneIds` で設定する（呼び出し側は `PlayerScreen` が対象 script ファイル
+   * 自身の sceneId 一覧を渡す）。
+   */
+  private confinedSceneIds: string[] | null = null
+  /**
+   * 終劇状態 (#386)。GameState 上の宣言的フラグ（`NovelGameState.storyEnded`）と対になる
+   * 実行時フィールド。true の間は `advance()` が no-op になり（choice/advance は反応しない）、
+   * `jumpToScene` も再入しない。goBack/seekTo/セーブ復元は `applyState` 経由でこの値を
+   * そのまま反映する（フェード演出は再生しない＝宣言的な瞬時反映）。
+   */
+  private storyEnded = false
+  /** storyEnded 変化を DOM 側（NovelPlayer）に伝える hook (#386)。"to be continued..." 表示用。 */
+  private onStoryEndedChangeCallback: ((ended: boolean) => void) | null = null
   private assetBaseUrl: string = ''
   private textureCache: Map<string, Texture> = new Map()
   /** setBackground の非同期ロード用トークン。destroy / 再入 の race 回避に使う */
@@ -754,9 +772,27 @@ export class NovelRenderer {
   }
 
   /**
+   * `?scene=` ディープリンク単独埋め込みの confinement（在圏）一覧を設定する (#386)。
+   * null（既定）なら制限なし。渡した場合、`jumpToScene` はこの集合の外への遷移を
+   * 終劇として扱う（`endStory()`）。通常のハブ経由フロー（`/play/:projectName`）では
+   * 呼ばれない、または null を渡す想定。
+   */
+  setConfinedSceneIds(ids: string[] | null): void {
+    this.confinedSceneIds = ids
+  }
+
+  /**
    * 指定シーンにジャンプする
    */
   jumpToScene(sceneId: string): void {
+    // #386: confinement（在圏）外への choice ジャンプは通常のシーン遷移にせず終劇にする。
+    // theo-hayami の hub（別の問いを聞く → hub）等、埋め込み外の内容が漏れるのを防ぐ唯一の
+    // choke point。scene の存在チェックより前に判定する（allScenes に実在する hub 等でも
+    // 圏外なら即終劇＝lazy load すら試みない）。
+    if (!isSceneIdConfined(sceneId, this.confinedSceneIds)) {
+      this.endStory()
+      return
+    }
     const scene = findSceneById(this.allScenes, sceneId)
     if (!scene) {
       if (this.missingSceneResolver) {
@@ -770,6 +806,13 @@ export class NovelRenderer {
   }
 
   private startScene(sceneId: string, scene: EventScene): void {
+    // #386: 通常のシーン遷移が成立する経路なので、終劇状態は解除しておく（宣言的整合性の保険。
+    // 通常はここに来る前に jumpToScene の confinement チェックで弾かれるため storyEnded は
+    // 既に false のはずだが、デバッグ等から直接呼ばれた場合の保険として明示的に戻す）。
+    if (this.storyEnded) {
+      this.storyEnded = false
+      this.onStoryEndedChangeCallback?.(false)
+    }
     this.currentSceneId = sceneId
     this.resetAndStartEvents([...scene.events], { preserveBackgroundForTransition: true })
     this.onSceneChangeCallback?.(sceneId)
@@ -793,6 +836,70 @@ export class NovelRenderer {
     } finally {
       this.pendingMissingScenes.delete(sceneId)
     }
+  }
+
+  /**
+   * confinement（在圏）外へのシーンジャンプを終劇として扱う (#386)。
+   *
+   * `?scene=` ディープリンク単独埋め込み（`confinedSceneIds` が設定されている場合のみ）で、
+   * hub や他ファイルへの choice ジャンプが埋め込みの外側の内容を漏らさないようにする
+   * （theo-hayami #20: 他住人/業一覧への遷移は埋め込み内の choice ではなく HTML リンクで行う設計）。
+   *
+   * `storyEnded` は演出の中間状態ではなく GameState 上の宣言的フラグとして持つ（ADR0002 /
+   * doctrine 規律3）。フェード演出（背景・立ち絵）はこの一度きりの遷移に付随する見た目でしか
+   * なく、確定する状態そのものは「背景も立ち絵もない終劇後」という終端値（下記で即座に確定）。
+   * これにより getSnapshot/applyState の往復（goBack・seekTo・セーブ復元）は常にこの終端状態
+   * をそのまま扱えばよく、フェード途中を再現する必要がない。
+   *
+   * 通常のハブ経由フロー（confinedSceneIds が null）では jumpToScene 側の判定により
+   * ここには来ない。
+   */
+  private endStory(): void {
+    if (this.storyEnded) return // 二重発火防止（連打等でフェード/コールバックを重複させない）
+    this.storyEnded = true
+    this.waitingForChoice = false
+    this.choiceOverlay.hide()
+    this.dialogBox.clearText()
+
+    // 宣言的な終端状態を即座に確定する（背景/色地/動画/立ち絵はすべて「なし」）。
+    // 見た目のフェードはこの下で別途アニメさせるが、GameState としては最初からこの値。
+    this.currentBackgroundPath = null
+    this.currentBackgroundFade = null
+    this.currentBackgroundBrightness = null
+    this.bgLoadToken++
+    this.pendingBackgroundLoadToken = null
+    this.clearBackgroundColor()
+    this.videoLayer.remove()
+
+    // 見た目のフェード演出（既存の背景クロスフェード / 立ち絵退場フェードの仕組みをそのまま流用）。
+    this.fadeOutBackgroundEntries(BACKGROUND_CROSSFADE_MS)
+    this.characterLayer.clearForSceneTransition()
+
+    this.onStoryEndedChangeCallback?.(true)
+  }
+
+  /**
+   * 現在の背景画像 entry 群をフェードアウトさせる (#386 終劇演出)。
+   * `crossfadeToBackgroundEntry` の「旧背景を消す」半分だけを取り出した形（次背景を
+   * 追加しない）。完了後は `updateBackgroundFadeFrame` の `destroyOnComplete` で自動的に
+   * 破棄される。ステージ最背面の `bgGraphics`（既定/設定色）は endStory 側で先に黒へ
+   * リセット済みのため、フェード完了後は自然に黒が残る。
+   */
+  private fadeOutBackgroundEntries(durationMs: number): void {
+    if (this.bgEntries.length === 0) return
+    this.stopBackgroundCrossfade()
+    const startMs = this.time.now()
+    for (const entry of this.bgEntries) {
+      entry.fadeAnimation = {
+        startMs,
+        durationMs,
+        fromAlpha: entry.sprite.alpha,
+        toAlpha: 0,
+        destroyOnComplete: true,
+      }
+    }
+    this.updateBackgroundFadeFrame()
+    this.ensureBackgroundCrossfadeTicker()
   }
 
   /** 現在表示中のシーンID (#228 動画エクスポート用) */
@@ -1377,6 +1484,12 @@ export class NovelRenderer {
     this.onSeekActiveChange = cb
   }
 
+  /** 終劇状態の変化コールバックを登録する (#386)。NovelPlayer が "to be continued..." の
+   *  DOM 表示に繋ぐ（setOnAutoModeChange 等と同じ配線パターン）。 */
+  setOnStoryEndedChange(cb: ((ended: boolean) => void) | null): void {
+    this.onStoryEndedChangeCallback = cb
+  }
+
   /** スキップモードの現在状態を取得する */
   isSkipMode(): boolean {
     return this.skipMode
@@ -1663,6 +1776,7 @@ export class NovelRenderer {
       isBlackout: this.blackoutOverlay.visible,
       characters: this.characterLayer.getCharacterStates(),
       currentBgmPath: this.currentBgmPath,
+      storyEnded: this.storyEnded,
     }
   }
 
@@ -1670,6 +1784,8 @@ export class NovelRenderer {
    * 次のテキスト / 次のイベントへ進む
    */
   advance(): void {
+    // #386: 終劇後は入力を受け付けない（タップしても何も起きない状態を維持する）。
+    if (this.storyEnded) return
     if (this.resolvedEvents.length === 0) return
     if (this.waitingForChoice || this.waitingForWait) return
 
@@ -1918,6 +2034,11 @@ export class NovelRenderer {
     // novel 改頁キャッシュは派生。任意局面復元で events / 幾何 / eventIndex が変わり得るので破棄し、
     // render() 側で現在の eventIndex に対して再計算させる (#283)。
     this.novelPagesCache = null
+
+    // 終劇状態の復元 (#386)。goBack/seekTo/セーブ復元はすべて即時反映（フェード演出はしない）。
+    // DOM 側（NovelPlayer の "to be continued..." 表示）は callback で同期する。
+    this.storyEnded = state.storyEnded
+    this.onStoryEndedChangeCallback?.(state.storyEnded)
 
     // 背景復元
     if (state.backgroundPath) {
@@ -3183,6 +3304,7 @@ export class NovelRenderer {
       isBlackout: false,
       characters: [],
       currentBgmPath: null,
+      storyEnded: false,
     }
     this.restoreToScene(scene, state)
   }

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -3092,11 +3092,18 @@ export class NovelRenderer {
 
   /**
    * 現在のゲーム状態をクイックセーブスロットに保存する。
-   * 選択肢・Wait 待機中は保存しない（不整合状態を避けるため）。
+   * 選択肢・Wait 待機中・終劇後は保存しない（不整合状態を避けるため）。
+   *
+   * 終劇後 (#386) を除外する理由: `endStory()` は `waitingForChoice` を false に戻すため
+   * その条件だけでは終劇後のセーブを防げない。また `SaveSlotData`/`saveSlotToGameState` は
+   * 意図的に `storyEnded` を保存しない設計（常に false で復元）なので、もし終劇後の
+   * eventIndex（圏外 choice に到達したまま止まっている位置）でセーブを許すと、ロード時に
+   * 「storyEnded=false なのに Choice イベント位置で止まっている」行き止まり（テキストも
+   * 選択肢も "to be continued..." も出ない空白画面）になる。
    * 成功したら true、保存できない状態なら false を返す。
    */
   quickSave(): boolean {
-    if (this.waitingForChoice || this.waitingForWait) return false
+    if (this.waitingForChoice || this.waitingForWait || this.storyEnded) return false
 
     // シーンタイトルの解決（sceneId ガード + find + ?.title ?? null）は openSaveMenu と
     // 共通の novelLayout.resolveSceneTitle に集約 (#260)。
@@ -3146,9 +3153,12 @@ export class NovelRenderer {
   }
 
   /**
-   * セーブメニューを表示する
+   * セーブメニューを表示する。
+   * 終劇後 (#386) はメニュー自体を開かない。理由は quickSave() の doc コメント参照
+   * （SaveSlotData は storyEnded を持たないため、終劇後のセーブは行き止まりの原因になる）。
    */
   private openSaveMenu(): void {
+    if (this.storyEnded) return
     this.saveLoadOverlay.showSave((slot: number) => {
       // quickSave と共通のシーンタイトル解決 (#260)。
       const sceneName = resolveSceneTitle(this.allScenes, this.currentSceneId)

--- a/frontend/src/game/novelLayout.test.ts
+++ b/frontend/src/game/novelLayout.test.ts
@@ -366,6 +366,8 @@ describe('saveSlotToGameState', () => {
       isBlackout: data.isBlackout ?? false,
       characters: data.characters ?? [],
       currentBgmPath: data.currentBgmPath ?? null,
+      // 終劇状態 (#386) は SaveSlotData 未対応。セーブ/ロードは常に「終劇していない」扱い。
+      storyEnded: false,
     }
   }
 
@@ -392,6 +394,7 @@ describe('saveSlotToGameState', () => {
       isBlackout: true,
       characters: [{ name: 'A', expression: 'smile', position: 'center' }],
       currentBgmPath: 'bgm/main.mp3',
+      storyEnded: false,
     })
   })
 

--- a/frontend/src/game/novelLayout.ts
+++ b/frontend/src/game/novelLayout.ts
@@ -314,6 +314,7 @@ export function resolveCharacterImageUrls(baseUrl: string, cleanPath: string): s
  *   isBlackout     = data.isBlackout ?? false
  *   characters     = data.characters ?? []
  *   currentBgmPath = data.currentBgmPath ?? null
+ *   storyEnded     = false  // SaveSlotData 未対応 (#386)。セーブ/ロードは常に「終劇していない」扱い
  *
  * `backgroundFade` の正規化（`normalizeBackgroundFade` / `edgeFadeMask`）は PixiJS を間接
  * 参照するため、このモジュールを PixiJS 非依存に保つ目的で「正規化済みの値」を引数で受け取る。
@@ -343,6 +344,9 @@ export function saveSlotToGameState(
     isBlackout: data.isBlackout ?? false,
     characters: data.characters ?? [],
     currentBgmPath: data.currentBgmPath ?? null,
+    // 終劇状態 (#386) はセーブデータに持たせない（SaveSlotData 未対応・古いセーブにも無い）。
+    // quicksave/quickload・スロット保存はすべて「終劇していない」状態として復元する。
+    storyEnded: false,
   }
 }
 

--- a/frontend/src/game/sceneConfinement.test.ts
+++ b/frontend/src/game/sceneConfinement.test.ts
@@ -1,0 +1,40 @@
+/**
+ * isSceneIdConfined(sceneId, confinedSceneIds) のテスト (#386)。
+ *
+ * `?scene=` ディープリンク単独埋め込みの confinement（在圏）判定を行う純粋関数の検証。
+ * 副作用なし・DOM 非依存なので、値を直接突き合わせる最小構成で行う（観点ごとに 1 テスト）。
+ */
+import { describe, it, expect } from 'vitest'
+import { isSceneIdConfined } from './sceneConfinement'
+
+describe('isSceneIdConfined (#386)', () => {
+  // ===== A. null passthrough（制限なし＝通常のハブ経由フロー） =====
+
+  it('1: confinedSceneIds=null なら常に true（制限なし）', () => {
+    expect(isSceneIdConfined('x', null)).toBe(true)
+  })
+
+  // ===== B. 同値分割: 在圏 / 圏外 =====
+
+  it('2: 在圏（集合に含まれる）→ true', () => {
+    expect(isSceneIdConfined('a', ['a', 'b'])).toBe(true)
+  })
+
+  it('3: 圏外（集合に含まれない）→ false', () => {
+    expect(isSceneIdConfined('c', ['a', 'b'])).toBe(false)
+  })
+
+  // ===== C. 境界値 =====
+
+  it('4: 空配列 → 常に false（在圏の要素がそもそも無い）', () => {
+    expect(isSceneIdConfined('a', [])).toBe(false)
+  })
+
+  it('5: 単一要素の配列で一致 → true', () => {
+    expect(isSceneIdConfined('a', ['a'])).toBe(true)
+  })
+
+  it('6: 単一要素の配列で不一致 → false', () => {
+    expect(isSceneIdConfined('b', ['a'])).toBe(false)
+  })
+})

--- a/frontend/src/game/sceneConfinement.ts
+++ b/frontend/src/game/sceneConfinement.ts
@@ -1,0 +1,25 @@
+/**
+ * `?scene=` ディープリンク単独埋め込みの confinement（在圏）判定 (#386)。
+ *
+ * theo-hayami サイト設計（theo-hayami #20）は「他ファイル（住人一覧・業一覧などの hub）への
+ * 遷移は埋め込み内の choice ではなく、埋め込みの外側の HTML リンクで行う」ことを前提にしている。
+ * `?scene=` 単独埋め込み起動時（`PlayerScreen` が対象 script ファイル自身の sceneId 一覧を
+ * `NovelRenderer.setConfinedSceneIds` で渡したとき）だけ、その集合の外へのシーンジャンプを
+ * `NovelRenderer.jumpToScene` の choke point で検出し、通常の scene 遷移ではなく終劇として
+ * 扱う（`NovelRenderer.endStory`）。通常のハブ経由フロー（`/play/:projectName` 単体）では
+ * confinedSceneIds が null のまま渡らないため、常に無制限（在圏）になる。
+ *
+ * 副作用なし・DOM 非依存の純粋関数。
+ */
+
+/**
+ * sceneId が現在の confinement（在圏）内かどうかを判定する。
+ *
+ * @param sceneId 遷移先の sceneId
+ * @param confinedSceneIds 在圏シーンID一覧。null なら「圏の制限なし」＝常に true
+ *   （通常のハブ経由フロー・dev の debug_scene 等、production `?scene=` 以外はすべて null）
+ * @returns 圏内（遷移してよい）なら true、圏外（終劇にすべき）なら false
+ */
+export function isSceneIdConfined(sceneId: string, confinedSceneIds: string[] | null): boolean {
+  return confinedSceneIds === null || confinedSceneIds.includes(sceneId)
+}

--- a/frontend/src/game/sceneQuery.test.ts
+++ b/frontend/src/game/sceneQuery.test.ts
@@ -1,0 +1,65 @@
+/**
+ * parseSceneQuery(search) のテスト (#386)。
+ *
+ * `?scene=<sceneId>` を PlayerScreen が読むための最小パーサの検証。
+ * `debugQuery.test.ts` と同じ流儀（副作用なし・DOM 非依存の純粋関数に文字列を渡し、
+ * 戻り値を直接突き合わせる）で、観点ごとに 1 テストにする。
+ */
+import { describe, it, expect } from 'vitest'
+import { parseSceneQuery } from './sceneQuery'
+
+describe('parseSceneQuery (#386)', () => {
+  // ===== A. 正常系 =====
+
+  it('1: ?scene=foo → foo', () => {
+    expect(parseSceneQuery('?scene=foo')).toBe('foo')
+  })
+
+  it('2: 先頭 ? 無し scene=foo → foo（URLSearchParams はどちらも受け付ける）', () => {
+    expect(parseSceneQuery('scene=foo')).toBe('foo')
+  })
+
+  // ===== B. 境界値・null/空文字/未設定 =====
+
+  it('3: 空文字 "" → null', () => {
+    expect(parseSceneQuery('')).toBeNull()
+  })
+
+  it('4: ?scene=（値が空）→ null', () => {
+    expect(parseSceneQuery('?scene=')).toBeNull()
+  })
+
+  it('4b: ?scene=a（1 文字）→ a（空文字との境界）', () => {
+    expect(parseSceneQuery('?scene=a')).toBe('a')
+  })
+
+  it('5: ?other=1（scene 未設定）→ null', () => {
+    expect(parseSceneQuery('?other=1')).toBeNull()
+  })
+
+  // ===== C. 同値分割 =====
+
+  it('6: ?debug_scene=foo（scene キーではない）→ null', () => {
+    expect(parseSceneQuery('?debug_scene=foo')).toBeNull()
+  })
+
+  // ===== D. 重複・複数パラメータ =====
+
+  it('7: ?scene=a&scene=b（重複）→ a（先勝ち。URLSearchParams.get の仕様）', () => {
+    expect(parseSceneQuery('?scene=a&scene=b')).toBe('a')
+  })
+
+  it('8: ?other=1&scene=bar（他パラメータ混在）→ bar', () => {
+    expect(parseSceneQuery('?other=1&scene=bar')).toBe('bar')
+  })
+
+  // ===== E. i18n・特殊文字 =====
+
+  it('9: ?scene=%E3%81%82（URL エンコード）→ デコード後の値 "あ"', () => {
+    expect(parseSceneQuery('?scene=%E3%81%82')).toBe('あ')
+  })
+
+  it('10: ?scene=%20（空白 1 文字）→ " "（空文字とは区別される）', () => {
+    expect(parseSceneQuery('?scene=%20')).toBe(' ')
+  })
+})

--- a/frontend/src/game/sceneQuery.ts
+++ b/frontend/src/game/sceneQuery.ts
@@ -1,0 +1,24 @@
+/**
+ * URL クエリによる scene 起点指定のパーサ (#386)。
+ *
+ * `?scene=<sceneId>` を `PlayerScreen` が読み、対象 sceneId が属する script を
+ * 事前解決・ロードしてから `NovelPlayer` に `initialSceneId` として渡す production 経路。
+ * `debugQuery.ts` の `debug_scene`（dev 専用・`import.meta.env.DEV` でのみ有効・
+ * flags/eventIndex/textIndex 対応）とは別に、production ビルドでも常時有効な
+ * 「特定シーンへの直接ディープリンク」用の最小限の入口として用意する
+ * （theo-hayami サイト設計「1セル1URL＝1遅延埋め込み」の前提）。
+ *
+ * 副作用なし・DOM 非依存の純粋関数。
+ */
+
+/**
+ * URL の query string から `scene` パラメータ（sceneId）を取り出す。
+ *
+ * @param search `window.location.search`（先頭 `?` の有無どちらも可）
+ * @returns sceneId 文字列。未指定/空文字なら null
+ */
+export function parseSceneQuery(search: string): string | null {
+  const params = new URLSearchParams(search)
+  const sceneId = params.get('scene')
+  return sceneId !== null && sceneId !== '' ? sceneId : null
+}

--- a/frontend/src/game/seekMapping.test.ts
+++ b/frontend/src/game/seekMapping.test.ts
@@ -27,6 +27,7 @@ function makeState(eventIndex: number): NovelGameState {
     isBlackout: false,
     characters: [],
     currentBgmPath: null,
+    storyEnded: false,
   }
 }
 

--- a/frontend/src/screens/PlayerScreen.test.tsx
+++ b/frontend/src/screens/PlayerScreen.test.tsx
@@ -1186,4 +1186,214 @@ describe('PlayerScreen', () => {
     await renderWithFrontmatter({})
     expect(lastNovelPlayerProps().speakerNudge).toBeNull()
   })
+
+  // --- #386: `?scene=<sceneId>` ディープリンク + confinement ---
+  //
+  // マルチ MD 構成（エントリ = hub、別 MD = 個別セル）で `?scene=` を解決し、
+  // NovelPlayer に initialSceneId / confinedSceneIds として渡る配線を検証する。
+  // findConfinedSceneIds は PlayerScreen 内の非公開関数なので、直接ではなく
+  // lastNovelPlayerProps() 経由で観測する（既存の #310/#382 転送テストと同じ流儀）。
+  describe('PlayerScreen `?scene=` ディープリンク + confinement (#386)', () => {
+    beforeEach(() => {
+      window.history.pushState({}, '', '/')
+    })
+    afterEach(() => {
+      window.history.pushState({}, '', '/')
+    })
+
+    /** hub(script.md) 1 シーン + 別 MD(cell) 2 シーンの標準的なマルチ MD 構成をセットアップする。 */
+    function mockMultiDocProject() {
+      listProjectsMock.mockResolvedValue([
+        { name: 'theo-hayami', title: 'せおはやみ', repo: 'kako-jun/theo-hayami' },
+      ])
+      listScriptsMock.mockResolvedValue([
+        { path: 'script.md', sha: 's0', size: 1, title: null, hidden: false },
+        { path: 'content/scripts/free/a.md', sha: 's1', size: 1, title: null, hidden: false },
+      ])
+      getContentsMock.mockImplementation(async (_name: string, path: string) => ({
+        path,
+        sha: 'x',
+        content: path,
+      }))
+      parseMarkdownMock.mockImplementation(async (md: string) => {
+        const isEntry = md === 'script.md'
+        return {
+          engine: 'name-name',
+          chapters: [
+            {
+              number: 1,
+              title: 'c',
+              hidden: false,
+              default_bgm: null,
+              scenes: isEntry
+                ? [{ id: 'hub-scene', title: 'hub', view: 'TopDown', events: [] }]
+                : [
+                    { id: 'cell-scene-1', title: 'cell1', view: 'TopDown', events: [] },
+                    { id: 'cell-scene-2', title: 'cell2', view: 'TopDown', events: [] },
+                  ],
+            },
+          ],
+        }
+      })
+    }
+
+    async function renderMultiDocProject() {
+      mockMultiDocProject()
+      render(
+        <PlayerScreen
+          projectName="theo-hayami"
+          apiBaseUrl="http://api.test"
+          isDark={false}
+          onBack={() => {}}
+        />
+      )
+      await waitFor(() => {
+        expect(screen.getByTestId('novel-player')).toBeInTheDocument()
+      })
+    }
+
+    it('40: ?scene=<別MDのcell sceneId> 指定時、initialSceneId が解決済み sceneId になる', async () => {
+      window.history.pushState({}, '', '?scene=cell-scene-1')
+      await renderMultiDocProject()
+      expect(lastNovelPlayerProps().initialSceneId).toBe('cell-scene-1')
+    })
+
+    it('41: 上記と同条件で、confinedSceneIds はその cell ファイル自身の sceneId 一覧のみ（hub の sceneId を含まない）', async () => {
+      window.history.pushState({}, '', '?scene=cell-scene-1')
+      await renderMultiDocProject()
+      expect(lastNovelPlayerProps().confinedSceneIds).toEqual(['cell-scene-1', 'cell-scene-2'])
+    })
+
+    it('42: ?scene= 未指定時、initialSceneId/confinedSceneIds はともに null のまま', async () => {
+      await renderMultiDocProject()
+      expect(lastNovelPlayerProps().initialSceneId).toBeNull()
+      expect(lastNovelPlayerProps().confinedSceneIds).toBeNull()
+    })
+
+    it('43: ?scene=<存在しない sceneId> 指定時、initialSceneId/confinedSceneIds ともに null にフォールバックする', async () => {
+      window.history.pushState({}, '', '?scene=no-such-scene')
+      await renderMultiDocProject()
+      expect(lastNovelPlayerProps().initialSceneId).toBeNull()
+      expect(lastNovelPlayerProps().confinedSceneIds).toBeNull()
+      // フォールバックであってエラー扱いにはならない
+      expect(screen.queryByRole('alert')).toBeNull()
+    })
+
+    it('44【修正2】: ?scene=<entry(hub)自身の sceneId> 指定時、initialSceneId は解決されるが confinedSceneIds は null のまま（無制限フローへフォールバック）', async () => {
+      window.history.pushState({}, '', '?scene=hub-scene')
+      await renderMultiDocProject()
+      expect(lastNovelPlayerProps().initialSceneId).toBe('hub-scene')
+      // hub 自身を confinement にすると hub→各お題への通常遷移まで即終劇になってしまうため、
+      // findConfinedSceneIds は entry doc を候補から除外して null を返す（無制限フロー）。
+      expect(lastNovelPlayerProps().confinedSceneIds).toBeNull()
+    })
+
+    it('45: listScripts 失敗（単一 script.md フォールバック）時、?scene= が entry 内で解決できても confinedSceneIds は常に null のままである', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      window.history.pushState({}, '', '?scene=only-scene')
+      listProjectsMock.mockResolvedValue([
+        { name: 'theo-hayami', title: 'せおはやみ', repo: 'kako-jun/theo-hayami' },
+      ])
+      listScriptsMock.mockRejectedValue(new Error('listScripts unavailable'))
+      getContentsMock.mockResolvedValue({
+        path: 'script.md',
+        sha: 'sha-entry',
+        content: 'script.md',
+      })
+      parseMarkdownMock.mockResolvedValue({
+        engine: 'name-name',
+        chapters: [
+          {
+            number: 1,
+            title: 'c',
+            hidden: false,
+            default_bgm: null,
+            scenes: [{ id: 'only-scene', title: 'only', view: 'TopDown', events: [] }],
+          },
+        ],
+      })
+
+      render(
+        <PlayerScreen
+          projectName="theo-hayami"
+          apiBaseUrl="http://api.test"
+          isDark={false}
+          onBack={() => {}}
+        />
+      )
+      await waitFor(() => {
+        expect(screen.getByTestId('novel-player')).toBeInTheDocument()
+      })
+
+      expect(lastNovelPlayerProps().initialSceneId).toBe('only-scene')
+      expect(lastNovelPlayerProps().confinedSceneIds).toBeNull()
+    })
+
+    it('46: ?scene= 解決に必要な別 MD の取得が失敗しても（resolveMissingScene が内部で catch して null を返す）クラッシュせず entry 再生にフォールバックする', async () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+      window.history.pushState({}, '', '?scene=unreachable-scene')
+      listProjectsMock.mockResolvedValue([
+        { name: 'theo-hayami', title: 'せおはやみ', repo: 'kako-jun/theo-hayami' },
+      ])
+      listScriptsMock.mockResolvedValue([
+        { path: 'script.md', sha: 's0', size: 1, title: null, hidden: false },
+        { path: 'content/scripts/broken.md', sha: 's1', size: 1, title: null, hidden: false },
+      ])
+      getContentsMock.mockImplementation(async (_name: string, path: string) => {
+        if (path === 'content/scripts/broken.md') {
+          throw new Error('network down')
+        }
+        return { path, sha: 'x', content: path }
+      })
+      parseMarkdownMock.mockImplementation(async (md: string) => ({
+        engine: 'name-name',
+        chapters: [
+          {
+            number: 1,
+            title: 'c',
+            hidden: false,
+            default_bgm: null,
+            scenes: [
+              {
+                id: md === 'script.md' ? 'hub-scene' : 'unreachable-scene',
+                title: md,
+                view: 'TopDown',
+                events: [],
+              },
+            ],
+          },
+        ],
+      }))
+
+      render(
+        <PlayerScreen
+          projectName="theo-hayami"
+          apiBaseUrl="http://api.test"
+          isDark={false}
+          onBack={() => {}}
+        />
+      )
+      await waitFor(() => {
+        expect(screen.getByTestId('novel-player')).toBeInTheDocument()
+      })
+
+      expect(screen.queryByRole('alert')).toBeNull()
+      expect(lastNovelPlayerProps().initialSceneId).toBeNull()
+      expect(lastNovelPlayerProps().confinedSceneIds).toBeNull()
+    })
+
+    it('47a: ?scene= 解決成功時、debugInfo に "scene param: ... → resolved" の行が入る', async () => {
+      window.history.pushState({}, '', '?scene=cell-scene-1')
+      await renderMultiDocProject()
+      const debugInfo = lastNovelPlayerProps().debugInfo as string[]
+      expect(debugInfo).toContain('scene param: cell-scene-1 → resolved')
+    })
+
+    it('47b: ?scene= 解決失敗時、debugInfo に "scene param: ... → not found (fallback to entry)" の行が入る', async () => {
+      window.history.pushState({}, '', '?scene=no-such-scene')
+      await renderMultiDocProject()
+      const debugInfo = lastNovelPlayerProps().debugInfo as string[]
+      expect(debugInfo).toContain('scene param: no-such-scene → not found (fallback to entry)')
+    })
+  })
 })

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -8,6 +8,7 @@ import { parseMarkdown } from '../wasm/parser'
 import { findRpgSceneIndex, rpgProjectFromDoc } from '../game/rpgProjectFromDoc'
 import { ApiError, createApiClient, type ProjectInfo, type ScriptInfo } from '../api/client'
 import { clearReadProgress, hasAnyReadProgress } from '../game/readProgress'
+import { parseSceneQuery } from '../game/sceneQuery'
 import { useVisualViewportHeight } from '../utils/useVisualViewportHeight'
 import {
   getCachedParsedScriptDocument,
@@ -153,6 +154,10 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
   const [loadDebugInfo, setLoadDebugInfo] = useState<string[]>([])
   // script.md がまだリポに無い「未投入」状態。エラーではなく案内として扱う。
   const [unpopulated, setUnpopulated] = useState(false)
+  // `?scene=<sceneId>` の解決結果 (#386)。対象 sceneId が属する script を事前ロードして
+  // allScenes に反映できた場合だけ sceneId を保持する。見つからない/未指定は null＝
+  // NovelPlayer には initialSceneId を渡さず、現行どおりエントリ（ハブ）から開始する。
+  const [startSceneId, setStartSceneId] = useState<string | null>(null)
   const sortedPlayablePathsRef = useRef<string[]>([])
   const scriptInfoByPathRef = useRef<Map<string, ScriptInfo>>(new Map())
   const entryPathRef = useRef<string | null>(null)
@@ -296,11 +301,16 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
       setError(null)
       setUnpopulated(false)
       setLoadDebugInfo([])
+      setStartSceneId(null)
       sortedPlayablePathsRef.current = []
       scriptInfoByPathRef.current = new Map()
       entryPathRef.current = null
       loadedDocsRef.current = new Map()
       loadingDocsRef.current = new Map()
+      // `?scene=<sceneId>` ディープリンク (#386)。production でも常時有効（DEV 限定の
+      // debug_scene とは別系統）。読み込み完了まで NovelPlayer はマウントされないため、
+      // ここで一度読めば十分（マウント後のクエリ変化への追従は対象外）。
+      const sceneParam = parseSceneQuery(window.location.search)
       try {
         // 1. プロジェクト情報と scripts 一覧は独立しているので並列に開始する (#314)。
         //    hard reload の cold path で、project metadata 待ちが entry MD 取得開始を
@@ -368,6 +378,11 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
           loadedDocsRef.current.set(SCRIPT_BASENAME, entryDoc)
           setDoc(entryDoc)
           setAllScenes(entryScenes)
+          // #386: listScripts 不能時はクロスファイル解決ができないため、entry 自身の
+          // シーンに含まれる場合だけ resolve する（無ければエントリ開始にフォールバック）。
+          const resolvedStartSceneId =
+            sceneParam && entryScenes.some((s) => s.id === sceneParam) ? sceneParam : null
+          setStartSceneId(resolvedStartSceneId)
           setLoadDebugInfo([
             'mode: single script fallback',
             `entry: ${SCRIPT_BASENAME}`,
@@ -375,6 +390,11 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
             'loaded docs: 1',
             `scenes: ${entryScenes.length}`,
             `events: ${flattenDocumentEvents(entryDoc).length}`,
+            ...(sceneParam
+              ? [
+                  `scene param: ${sceneParam} → ${resolvedStartSceneId ? 'resolved' : 'not found (fallback to entry)'}`,
+                ]
+              : []),
           ])
           return
         }
@@ -410,8 +430,23 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
         //    供給元はエントリ doc (#284 S1)。
         setDoc(entryDoc)
 
-        // 初期ジャンプ解決索引は entry のシーンだけ。未ロード target は NovelRenderer の
-        // missingSceneResolver が必要時に追加する (#314)。
+        // #386: `?scene=` 指定があれば、対象 sceneId が属する script を NovelPlayer
+        // マウント前に事前解決・ロードする。resolveMissingScene（#314）をそのまま再利用し、
+        // sceneId→script のマッピングロジック（inferScriptPathsForSceneId）を重複実装しない。
+        // 見つかった場合は loadedDocsRef が更新済みなので、直後の buildSceneIndex に自然に乗る。
+        // 見つからない/無効な sceneId は null のまま＝現行どおりエントリから開始する。
+        let resolvedStartSceneId: string | null = null
+        if (sceneParam) {
+          const scenesWithTarget = await resolveMissingScene(sceneParam)
+          if (cancelled) return
+          if (scenesWithTarget && scenesWithTarget.some((s) => s.id === sceneParam)) {
+            resolvedStartSceneId = sceneParam
+          }
+        }
+        setStartSceneId(resolvedStartSceneId)
+
+        // 初期ジャンプ解決索引は entry のシーン + #386 で事前ロードした対象 script のシーン。
+        // 未ロード target は NovelRenderer の missingSceneResolver が必要時に追加する (#314)。
         const scenes = buildSceneIndex(entryPath, sortedPaths, loadedDocsRef.current)
         warnDuplicateSceneIds(scenes)
         if (cancelled) return
@@ -424,6 +459,11 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
           `persistent cache: enabled`,
           `lazy loading: enabled`,
           `scenes: ${scenes.length}`,
+          ...(sceneParam
+            ? [
+                `scene param: ${sceneParam} → ${resolvedStartSceneId ? 'resolved' : 'not found (fallback to entry)'}`,
+              ]
+            : []),
           `events: ${flattenDocumentEvents(entryDoc).length}`,
         ])
       } catch (e) {
@@ -442,7 +482,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
     return () => {
       cancelled = true
     }
-  }, [api, loadScriptDoc, projectName])
+  }, [api, loadScriptDoc, projectName, resolveMissingScene])
 
   // 通常再生ストリーム = エントリ doc を線形に flatten した Event[] (#284 M2)。
   // これを NovelPlayer に events= で渡すことで多シーンの線形自動進行が成立する。
@@ -540,6 +580,10 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
               events={novelEvents}
               jumpSceneIndex={allScenes}
               onResolveMissingScene={resolveMissingScene}
+              // #386: `?scene=<sceneId>` ディープリンク。事前解決できた場合のみ渡し、
+              // NovelPlayer マウント時に startFrom で該当シーンから開始する。
+              // null（未指定/未解決）なら渡さず、現行どおりエントリから開始する。
+              initialSceneId={startSceneId}
               assetBaseUrl={assetBaseUrl}
               aspectRatio={doc?.aspect_ratio}
               choiceStyle={doc?.choice_style ?? null}

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -143,15 +143,23 @@ function inferScriptPathsForSceneId(sceneId: string, paths: string[]): string[] 
  * HTML リンクで、埋め込み内の choice では遷移しない」という設計と矛盾する）。この一覧を
  * `NovelRenderer.setConfinedSceneIds` に渡し、圏外へのジャンプを終劇として扱わせる。
  *
- * 見つからなければ null（呼び出し側は confinement を有効化しない＝無制限のまま）。
+ * entry doc（hub。`entryPath` が指すファイル）は候補から除外する (#386 修正2)。
+ * `?scene=` が hub 自身の sceneId を指した場合、confinement を hub のシーン集合に
+ * してしまうと、hub → 各お題への通常 choice 遷移まで軒並み「圏外」＝即終劇になり、
+ * 汎用フローを壊す。hub 自身が指定された場合は null を返し、呼び出し側は confinement を
+ * 有効化しない（無制限フロー扱い）という割り切りにする。
+ *
+ * それ以外で見つからなければ null（呼び出し側は confinement を有効化しない＝無制限のまま）。
  * sceneId は全 MD でグローバル一意が前提（warnDuplicateSceneIds 参照）なので、
- * 最初に見つかった doc をそのまま採用する。
+ * 最初に見つかった（entry 以外の）doc をそのまま採用する。
  */
 function findConfinedSceneIds(
   targetSceneId: string,
-  docs: Map<string, EventDocument>
+  docs: Map<string, EventDocument>,
+  entryPath: string | null
 ): string[] | null {
-  for (const doc of docs.values()) {
+  for (const [path, doc] of docs) {
+    if (path === entryPath) continue // hub 自身は confinement の対象にしない
     const ids = flattenDocumentScenes(doc).map((s) => s.id)
     if (ids.includes(targetSceneId)) return ids
   }
@@ -475,11 +483,13 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
         setStartSceneId(resolvedStartSceneId)
 
         // confinement（在圏）一覧 (#386)。対象 sceneId が属する doc 自身の sceneId 一覧に
-        // 限定する。これにより NovelRenderer.jumpToScene がこの集合外（hub・他ファイル）への
-        // choice ジャンプを終劇として扱い、単独埋め込みに hub の内容が漏れるのを防ぐ
-        // （theo-hayami #20: 他ファイルへは HTML リンクで、埋め込み内の choice では遷移しない）。
+        // 限定する（entry/hub 自身は候補から除外・修正2）。これにより NovelRenderer.jumpToScene
+        // がこの集合外（hub・他ファイル）への choice ジャンプを終劇として扱い、単独埋め込みに
+        // hub の内容が漏れるのを防ぐ（theo-hayami #20: 他ファイルへは HTML リンクで、埋め込み
+        // 内の choice では遷移しない）。`?scene=` が hub 自身の sceneId を指した場合は
+        // findConfinedSceneIds が null を返す＝無制限フローにフォールバックする。
         const confinedIds = resolvedStartSceneId
-          ? findConfinedSceneIds(resolvedStartSceneId, loadedDocsRef.current)
+          ? findConfinedSceneIds(resolvedStartSceneId, loadedDocsRef.current, entryPath)
           : null
         setConfinedSceneIds(confinedIds)
 

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -135,6 +135,29 @@ function inferScriptPathsForSceneId(sceneId: string, paths: string[]): string[] 
   return paths.filter((path) => basenames.has(basename(path)))
 }
 
+/**
+ * 対象 sceneId が属する doc（script ファイル）自身のシーンID一覧を返す (#386 confinement)。
+ *
+ * `?scene=` ディープリンク単独埋め込みでは、対象ファイル外（hub・他ファイル）への choice
+ * ジャンプが埋め込みの外側の内容を漏らしてしまう（theo-hayami #20 の「他ファイルへは
+ * HTML リンクで、埋め込み内の choice では遷移しない」という設計と矛盾する）。この一覧を
+ * `NovelRenderer.setConfinedSceneIds` に渡し、圏外へのジャンプを終劇として扱わせる。
+ *
+ * 見つからなければ null（呼び出し側は confinement を有効化しない＝無制限のまま）。
+ * sceneId は全 MD でグローバル一意が前提（warnDuplicateSceneIds 参照）なので、
+ * 最初に見つかった doc をそのまま採用する。
+ */
+function findConfinedSceneIds(
+  targetSceneId: string,
+  docs: Map<string, EventDocument>
+): string[] | null {
+  for (const doc of docs.values()) {
+    const ids = flattenDocumentScenes(doc).map((s) => s.id)
+    if (ids.includes(targetSceneId)) return ids
+  }
+  return null
+}
+
 function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenProps) {
   const viewportHeight = useVisualViewportHeight()
   const api = useMemo(() => createApiClient({ baseUrl: apiBaseUrl }), [apiBaseUrl])
@@ -158,6 +181,11 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
   // allScenes に反映できた場合だけ sceneId を保持する。見つからない/未指定は null＝
   // NovelPlayer には initialSceneId を渡さず、現行どおりエントリ（ハブ）から開始する。
   const [startSceneId, setStartSceneId] = useState<string | null>(null)
+  // confinement（在圏）一覧 (#386)。startSceneId が解決できた（＝?scene= ディープリンク単独
+  // 埋め込みモード）ときだけ、対象 script ファイル自身の sceneId 一覧を持つ。null は
+  // 制限なし＝通常のハブ経由フロー（listScripts 不能の単一ファイルフォールバックも、
+  // 元々ファイルをまたげないため null のままでよい）。
+  const [confinedSceneIds, setConfinedSceneIds] = useState<string[] | null>(null)
   const sortedPlayablePathsRef = useRef<string[]>([])
   const scriptInfoByPathRef = useRef<Map<string, ScriptInfo>>(new Map())
   const entryPathRef = useRef<string | null>(null)
@@ -302,6 +330,7 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
       setUnpopulated(false)
       setLoadDebugInfo([])
       setStartSceneId(null)
+      setConfinedSceneIds(null)
       sortedPlayablePathsRef.current = []
       scriptInfoByPathRef.current = new Map()
       entryPathRef.current = null
@@ -445,6 +474,15 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
         }
         setStartSceneId(resolvedStartSceneId)
 
+        // confinement（在圏）一覧 (#386)。対象 sceneId が属する doc 自身の sceneId 一覧に
+        // 限定する。これにより NovelRenderer.jumpToScene がこの集合外（hub・他ファイル）への
+        // choice ジャンプを終劇として扱い、単独埋め込みに hub の内容が漏れるのを防ぐ
+        // （theo-hayami #20: 他ファイルへは HTML リンクで、埋め込み内の choice では遷移しない）。
+        const confinedIds = resolvedStartSceneId
+          ? findConfinedSceneIds(resolvedStartSceneId, loadedDocsRef.current)
+          : null
+        setConfinedSceneIds(confinedIds)
+
         // 初期ジャンプ解決索引は entry のシーン + #386 で事前ロードした対象 script のシーン。
         // 未ロード target は NovelRenderer の missingSceneResolver が必要時に追加する (#314)。
         const scenes = buildSceneIndex(entryPath, sortedPaths, loadedDocsRef.current)
@@ -584,6 +622,10 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
               // NovelPlayer マウント時に startFrom で該当シーンから開始する。
               // null（未指定/未解決）なら渡さず、現行どおりエントリから開始する。
               initialSceneId={startSceneId}
+              // #386: 対象 script ファイル自身の sceneId 一覧。hub 等その集合外への choice
+              // ジャンプは通常のシーン遷移ではなく終劇として扱われる（NovelPlayer 経由で
+              // NovelRenderer.setConfinedSceneIds に渡る）。null（未指定/未解決）は無制限。
+              confinedSceneIds={confinedSceneIds}
               assetBaseUrl={assetBaseUrl}
               aspectRatio={doc?.aspect_ratio}
               choiceStyle={doc?.choice_style ?? null}


### PR DESCRIPTION
## 関連 Issue
Refs #386

## 変更内容

theo-hayamiサイト設計（theo-hayami #20「1セル1URL＝1遅延埋め込み」）の前提となる、name-nameプレイヤーへの直接ディープリンク機能を追加した。

### 1. production向け `?scene=` ディープリンク
- `?scene=<sceneId>` というURLクエリで、production でも常時有効な「特定シーンから直接再生開始」の口を追加（`sceneQuery.ts`）。DEV専用の既存 `debug_scene` とは別系統。
- `PlayerScreen` が対象sceneIdの所属scriptを事前解決・遅延ロードしてから `NovelPlayer` に `initialSceneId` として渡す。無効/未解決ならエントリ（ハブ）から開始する既存挙動にフォールバック。

### 2. confinement（閉じ込め）+ 終劇
- `?scene=` で解決された場合、対象scriptファイル自身のsceneIdだけを在圏とし（hub/他ファイルは圏外）、圏外へのchoiceジャンプは通常のシーン遷移にせず「終劇」（`NovelRenderer.endStory()`）にする。
- 終劇時は背景・立ち絵をフェードアウトし（既存フェード機構を流用）、以後 `advance()` は no-op。DOM側に控えめな斜体の "to be continued..." 表示（右下ボタン行の少し上）。
- 終劇状態は `NovelGameState.storyEnded` という宣言的フラグとして持ち、GameState規約（ADR 0002）に沿って `getSnapshot`/`applyState` で往復する。セーブは意図的に `storyEnded` を持ち越さない設計。

### 3. レビューで見つかった不具合の修正
- `quickSave()`/`openSaveMenu()` が `storyEnded` 中でも通ってしまい、ロード時に行き止まり状態になり得た → ガード追加。
- `?scene=` がhub自身のsceneIdを指した場合、confinementがhub自身になりhub→各お題への通常choice遷移まで巻き込まれる問題 → entry docをconfinement候補から除外。

### 4. テスト・docs
- 51件のテストケースを新規追加（`sceneQuery`/`sceneConfinement`の純粋関数テスト、`NovelRenderer`のconfinement/終劇/race条件、`NovelPlayer`/`PlayerScreen`の配線）。既存1731件と合わせて全1782件green。
- `docs/architecture.md`・ADR 0002・`docs/guide/debugger.md` を更新（production向け`?scene=`とDEV専用`debug_scene`の違いを明記）。

## Test plan
- [x] `npm run type-check` クリーン
- [x] `npm run lint` クリーン
- [x] `npx vitest run` 全件green（67ファイル/1782テスト）
- [ ] 実機/Playwrightでの見た目確認（"to be continued..."の位置・フェード、縦9:16/横16:9両方）は未実施。theo-hayamiサイト側の埋め込み実装時に合わせて確認する