### PR TITLE
?scene= ディープリンク時はタイトル画面を飛ばしシーンへ直行する

### DIFF
--- a/frontend/src/screens/PlayerScreen.test.tsx
+++ b/frontend/src/screens/PlayerScreen.test.tsx
@@ -1395,5 +1395,32 @@ describe('PlayerScreen', () => {
       const debugInfo = lastNovelPlayerProps().debugInfo as string[]
       expect(debugInfo).toContain('scene param: no-such-scene → not found (fallback to entry)')
     })
+
+    // #388: ディープリンク解決時は TitleOverlay を出さず該当シーンへ直行する。
+    // TitleOverlay の存在は「新規開始」ボタン（TitleOverlay 固有の文言）で判定する。
+    it('48【#388】: ?scene= 解決時（deep-link モード）は TitleOverlay（新規開始ボタン）を出さない', async () => {
+      window.history.pushState({}, '', '?scene=cell-scene-1')
+      await renderMultiDocProject()
+      // 前提: deep-link が解決されている（initialSceneId 非 null）
+      expect(lastNovelPlayerProps().initialSceneId).toBe('cell-scene-1')
+      // タイトルは出ない＝startFrom(initialSceneId) の該当シーンをそのまま見せる
+      expect(screen.queryByRole('button', { name: '新規開始' })).toBeNull()
+    })
+
+    it('49【#388】: ?scene= 未指定時（通常フロー）は従来どおり TitleOverlay（新規開始ボタン）を出す', async () => {
+      await renderMultiDocProject()
+      expect(lastNovelPlayerProps().initialSceneId).toBeNull()
+      expect(screen.getByRole('button', { name: '新規開始' })).toBeInTheDocument()
+    })
+
+    it('50【#388】: ?scene=<entry(hub)自身の sceneId> でも解決されれば deep-link モードとして TitleOverlay を出さない', async () => {
+      // hub 自身指定は confinedSceneIds=null（無制限）にフォールバックするが、
+      // initialSceneId は解決される（#386 修正2）。deep-link モード判定は startSceneId 非 null なので
+      // この場合もタイトルは出さない（startFrom(hub-scene) の位置を保つ）。
+      window.history.pushState({}, '', '?scene=hub-scene')
+      await renderMultiDocProject()
+      expect(lastNovelPlayerProps().initialSceneId).toBe('hub-scene')
+      expect(screen.queryByRole('button', { name: '新規開始' })).toBeNull()
+    })
   })
 })

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -655,8 +655,18 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
               docKey={projectName}
               initialSkipMode={startWithSkip}
             />
-            {/* タイトル画面オーバーレイ (#141): ゲーム開始前に表示 */}
-            {!titleDismissed && (
+            {/* タイトル画面オーバーレイ (#141): ゲーム開始前に表示。
+                #388: `?scene=` ディープリンク解決時（startSceneId 非 null＝deep-link モード）は
+                タイトルを一切出さず、NovelPlayer が startFrom(initialSceneId) で開始した該当シーンを
+                そのまま見せる。startSceneId はスクリプトロード後に非同期解決されるが、
+                setStartSceneId と setLoading(false) は同一の非同期継続内でバッチされるため、
+                loading=false になる最初のレンダー時点で startSceneId は確定済み。ここで
+                render gate として直接判定すれば effect 同期のような 1 フレームのタイトルちらつきが
+                出ない。deep-link モードでは TitleOverlay 自体を描かないので、onNewGame の副作用
+                （clearReadProgress / renderer.restart()）が発火することも構造的にあり得ず、
+                startFrom(initialSceneId) の開始位置が保たれる。
+                通常フロー（`?scene=` 無し＝startSceneId null）は従来どおりタイトルを出す（後方互換）。 */}
+            {startSceneId === null && !titleDismissed && (
               <TitleOverlay
                 title={title}
                 titleImageUrl={`${assetBaseUrl}/images/title.png`}


### PR DESCRIPTION
## 関連 Issue
closes #388

## 背景

#386（PR #387）で `?scene=` ディープリンクを実装・本番デプロイしたが、**本番実機検証（ルール7）で、ディープリンクがタイトル画面（TitleOverlay #141・新規開始/つづきから/設定/終了）に阻まれてエピソードに直行しないことが判明**した。

## 変更

`PlayerScreen.tsx` の TitleOverlay 描画ゲートを `!titleDismissed` → `startSceneId === null && !titleDismissed` に変更。

- `startSceneId` 非null＝`?scene=` 解決済み（deep-link モード）のときは TitleOverlay を一切描かず、`startFrom(initialSceneId)` で開始した該当シーンを直接見せる。
- effect 同期でなく render gate 直接判定にした（`setStartSceneId`/`setLoading(false)` が同一非同期継続でバッチされ、loading=false の初回レンダー時点で startSceneId 確定済み＝1フレームのタイトルちらつきが出ない）。
- deep-link モードでは overlay 自体が無いので、`onNewGame` の `clearReadProgress`/`renderer.restart()` が発火せず、開始位置が構造的に保たれる（ハブへの巻き戻り無し）。
- 通常 `/play/:projectName`（`?scene=` 無し）は従来どおりタイトルを出す（後方互換）。
- AudioContext: 従来 onNewGame がジェスチャ起点だったが、deep-link では最初の本文送りタップ（`handleAdvance`→`ensureContext`）が起点になる。theo-hayami は「無音で読める設計が基本」なので許容。経路が生きていることを確認済み。

## Test plan
- [x] `PlayerScreen.test.tsx` に3件追加（scene解決→タイトル非表示 / scene無し→タイトル表示 / hub自身指定→deep-linkモード維持）
- [x] `npm run type-check` / `npm run lint` クリーン
- [x] `npx vitest run` 全1790件green
- [x] ローカルdev（本番API）で `?scene=aristo-ai` がタイトルメニューを出さないことを確認（シーン描画自体はCORSでローカル検証不可・本番マージ後に確認）