### PR TITLE
埋め込み(iframe)表示時はプレイヤーのヘッダ(戻る/タイトル)を出さない

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,6 +156,14 @@ choke point）はこの集合外への遷移を検知すると通常のシーン
 （ADR 0002 の「演出の中間状態を持たない」規律との関係）は
 [ADR 0002](./adr/0002-deterministic-state-and-debuggability.md) を参照。
 
+**埋め込み時のヘッダ抑制（#392）**: `PlayerScreen` 上端のヘッダ（プロジェクト一覧への戻る
+ボタン＋タイトル）は、**iframe に埋め込まれて表示されているとき（`utils/isEmbedded.ts` の
+`isEmbedded()` ＝ `window.self !== window.top`）は描画しない**。埋め込み文脈では name-name の
+トップへ戻る導線が無意味で、埋め込み側（theo-hayami 等）が既に額縁とタイトルを出しており二重に
+なるため。standalone タブで `/play/*` を直接開いたときは従来どおりヘッダを出す（後方互換）。
+これは `?scene=` に依存しない一般的な埋め込み挙動で、`?scene=`（＝ディープリンク意図＝#388 の
+TitleOverlay 飛ばしの条件）とは関心が別（ゲートも別）。
+
 ### 再生時
 
 ```

--- a/frontend/src/screens/PlayerScreen.test.tsx
+++ b/frontend/src/screens/PlayerScreen.test.tsx
@@ -1471,15 +1471,32 @@ describe('PlayerScreen', () => {
         expect(screen.queryByRole('banner')).toBeNull()
       })
 
-      it('埋め込み時は ?scene=<cell の sceneId> ディープリンク有りでもヘッダを描画しない（当初の startSceneId 誤設計への回帰防止）', async () => {
+      it('埋め込み時は ?scene=<cell の sceneId> ディープリンク有りでもヘッダを描画しない（?scene= 有無に依存しない＝直交の担保）', async () => {
         isEmbeddedMock.mockReturnValue(true)
         window.history.pushState({}, '', '?scene=cell-scene-1')
         await renderMultiDocProject()
         // 前提: ?scene= は実際に解決している（scene param が効いていることの確認）。
         // それでもヘッダ抑制は isEmbedded() が担い、startSceneId には依存しない。
+        // 注: 旧 startSceneId 設計の回帰そのものは、この embedded×scene 条件では新旧どちらも
+        // ヘッダが隠れて弁別しない。旧設計を射抜くのは embedded×no-scene の上の2ケース
+        // （旧設計なら startSceneId===null でヘッダが出てしまい赤くなる）。本ケースの価値は
+        // 「埋め込みなら ?scene= が有ってもヘッダを再表示させない」＝直交の担保。
         expect(lastNovelPlayerProps().initialSceneId).toBe('cell-scene-1')
         expect(screen.queryByLabelText('プロジェクト一覧に戻る')).toBeNull()
         expect(screen.queryByRole('banner')).toBeNull()
+      })
+
+      it('standalone は ?scene=<cell の sceneId> ディープリンク有りでもヘッダを描画する（抑制は isEmbedded が担い ?scene= は無関係・4象限を閉じる）', async () => {
+        // 既定 false（standalone）のまま。architecture.md の約束＝`?scene=` 標準タブ直開きは
+        // ヘッダ有。抑制ゲートが isEmbedded() であり startSceneId/?scene= に依存しないことを
+        // standalone 方向でも固定する（embedded×scene と対を成す）。
+        window.history.pushState({}, '', '?scene=cell-scene-1')
+        await renderMultiDocProject()
+        // ?scene= は解決している（deep-link だが standalone なのでヘッダは出る）
+        expect(lastNovelPlayerProps().initialSceneId).toBe('cell-scene-1')
+        expect(screen.queryByLabelText('プロジェクト一覧に戻る')).not.toBeNull()
+        const banner = screen.getByRole('banner')
+        expect(within(banner).getByRole('heading', { level: 1 }).textContent).toBe(MULTI_DOC_TITLE)
       })
 
       it('埋め込み判定は #388 の TitleOverlay ゲート（startSceneId）と直交する（埋め込みでヘッダは消えるが ?scene= 未指定なら TitleOverlay の新規開始は従来どおり出る）', async () => {

--- a/frontend/src/screens/PlayerScreen.test.tsx
+++ b/frontend/src/screens/PlayerScreen.test.tsx
@@ -106,6 +106,15 @@ vi.mock('../components/RPGPlayer', () => ({
   },
 }))
 
+// #392: iframe 埋め込み検知 isEmbedded() を stub する。純粋関数なので true/false を
+// 切り替えるだけでヘッダ抑制ゲート（PlayerScreen: const embedded = isEmbedded() →
+// {!embedded && <header>...}）を分岐できる（window.top 差し替えより堅牢）。既定値は
+// 下の global beforeEach で false（standalone）に固定し、埋め込みテストだけ true に上書きする。
+const { isEmbeddedMock } = vi.hoisted(() => ({ isEmbeddedMock: vi.fn() }))
+vi.mock('../utils/isEmbedded', () => ({
+  isEmbedded: isEmbeddedMock,
+}))
+
 import PlayerScreen from './PlayerScreen'
 
 /**
@@ -172,6 +181,10 @@ beforeEach(() => {
   parseMarkdownMock.mockReset()
   novelPlayerProps.mockReset()
   rpgPlayerProps.mockReset()
+  isEmbeddedMock.mockReset()
+  // 既定は standalone（非 iframe）。jsdom の本物 isEmbedded() も self===top で false を
+  // 返すので後方互換。埋め込みを検証するテストだけ mockReturnValue(true) で上書きする。
+  isEmbeddedMock.mockReturnValue(false)
 })
 
 afterEach(() => {
@@ -1427,20 +1440,22 @@ describe('PlayerScreen', () => {
       expect(screen.queryByRole('button', { name: '新規開始' })).toBeNull()
     })
 
-    // --- #392: `?scene=` 埋め込み時はプレイヤーヘッダ（戻る＋タイトル）を描画しない ---
+    // --- #392: iframe 埋め込み表示時はプレイヤーヘッダ（戻る＋タイトル）を描画しない ---
     //
-    // ゲートは #388 の TitleOverlay と同じ startSceneId===null。ヘッダの有無は
-    // ユーザー可視要素で判定する:
+    // 抑制ゲートは iframe 埋め込み検知 isEmbedded()（PlayerScreen.tsx:
+    // `const embedded = isEmbedded()` → `{!embedded && <header>...}`）。
+    // isEmbedded は純粋関数なのでファイル先頭で vi.mock し、true/false を切り替えて分岐させる
+    // （window.top 差し替えより堅牢）。既定は global beforeEach で false（standalone）に固定。
+    // ヘッダの有無はユーザー可視要素で判定する:
     //   - 戻るボタン: aria-label='プロジェクト一覧に戻る'（ヘッダ固有。TitleOverlay の
     //     終了ボタンは text '終了' で aria-label を持たないため衝突しない）
     //   - <header> 要素（暗黙 role=banner）内のタイトル h1
-    // startSceneId 非 null（deep-link/埋め込み）で消え、null（通常フロー・無効 scene の
-    // フォールバック）で出ることを、否定・肯定の両側で担保する。
+    // 埋め込み(true)で消え、standalone(false)で出ることを否定・肯定の両側で担保する。
+    // ヘッダ抑制は `?scene=`（#388 の startSceneId ゲート）と直交する。
     describe('プレイヤーヘッダ（戻る/タイトル）の表示制御 (#392)', () => {
-      it('通常フロー（?scene= 未指定）は戻るボタンとタイトル h1 を持つヘッダを描画する', async () => {
+      it('standalone（isEmbedded()===false）は戻るボタンとタイトル h1 を持つヘッダを描画する', async () => {
+        // 既定 false のまま（global beforeEach の mockReturnValue(false)）
         await renderMultiDocProject()
-        // 前提: deep-link ではない（startSceneId=null 相当＝initialSceneId 未解決）
-        expect(lastNovelPlayerProps().initialSceneId).toBeNull()
         // ヘッダ固有の戻るボタンが存在する
         expect(screen.queryByLabelText('プロジェクト一覧に戻る')).not.toBeNull()
         // <header>（banner）内にプロジェクトタイトルの h1 が出る（title.png は jsdom で
@@ -1449,37 +1464,35 @@ describe('PlayerScreen', () => {
         expect(within(banner).getByRole('heading', { level: 1 }).textContent).toBe(MULTI_DOC_TITLE)
       })
 
-      it('?scene=<cell の sceneId> 解決時（deep-link モード）はヘッダ（戻る/タイトル）を描画しない', async () => {
+      it('埋め込み（isEmbedded()===true）はヘッダ（戻るボタン/banner）を描画しない', async () => {
+        isEmbeddedMock.mockReturnValue(true)
+        await renderMultiDocProject()
+        expect(screen.queryByLabelText('プロジェクト一覧に戻る')).toBeNull()
+        expect(screen.queryByRole('banner')).toBeNull()
+      })
+
+      it('埋め込み時は ?scene=<cell の sceneId> ディープリンク有りでもヘッダを描画しない（当初の startSceneId 誤設計への回帰防止）', async () => {
+        isEmbeddedMock.mockReturnValue(true)
         window.history.pushState({}, '', '?scene=cell-scene-1')
         await renderMultiDocProject()
-        // 前提: deep-link が解決している（startSceneId 非 null）
+        // 前提: ?scene= は実際に解決している（scene param が効いていることの確認）。
+        // それでもヘッダ抑制は isEmbedded() が担い、startSceneId には依存しない。
         expect(lastNovelPlayerProps().initialSceneId).toBe('cell-scene-1')
-        // 戻るボタンも <header>（banner）も描画されない
         expect(screen.queryByLabelText('プロジェクト一覧に戻る')).toBeNull()
         expect(screen.queryByRole('banner')).toBeNull()
       })
 
-      it('?scene=<entry(hub)自身の sceneId>（confinedSceneIds=null でも startSceneId 非 null）ならヘッダを描画しない', async () => {
-        window.history.pushState({}, '', '?scene=hub-scene')
+      it('埋め込み判定は #388 の TitleOverlay ゲート（startSceneId）と直交する（埋め込みでヘッダは消えるが ?scene= 未指定なら TitleOverlay の新規開始は従来どおり出る）', async () => {
+        isEmbeddedMock.mockReturnValue(true)
         await renderMultiDocProject()
-        // 前提: startSceneId は解決されるが confinement は無制限（#386 修正2）。
-        // ヘッダゲートは startSceneId のみに依存し confinedSceneIds には依存しないことの担保。
-        expect(lastNovelPlayerProps().initialSceneId).toBe('hub-scene')
-        expect(lastNovelPlayerProps().confinedSceneIds).toBeNull()
+        // ヘッダは isEmbedded()===true で消える
         expect(screen.queryByLabelText('プロジェクト一覧に戻る')).toBeNull()
         expect(screen.queryByRole('banner')).toBeNull()
-      })
-
-      it('?scene=<存在しない sceneId> フォールバック（startSceneId が null に戻る）はヘッダを描画する', async () => {
-        window.history.pushState({}, '', '?scene=no-such-scene')
-        await renderMultiDocProject()
-        // 前提: 解決失敗で startSceneId=null にフォールバック（initialSceneId=null）。
-        // ゲートが initialSceneId prop でなく startSceneId state であることの回帰防止:
-        // 無効 scene でも通常フロー扱いに戻ってヘッダ（戻る/タイトル）が復活する。
+        // 一方 TitleOverlay は startSceneId===null（?scene= 未指定）なので従来どおり出る。
+        // ＝ヘッダ抑制ゲート（isEmbedded）が TitleOverlay 表示ゲート（startSceneId）に
+        // 影響しないことの担保。
         expect(lastNovelPlayerProps().initialSceneId).toBeNull()
-        expect(screen.queryByLabelText('プロジェクト一覧に戻る')).not.toBeNull()
-        const banner = screen.getByRole('banner')
-        expect(within(banner).getByRole('heading', { level: 1 }).textContent).toBe(MULTI_DOC_TITLE)
+        expect(screen.getByRole('button', { name: '新規開始' })).toBeInTheDocument()
       })
     })
   })

--- a/frontend/src/screens/PlayerScreen.test.tsx
+++ b/frontend/src/screens/PlayerScreen.test.tsx
@@ -8,7 +8,7 @@
 //   - データ取得失敗時にエラーメッセージが表示される
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor, within } from '@testing-library/react'
 // #284: NovelRenderer.jumpToScene が使う実シーン解決プリミティブ。
 // PlayerScreen が連結した scenes に対してクロスファイルのジャンプが解決することを、
 // 実装で実際に使われるこの純粋関数で確認する（Pixi/NovelRenderer は jsdom で init 不可）。
@@ -1201,10 +1201,14 @@ describe('PlayerScreen', () => {
       window.history.pushState({}, '', '/')
     })
 
+    // マルチ MD 構成のプロジェクトタイトル。mock（listProjects）と #392 のヘッダ h1
+    // アサーションで同じ定数を参照し、期待値の直書き・二重管理を避ける。
+    const MULTI_DOC_TITLE = 'せおはやみ'
+
     /** hub(script.md) 1 シーン + 別 MD(cell) 2 シーンの標準的なマルチ MD 構成をセットアップする。 */
     function mockMultiDocProject() {
       listProjectsMock.mockResolvedValue([
-        { name: 'theo-hayami', title: 'せおはやみ', repo: 'kako-jun/theo-hayami' },
+        { name: 'theo-hayami', title: MULTI_DOC_TITLE, repo: 'kako-jun/theo-hayami' },
       ])
       listScriptsMock.mockResolvedValue([
         { path: 'script.md', sha: 's0', size: 1, title: null, hidden: false },
@@ -1421,6 +1425,62 @@ describe('PlayerScreen', () => {
       await renderMultiDocProject()
       expect(lastNovelPlayerProps().initialSceneId).toBe('hub-scene')
       expect(screen.queryByRole('button', { name: '新規開始' })).toBeNull()
+    })
+
+    // --- #392: `?scene=` 埋め込み時はプレイヤーヘッダ（戻る＋タイトル）を描画しない ---
+    //
+    // ゲートは #388 の TitleOverlay と同じ startSceneId===null。ヘッダの有無は
+    // ユーザー可視要素で判定する:
+    //   - 戻るボタン: aria-label='プロジェクト一覧に戻る'（ヘッダ固有。TitleOverlay の
+    //     終了ボタンは text '終了' で aria-label を持たないため衝突しない）
+    //   - <header> 要素（暗黙 role=banner）内のタイトル h1
+    // startSceneId 非 null（deep-link/埋め込み）で消え、null（通常フロー・無効 scene の
+    // フォールバック）で出ることを、否定・肯定の両側で担保する。
+    describe('プレイヤーヘッダ（戻る/タイトル）の表示制御 (#392)', () => {
+      it('通常フロー（?scene= 未指定）は戻るボタンとタイトル h1 を持つヘッダを描画する', async () => {
+        await renderMultiDocProject()
+        // 前提: deep-link ではない（startSceneId=null 相当＝initialSceneId 未解決）
+        expect(lastNovelPlayerProps().initialSceneId).toBeNull()
+        // ヘッダ固有の戻るボタンが存在する
+        expect(screen.queryByLabelText('プロジェクト一覧に戻る')).not.toBeNull()
+        // <header>（banner）内にプロジェクトタイトルの h1 が出る（title.png は jsdom で
+        // 読み込まれないため TitleOverlay 側にも h1 は出るが、banner スコープ内の 1 本を見る）
+        const banner = screen.getByRole('banner')
+        expect(within(banner).getByRole('heading', { level: 1 }).textContent).toBe(MULTI_DOC_TITLE)
+      })
+
+      it('?scene=<cell の sceneId> 解決時（deep-link モード）はヘッダ（戻る/タイトル）を描画しない', async () => {
+        window.history.pushState({}, '', '?scene=cell-scene-1')
+        await renderMultiDocProject()
+        // 前提: deep-link が解決している（startSceneId 非 null）
+        expect(lastNovelPlayerProps().initialSceneId).toBe('cell-scene-1')
+        // 戻るボタンも <header>（banner）も描画されない
+        expect(screen.queryByLabelText('プロジェクト一覧に戻る')).toBeNull()
+        expect(screen.queryByRole('banner')).toBeNull()
+      })
+
+      it('?scene=<entry(hub)自身の sceneId>（confinedSceneIds=null でも startSceneId 非 null）ならヘッダを描画しない', async () => {
+        window.history.pushState({}, '', '?scene=hub-scene')
+        await renderMultiDocProject()
+        // 前提: startSceneId は解決されるが confinement は無制限（#386 修正2）。
+        // ヘッダゲートは startSceneId のみに依存し confinedSceneIds には依存しないことの担保。
+        expect(lastNovelPlayerProps().initialSceneId).toBe('hub-scene')
+        expect(lastNovelPlayerProps().confinedSceneIds).toBeNull()
+        expect(screen.queryByLabelText('プロジェクト一覧に戻る')).toBeNull()
+        expect(screen.queryByRole('banner')).toBeNull()
+      })
+
+      it('?scene=<存在しない sceneId> フォールバック（startSceneId が null に戻る）はヘッダを描画する', async () => {
+        window.history.pushState({}, '', '?scene=no-such-scene')
+        await renderMultiDocProject()
+        // 前提: 解決失敗で startSceneId=null にフォールバック（initialSceneId=null）。
+        // ゲートが initialSceneId prop でなく startSceneId state であることの回帰防止:
+        // 無効 scene でも通常フロー扱いに戻ってヘッダ（戻る/タイトル）が復活する。
+        expect(lastNovelPlayerProps().initialSceneId).toBeNull()
+        expect(screen.queryByLabelText('プロジェクト一覧に戻る')).not.toBeNull()
+        const banner = screen.getByRole('banner')
+        expect(within(banner).getByRole('heading', { level: 1 }).textContent).toBe(MULTI_DOC_TITLE)
+      })
     })
   })
 })

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -10,6 +10,7 @@ import { ApiError, createApiClient, type ProjectInfo, type ScriptInfo } from '..
 import { clearReadProgress, hasAnyReadProgress } from '../game/readProgress'
 import { parseSceneQuery } from '../game/sceneQuery'
 import { useVisualViewportHeight } from '../utils/useVisualViewportHeight'
+import { isEmbedded } from '../utils/isEmbedded'
 import {
   getCachedParsedScriptDocument,
   getCachedScriptContent,
@@ -168,6 +169,8 @@ function findConfinedSceneIds(
 
 function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenProps) {
   const viewportHeight = useVisualViewportHeight()
+  // iframe 埋め込み表示か (#392)。マウント中は不変なので state 化せずレンダー時に一度評価する。
+  const embedded = isEmbedded()
   const api = useMemo(() => createApiClient({ baseUrl: apiBaseUrl }), [apiBaseUrl])
   // doc: エントリ MD のドキュメント。通常再生ストリーム（線形 events）の供給元であり、
   // かつ RPG 判定・aspect_ratio / choice_style / font_family 等の per-game 設定の
@@ -562,14 +565,18 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
       style={{ height: viewportHeight, minHeight: viewportHeight }}
     >
       {/* プレイヤーヘッダ（戻る＋タイトル）(#392):
-          #388 と同じゲート startSceneId===null を使う。`?scene=` ディープリンク解決時
-          （startSceneId 非 null＝deep-link/埋め込みモード）は、theo-hayami 等の埋め込み側が
-          既に HTML 額縁とタイトルを出しており、name-name 自身のヘッダはタイトル二重・
-          戻るボタンが無意味・没入破壊になるため描画しない（delivery ショーケースモード）。
-          通常フロー（`?scene=` 無し＝startSceneId null）は従来どおりヘッダを出す（後方互換）。
+          iframe 埋め込み表示時（isEmbedded()）は描画しない。theo-hayami 等の埋め込み側が
+          既に HTML 額縁とタイトルを出しており、name-name トップへ戻る導線は埋め込み文脈で
+          無意味・タイトル二重・没入破壊になるため（delivery ショーケースモード）。
+          埋め込み条件は「iframe 内か」であって `?scene=` の有無ではない。`?scene=` は #388 の
+          タイトル飛ばし（startSceneId）の条件であり、ヘッダ抑制の条件ではない。
+          standalone タブで name-name.llll-ll.com/play/... を直接開いたときは name-name 自身の
+          サイトなので従来どおりヘッダを出す（後方互換）。
+          （#388 の TitleOverlay ゲートは deep-link 意図で startSceneId のまま。こちらは
+          埋め込み文脈判定で isEmbedded()。関心が別なのでゲートも別。）
           ヘッダを外しても外枠は flex-col、<main> が flex-1 で全高を埋める（viewportHeight は
           visual viewport 全高で header 高さ前提を持たない）。 */}
-      {startSceneId === null && (
+      {!embedded && (
         <header
           className={`border-b ${isDark ? 'border-gray-700 bg-gray-900' : 'border-blue-200 bg-blue-50'}`}
         >

--- a/frontend/src/screens/PlayerScreen.tsx
+++ b/frontend/src/screens/PlayerScreen.tsx
@@ -561,32 +561,42 @@ function PlayerScreen({ projectName, apiBaseUrl, isDark, onBack }: PlayerScreenP
       className={`flex flex-col overflow-hidden ${isDark ? 'dark bg-gray-900' : 'bg-white'}`}
       style={{ height: viewportHeight, minHeight: viewportHeight }}
     >
-      <header
-        className={`border-b ${isDark ? 'border-gray-700 bg-gray-900' : 'border-blue-200 bg-blue-50'}`}
-      >
-        <div className="px-6 py-2 flex items-center gap-3">
-          <button
-            onClick={onBack}
-            aria-label="プロジェクト一覧に戻る"
-            className={`w-8 h-8 flex items-center justify-center rounded transition-colors ${
-              isDark ? 'text-gray-300 hover:bg-gray-800' : 'text-gray-600 hover:bg-gray-100'
-            }`}
-            title="プロジェクト一覧に戻る"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
-          </button>
-          <h1 className={`text-lg font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
-            {title}
-          </h1>
-        </div>
-      </header>
+      {/* プレイヤーヘッダ（戻る＋タイトル）(#392):
+          #388 と同じゲート startSceneId===null を使う。`?scene=` ディープリンク解決時
+          （startSceneId 非 null＝deep-link/埋め込みモード）は、theo-hayami 等の埋め込み側が
+          既に HTML 額縁とタイトルを出しており、name-name 自身のヘッダはタイトル二重・
+          戻るボタンが無意味・没入破壊になるため描画しない（delivery ショーケースモード）。
+          通常フロー（`?scene=` 無し＝startSceneId null）は従来どおりヘッダを出す（後方互換）。
+          ヘッダを外しても外枠は flex-col、<main> が flex-1 で全高を埋める（viewportHeight は
+          visual viewport 全高で header 高さ前提を持たない）。 */}
+      {startSceneId === null && (
+        <header
+          className={`border-b ${isDark ? 'border-gray-700 bg-gray-900' : 'border-blue-200 bg-blue-50'}`}
+        >
+          <div className="px-6 py-2 flex items-center gap-3">
+            <button
+              onClick={onBack}
+              aria-label="プロジェクト一覧に戻る"
+              className={`w-8 h-8 flex items-center justify-center rounded transition-colors ${
+                isDark ? 'text-gray-300 hover:bg-gray-800' : 'text-gray-600 hover:bg-gray-100'
+              }`}
+              title="プロジェクト一覧に戻る"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15 19l-7-7 7-7"
+                />
+              </svg>
+            </button>
+            <h1 className={`text-lg font-semibold ${isDark ? 'text-white' : 'text-gray-900'}`}>
+              {title}
+            </h1>
+          </div>
+        </header>
+      )}
 
       <main className="flex-1 overflow-hidden relative">
         {loading ? (

--- a/frontend/src/utils/isEmbedded.test.ts
+++ b/frontend/src/utils/isEmbedded.test.ts
@@ -1,0 +1,40 @@
+// isEmbedded() 本体（window.self !== window.top の iframe 埋め込み判定）の単体テスト (#392)。
+//
+// PlayerScreen.test.tsx など呼び出し側は isEmbedded を vi.mock で差し替えるため、本体の
+// 実ロジック（比較演算子・null ガード）はそこではゼロカバレッジになる。演算子反転や
+// ガード削除でも呼び出し側テストは赤くならないので、切り出した純粋関数の境界値は
+// ここで本体を実行して固定する。**このファイルでは isEmbedded を mock しない。**
+import { afterEach, describe, expect, it } from 'vitest'
+import { isEmbedded } from './isEmbedded'
+
+describe('isEmbedded (#392)', () => {
+  // jsdom の window.top は own・configurable なデータプロパティ。各枝で差し替えるので
+  // 元の記述子を退避し、テストごとに復元してリークを防ぐ。
+  const originalTop = Object.getOwnPropertyDescriptor(window, 'top')
+
+  afterEach(() => {
+    if (originalTop) {
+      Object.defineProperty(window, 'top', originalTop)
+    }
+  })
+
+  it('トップフレーム（self===top）では非埋め込み＝false を返す', () => {
+    // jsdom 既定は self===top（単独ウィンドウ）
+    expect(window.self === window.top).toBe(true)
+    expect(isEmbedded()).toBe(false)
+  })
+
+  it('window.top が self と異なる（iframe 相当）とき埋め込み＝true を返す', () => {
+    Object.defineProperty(window, 'top', { value: {}, configurable: true })
+    // 前提: self !== top（別 Window 参照）になっている
+    expect(window.self === window.top).toBe(false)
+    expect(isEmbedded()).toBe(true)
+  })
+
+  it('window.top が null（detached document 等）のとき安全側＝false を返す（null ガード）', () => {
+    Object.defineProperty(window, 'top', { value: null, configurable: true })
+    // ガードが無いと self !== null が true になり埋め込みと誤判定するので false を固定する
+    expect(window.top).toBeNull()
+    expect(isEmbedded()).toBe(false)
+  })
+})

--- a/frontend/src/utils/isEmbedded.ts
+++ b/frontend/src/utils/isEmbedded.ts
@@ -1,0 +1,17 @@
+/**
+ * このページが iframe に埋め込まれて表示されているかを返す (#392)。
+ *
+ * `window.self !== window.top` は、トップフレームで開かれていれば self===top で false、
+ * iframe 内なら self!==top で true になる。参照比較（===）なので、埋め込み元が
+ * cross-origin でも SecurityError を投げない（プロパティ値の読み取りではなく Window
+ * 参照どうしの同一性判定のため）。
+ *
+ * name-name は Vite の CSR のみで SSR は無いが、テスト（jsdom）や将来の非ブラウザ実行を
+ * 考慮して `typeof window` ガードを入れる。window が無い環境では埋め込みでないとみなす。
+ *
+ * テストで stub しやすいよう独立した純粋関数として置く。
+ */
+export function isEmbedded(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.self !== window.top
+}

--- a/frontend/src/utils/isEmbedded.ts
+++ b/frontend/src/utils/isEmbedded.ts
@@ -13,5 +13,8 @@
  */
 export function isEmbedded(): boolean {
   if (typeof window === 'undefined') return false
-  return window.self !== window.top
+  // window.top が null（detached document 等、フレーム木から切り離された状態）のときは
+  // 状況が不確実なので安全側＝非埋め込み（ヘッダを出す）に倒す。null ガードを外すと
+  // `window.self !== null` が true になり detached を埋め込みと誤判定する。
+  return window.top != null && window.self !== window.top
 }


### PR DESCRIPTION
## 関連 Issue
closes #392

## 背景

theo-hayami サイトが name-name を `<iframe>` で単独埋め込みした本番実機で、プレイヤー画面上端に name-name 自身のヘッダ（`< 戻るボタン` ＋ プロジェクトタイトル）が出ていた。埋め込み側が既に HTML 額縁とタイトルを出しておりタイトル二重・戻るボタンは無意味・没入破壊。

## 設計（kako-jun 指摘で訂正）

当初 `?scene=` ディープリンクを条件にしたが、本質は「**iframe に埋め込まれて表示されているか**」。**どんなゲームでも** iframe 埋め込みなら name-name トップへ戻る導線は不自然。`?scene=` かどうかは無関係。

## 変更

- **新ヘルパ `frontend/src/utils/isEmbedded.ts`**: `isEmbedded()` = `typeof window !== 'undefined' && window.self !== window.top`（純粋関数・cross-origin でも参照比較で例外なし）。
- **`PlayerScreen.tsx`**: ヘッダ `<header>`（戻る＋タイトル）のゲートを `{!embedded && ...}`（`embedded = isEmbedded()`）に。iframe 埋め込み表示時は非描画、standalone タブ直開きは従来どおり描画（後方互換）。
- **#388 の TitleOverlay ゲート（`startSceneId`）は不変**: あちらはディープリンク意図（`?scene=` で該当シーンから始める）、こちらは埋め込み文脈（`isEmbedded`）で関心が別＝ゲートも別。
- theo-hayami 側は変更不要（既に iframe 埋め込み＝自動判定）。
- docs（architecture.md `?scene=` セクション）に埋め込み時ヘッダ抑制を追記。

## Test plan
- [x] `PlayerScreen.test.tsx` に `isEmbedded()` を `vi.mock` する4ケース（standalone＝ヘッダ有／埋め込み＝ヘッダ無／埋め込み時は `?scene=` 有無に依存せずヘッダ無＝当初誤設計への回帰防止／埋め込み判定は #388 TitleOverlay ゲートと直交）。ミューテーション確認済み
- [x] `npm run type-check` / `npm run lint` クリーン
- [x] `npx vitest run` 全1817件green
- [ ] 本番マージ後、theo-hayami 埋め込みでヘッダ非表示＋standalone `/play/...?scene=` 直開きでヘッダ表示を実機確認