### PR TITLE
埋め込みプレイヤー: 圏外choiceの終劇直行と開始時の背景/立ち絵表示 (#398, #399)

### DIFF
--- a/docs/adr/0002-deterministic-state-and-debuggability.md
+++ b/docs/adr/0002-deterministic-state-and-debuggability.md
@@ -92,7 +92,7 @@ await renderer.playScript(steps: Step[]): Promise<void>
 
 sceneId と flags を直接指定して任意の状態から開始する API。
 history はリセットされる（デバッグ用）。
-実装: `NovelRenderer.startFrom`、`StartFromOptions` 型は `GameState.ts`。状態復元コアは `loadFromSaveData` と共通化済み（#256）— 両者とも private `restoreToScene(scene, state)` を呼ぶ（フラグ設定 → 選択肢/待機リセット → resolveEvents → applyState → history リセット → render）。シーン探索と「見つからない場合の挙動」は呼び出し側の責務で、`startFrom` は不正 sceneId で完全 no-op（フラグも復元しない）、`loadFromSaveData` はシーン欠落時もフラグだけ復元する。flags は置換セマンティクス、検証を flags 適用より先に行う、eventIndex/textIndex は範囲チェックなし（呼び出し側責任）。vitest 25 ケース。
+実装: `NovelRenderer.startFrom`、`StartFromOptions` 型は `GameState.ts`。`startFrom` は 2 経路に分岐する（#399）: **`eventIndex=textIndex=sentenceIndex=0`（本番の `?scene=` は常にこれ）は通常入場と同じ fresh-start 経路**（`gameState.fromJSON(flags)` → `startScene` → `resetAndStartEvents`）に乗せ、冒頭の `[背景:]`/`[BGM:]` を実行し最初の話者の立ち絵を出してから最初のテキストで止まる。**`eventIndex>0` 等の途中局面指定（DEV の `debug_scene`）だけ**、宣言的復元コア private `restoreToScene(scene, state)`（フラグ設定 → 選択肢/待機リセット → resolveEvents → applyState → history リセット → render）にフォールバックする。この `restoreToScene` は `loadFromSaveData`（セーブ復元＝完成 state を持つ）と共通化済み（#256）。従来は startFrom も常に restoreToScene を通していたため冒頭ディレクティブが実行されず、埋め込み開始時に背景も立ち絵も出ず `eventIndex=0` で止まっていた（#399 の症状）。fresh-start 経路は `resetAndStartEvents` が index を 0 にリセットしてしまうため途中局面を再現できず、そのため index 指定時だけ `restoreToScene` に倒す。シーン探索と「見つからない場合の挙動」は呼び出し側の責務で、`startFrom` は不正 sceneId で完全 no-op（フラグも復元しない）、`loadFromSaveData` はシーン欠落時もフラグだけ復元する。flags は置換セマンティクス、検証を flags 適用より先に行う、eventIndex/textIndex は範囲チェックなし（呼び出し側責任）。vitest 30 ケース（#399 の fresh-start 経路 3 ケースを追加）。
 
 ```typescript
 renderer.startFrom({
@@ -137,10 +137,16 @@ Phase 3 の `debug_scene` は開発環境限定のデバッグ起点だった。
 `?scene=` 単独埋め込みは対象ファイル外（hub・他ファイル）への choice ジャンプを許さない
 （theo-hayami #20: 他ファイルへの遷移は choice ではなく埋め込み外側の HTML リンクで行う設計）。
 `PlayerScreen` が対象ファイル自身の sceneId 一覧（entry doc/hub 自身は除く）を
-`NovelRenderer.setConfinedSceneIds` に渡し、`jumpToScene`（唯一の choke point）はこの集合外への
-遷移を検知すると通常のシーン遷移をせず `endStory()` を呼ぶ。`?scene=` が hub 自身の sceneId を
-指した場合は confinement を組まず無制限フローにフォールバックする（hub → 各お題への通常 choice
-遷移を壊さないため）。
+`NovelRenderer.setConfinedSceneIds` に渡す。圏外への遷移を検知すると通常のシーン遷移をせず
+`endStory()` を呼ぶ。終劇の判定箇所は 2 つある: **選んだ jump 先**が圏外なら `jumpToScene`
+（choice 確定後）が終劇する。加えて **全 option の jump 先が圏外の `[選択]` に到達した場合**は、
+選択肢を描画せず `processDirective` の Choice 分岐で先回りして終劇する（#398）。後者が無いと、
+全 option 圏外の choice は「クリックするまで」`jumpToScene` に届かず、`storyEnded` の
+postMessage（#395/#397）が発火しないため埋め込み側で既読化されなかった。既読化
+（`markCurrentSceneRead`）を済ませてから終劇するので、選択肢を出さずに完読を通知できる。
+`?scene=` が hub 自身の sceneId を指した場合は confinement を組まず無制限フローにフォールバック
+する（`confinedSceneIds === null` では両判定とも短絡しない。hub → 各お題への通常 choice 遷移を
+壊さないため）。
 
 `endStory()` は `NovelGameState.storyEnded` という**宣言的フラグ**を true にする。この設計は
 本 ADR の核心（演出の中間状態を持たない・完全にシリアライズ可能）にそのまま従う: 背景・立ち絵の
@@ -175,10 +181,12 @@ Phase 3 の `debug_scene` は開発環境限定のデバッグ起点だった。
 ## 関連
 
 - `GameState.ts`: `NovelGameState` 定義
-- `NovelRenderer.ts`: `applyState`、`restoreToScene`（`startFrom`/`loadFromSaveData` 共通コア）、`seekTo`、`advance`、`jumpToScene`、`setConfinedSceneIds`、`endStory`
+- `NovelRenderer.ts`: `applyState`、`startFrom`（`eventIndex=0` は `startScene` の fresh-start 経路、#399）、`restoreToScene`（startFrom の途中局面指定 / `loadFromSaveData` 共通コア）、`seekTo`、`advance`、`jumpToScene`、`processDirective`（Choice 短絡での終劇、#398）、`setConfinedSceneIds`、`endStory`
 - `frontend/src/game/sceneQuery.ts` / `frontend/src/game/sceneConfinement.ts`: `?scene=` パーサ・confinement 判定（#386）
 - `docs/architecture.md`: 「状態管理: NovelGameState」セクション、「production 向けシーン直接ディープリンク `?scene=`」セクション
 - `docs/guide/debugger.md`: `debug_scene`（DEV 専用）の使い方ガイド
 - Issue #220: `playScript` / `startFrom` 実装
 - Issue #256: `startFrom` / `loadFromSaveData` の状態復元コア共通化（`restoreToScene`）
 - Issue #386: `?scene=` ディープリンク + confinement + 終劇（`storyEnded`）
+- Issue #398: 全 option 圏外の `[選択]` は描画せず `processDirective` の Choice 分岐で先回りして終劇する
+- Issue #399: 埋め込み開始（`?scene=`, `eventIndex=0`）を fresh-start 経路に乗せ、冒頭ディレクティブ実行＋立ち絵表示を通す

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,15 +142,25 @@ resolver 経由で）事前解決・ロードしてから `NovelPlayer` に `ini
 `NovelPlayer` はマウント時に一度だけ `renderer.startFrom({ sceneId: initialSceneId })` を呼ぶ
 （DEV 専用の `debug_scene` ブロックより前に評価するため、DEV で両方指定されると `debug_scene`
 側が後勝ちで優先される）。無効・未解決の sceneId は現行どおりエントリ（ハブ）から開始する。
+`?scene=` の startFrom は `eventIndex=0`（シーン先頭）固定なので、**通常入場と同じ fresh-start
+経路**（`startScene` → `resetAndStartEvents`）に乗り、冒頭の `[背景:]`/`[BGM:]` を実行し最初の
+話者の立ち絵を出してから最初のテキストで止まる（#399）。従来は宣言的復元の `restoreToScene` に
+乗せていたため、冒頭ディレクティブが実行されず背景も立ち絵も出ないまま `eventIndex=0` で
+止まっていた。DEV の `debug_scene` で `eventIndex>0` を指定した途中局面起動だけ `restoreToScene`
+にフォールバックする（詳細は [ADR 0002](./adr/0002-deterministic-state-and-debuggability.md) の §3）。
 
 **confinement（在圏）+ 終劇**: 単独埋め込みは対象 script ファイルの外（hub・他ファイル）へ
 choice で漏れてはいけない（theo-hayami #20: 他ファイルへの遷移は choice ではなく埋め込み外側の
 HTML リンクで行う設計）。`PlayerScreen` の `findConfinedSceneIds(targetSceneId, docs, entryPath)`
 が対象 sceneId が属する script ファイル自身の sceneId 一覧を算出し（entry doc/hub 自身は候補から
-除外）、`NovelPlayer` → `NovelRenderer.setConfinedSceneIds` に渡す。`jumpToScene`（唯一の
-choke point）はこの集合外への遷移を検知すると通常のシーン遷移をせず `endStory()` を呼び、
-`NovelGameState.storyEnded` を true にする（背景・立ち絵はフェードアウトし、DOM 側は控えめな
-"to be continued..." を表示する）。`?scene=` が hub 自身の sceneId を指した場合は
+除外）、`NovelPlayer` → `NovelRenderer.setConfinedSceneIds` に渡す。集合外への遷移を検知すると
+通常のシーン遷移をせず `endStory()` を呼び、`NovelGameState.storyEnded` を true にする（背景・
+立ち絵はフェードアウトし、DOM 側は控えめな "to be continued..." を表示する）。判定箇所は 2 つ:
+**選んだ jump 先**が圏外なら `jumpToScene`（choice 確定後）が終劇する。さらに **全 option の
+jump 先が圏外の `[選択]` に到達した場合**は、選択肢を描画せず `processDirective` の Choice 分岐で
+先回りして終劇する（#398。全 option 圏外の choice はクリックするまで `jumpToScene` に届かず、
+`storyEnded` の postMessage が発火しないため既読化されなかった。`markCurrentSceneRead` を済ませて
+から終劇し、選択肢を出さずに完読を親へ通知する）。`?scene=` が hub 自身の sceneId を指した場合は
 `findConfinedSceneIds` が null を返し、confinement を組まず無制限フローにフォールバックする
 （hub → 各お題への通常 choice 遷移を壊さないため）。`storyEnded` の設計上の位置づけ
 （ADR 0002 の「演出の中間状態を持たない」規律との関係）は

--- a/docs/guide/debugger.md
+++ b/docs/guide/debugger.md
@@ -115,6 +115,6 @@ interface StartFromOptions {
 
 ## 設計背景
 
-- `playScript` / `startFrom` / セーブ復元は、共通コア `restoreToScene(scene, state)` を経由して状態を組み立てる（[#256](https://github.com/kako-jun/name-name/issues/256)）。復元ロジックは 1 本に集約されている。
+- `startFrom`（途中局面指定・`eventIndex>0`）とセーブ復元は、共通コア `restoreToScene(scene, state)` を経由して状態を宣言的に組み立てる（[#256](https://github.com/kako-jun/name-name/issues/256)）。復元ロジックは 1 本に集約されている。ただし `startFrom` の `eventIndex=0`（本番 `?scene=` 埋め込みの既定）だけは通常入場と同じ fresh-start 経路（`startScene` → `resetAndStartEvents`）に乗り、冒頭の `[背景:]`/`[BGM:]` を実行し最初の話者の立ち絵を出す（[#399](https://github.com/kako-jun/name-name/issues/399)）。
 - 「任意の state から起動・再開できる」ことは、状態と描画が分離できている**機械的な証明**でもある。新しいレンダラ／モードを足すときは、この API で任意局面を再現できることを完了条件にする。
 - 詳しい設計判断は [ADR 0002 — 決定論的状態とデバッグ容易性](../adr/0002-deterministic-state-and-debuggability.md) を参照。

--- a/frontend/src/game/NovelRenderer.confinement.test.ts
+++ b/frontend/src/game/NovelRenderer.confinement.test.ts
@@ -17,7 +17,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { Assets, Texture } from 'pixi.js'
 import { NovelRenderer } from './NovelRenderer'
 import { defaultTimeController } from './TimeController'
-import type { Event, EventScene } from '../types'
+import type { Event, EventScene, ChoiceOption } from '../types'
 
 // --- fixture helpers（startFrom.test.ts と同じスタイル） ---
 
@@ -27,6 +27,11 @@ function narration(...lines: string[]): Event {
 
 function scene(id: string, events: Event[]): EventScene {
   return { id, title: id, view: 'TopDown', events }
+}
+
+/** narration → Choice の 2 イベントシーン。advance 1 回で Choice に到達する（#398）。 */
+function choiceScene(id: string, options: ChoiceOption[]): EventScene {
+  return scene(id, [narration('本文'), { Choice: { options } } as Event])
 }
 
 /** confinement 検証用の内部アクセサ */
@@ -44,6 +49,9 @@ interface RendererInternals {
   shakeTimer: number | null
   effectTimer: number | null
   effectOverlay: { alpha: number; visible: boolean } | null
+  waitingForChoice: boolean
+  readSceneProgress: Set<string>
+  choiceOverlay: { show: (...args: unknown[]) => void; hide: () => void }
 }
 
 function internals(r: NovelRenderer): RendererInternals {
@@ -334,4 +342,99 @@ describe('NovelRenderer confinement / endStory (#386)', () => {
   })
   // 「圏外だが allScenes に実在する sceneId は console.warn されない」は既存テスト20が担保する
   // （out-scene は allScenes に実在するため、本テストの 'typo-scene-id' と対照的な既存カバレッジ）。
+})
+
+// ===================================================================================
+// #398: Choice ディレクティブ経由の短絡（全 option 圏外なら選択肢を出さず終劇へ倒す）
+// ===================================================================================
+//
+// 既存テスト（17〜32）は jumpToScene 起点の endStory（選んだ jump 先が圏外）だけをカバーする。
+// #398 は「そもそも全 option が圏外なら、クリックを待たず choice 描画前に短絡して終劇する」経路。
+// setter 直呼びでなく、narration → Choice を advance で再生して processDirective の Choice 分岐を
+// 実際に踏む。choiceOverlay.show() は AudioManager.ensureContext()（jsdom に AudioContext なし）と
+// PixiJS 実描画を伴うため、短絡しない（choice 表示に進む）ケースだけ show を no-op spy に差し替える
+// （短絡ケースは show に到達しないので差し替え不要）。
+
+describe('NovelRenderer confinement × Choice ディレクティブ短絡 (#398)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    defaultTimeController.setMode('live')
+    // markCurrentSceneRead は docKey ごとに localStorage へ書くため、テスト間で持ち越さない。
+    localStorage.clear()
+  })
+
+  // ===== 1. 全 option 圏外 → 短絡して終劇 =====
+
+  it('398-1: 全 option の jump が圏外を指す Choice に到達すると、choice を出さず storyEnded=true にする', async () => {
+    const cb = vi.fn()
+    const r = makeRenderer([
+      choiceScene('entry', [
+        { text: 'ハブへ', jump: 'hub' },
+        { text: '他業へ', jump: 'other' },
+      ]),
+      scene('hub', [narration('hub')]),
+      scene('other', [narration('other')]),
+    ])
+    r.setDocKey('doc-398-all-out') // markCurrentSceneRead を実際に効かせる（既読集合を観測するため）
+    r.setOnStoryEndedChange(cb)
+    r.setConfinedSceneIds(['entry']) // 圏内は entry のみ。hub / other は圏外
+    // choiceOverlay.show に到達しないことを spy で担保する（短絡なら呼ばれない）。
+    const showSpy = vi.spyOn(internals(r).choiceOverlay, 'show')
+
+    // narration('本文') → advance 1 回で Choice に到達（processDirective の Choice 分岐を再生経路で踏む）。
+    await r.playScript([{ type: 'advance' }])
+
+    expect(r.getSnapshot().storyEnded).toBe(true)
+    // waitingForChoice は立たず、choiceOverlay も表示されない（短絡で choice UI に進まない）。
+    expect(internals(r).waitingForChoice).toBe(false)
+    expect(showSpy).not.toHaveBeenCalled()
+    // onStoryEndedChange は true で 1 回だけ発火する。
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(cb).toHaveBeenCalledWith(true)
+    // Choice 到達時の markCurrentSceneRead が短絡より前に走り、シーンが既読になっている。
+    expect(internals(r).readSceneProgress.has('entry')).toBe(true)
+  })
+
+  // ===== 2. 一部 option が圏内 → 短絡せず choice 表示 =====
+
+  it('398-2: 一部 option が圏内なら短絡せず choice を表示する（waitingForChoice=true / storyEnded=false）', async () => {
+    const r = makeRenderer([
+      choiceScene('entry', [
+        { text: '中へ', jump: 'inside' }, // 圏内
+        { text: 'ハブへ', jump: 'hub' }, // 圏外
+      ]),
+      scene('inside', [narration('inside')]),
+      scene('hub', [narration('hub')]),
+    ])
+    r.setConfinedSceneIds(['entry', 'inside'])
+    // 圏内 option があるので choice 表示に進む。show は AudioContext/PixiJS を触るので no-op に差し替える。
+    const showSpy = vi.spyOn(internals(r).choiceOverlay, 'show').mockImplementation(() => {})
+
+    await r.playScript([{ type: 'advance' }])
+
+    expect(r.getSnapshot().storyEnded).toBe(false)
+    expect(internals(r).waitingForChoice).toBe(true)
+    expect(showSpy).toHaveBeenCalledTimes(1)
+  })
+
+  // ===== 3. confinedSceneIds === null（通常フロー） → 常に短絡しない（後方互換） =====
+
+  it('398-3: confinedSceneIds が null（既定）なら、全 option が圏外相当でも短絡せず choice を表示する（後方互換）', async () => {
+    const r = makeRenderer([
+      choiceScene('entry', [
+        { text: 'ハブへ', jump: 'hub' },
+        { text: '他業へ', jump: 'other' },
+      ]),
+      scene('hub', [narration('hub')]),
+      scene('other', [narration('other')]),
+    ])
+    // setConfinedSceneIds を呼ばない（confinedSceneIds は既定 null）。
+    const showSpy = vi.spyOn(internals(r).choiceOverlay, 'show').mockImplementation(() => {})
+
+    await r.playScript([{ type: 'advance' }])
+
+    expect(r.getSnapshot().storyEnded).toBe(false)
+    expect(internals(r).waitingForChoice).toBe(true)
+    expect(showSpy).toHaveBeenCalledTimes(1)
+  })
 })

--- a/frontend/src/game/NovelRenderer.startFrom.test.ts
+++ b/frontend/src/game/NovelRenderer.startFrom.test.ts
@@ -25,6 +25,24 @@ function dialog(character: string, ...lines: string[]): Event {
   return { Dialog: { character, expression: null, position: null, text: lines } }
 }
 
+/** 立ち絵付き Dialog（character + expression + position が全て埋まる → 立ち絵が載る）(#399)。 */
+function dialogWithPortrait(
+  character: string,
+  expression: string,
+  position: string,
+  ...lines: string[]
+): Event {
+  return { Dialog: { character, expression, position, text: lines } }
+}
+
+function background(path: string): Event {
+  return { Background: { path } }
+}
+
+function bgm(path: string): Event {
+  return { Bgm: { path, action: 'Play' } }
+}
+
 function scene(id: string, events: Event[]): EventScene {
   return { id, title: id, view: 'TopDown', events }
 }
@@ -93,6 +111,24 @@ const SCENES_CHOICE: EventScene[] = [
 // Wait を含むシーン（playScript で waitingForWait=true を作る用）
 const SCENES_WAIT: EventScene[] = [
   scene('start', [narration('intro'), { Wait: { ms: 100000 } } as Event, narration('after')]),
+]
+
+// #399 冒頭ディレクティブ実行用: [背景:] → [BGM:] → 最初の Dialog。
+// fresh-start 経路（eventIndex=0）は resetAndStartEvents → processUntilNextTextEvent が
+// 冒頭の Background / Bgm を最初のテキストまで実行するため、開始直後に背景/BGM が state に立つ。
+const SCENES_INTRO_DIRECTIVES: EventScene[] = [
+  scene('intro', [background('room.png'), bgm('theme.mp3'), dialog('A', 'おはよう')]),
+]
+
+// #399 立ち絵表示用: 最初の Dialog が character+expression+position を全て持つ。
+const SCENES_PORTRAIT: EventScene[] = [
+  scene('stage', [dialogWithPortrait('ヒロイン', 'smile', 'center', 'こんにちは')]),
+]
+
+// #399 DEV回帰用: 冒頭に [背景:] を持つシーン。eventIndex 指定の有無で経路が分岐する
+// （0 → fresh-start で背景を実行 / >0 → restoreToScene で宣言的復元・冒頭ディレクティブ不実行）。
+const SCENES_BG_THEN_DIALOG: EventScene[] = [
+  scene('bg', [background('sky.png'), dialog('A', 'ここ')]),
 ]
 
 describe('NovelRenderer.startFrom (#220)', () => {
@@ -355,5 +391,73 @@ describe('NovelRenderer.startFrom (#220)', () => {
 
     expect(r.getSnapshot().storyEnded).toBe(true)
     expect(cb).toHaveBeenCalledWith(true)
+  })
+})
+
+// ===================================================================================
+// #399: 埋め込み開始（`?scene=` deep-link, eventIndex=0）の fresh-start 経路
+// ===================================================================================
+//
+// 本番の `?scene=` 単独埋め込みは常に eventIndex=0 で startFrom する。この経路を通常入場
+// （jumpToScene → startScene → resetAndStartEvents）と揃え、冒頭の [背景:]/[BGM:] を実行し
+// 最初の話者の立ち絵を載せる（従来の restoreToScene 宣言的復元は冒頭ディレクティブを実行せず、
+// 背景も立ち絵も出ず eventIndex=0 で止まっていた ＝ #399 の症状）。
+//
+// index 指定あり（DEV の debug_scene）は従来どおり restoreToScene にフォールバックする。
+// 背景アセットの実ロード（WebGL）は jsdom 対象外だが、backgroundPath / currentBgmPath /
+// characters は Assets.load を待たず同期で確定するフィールドなので、これらの state が
+// 「開始直後に立つ」ことだけを検証する（実描画は CLAUDE.md ルール7 の実機 golden path に委ねる）。
+
+describe('NovelRenderer.startFrom fresh-start 経路 (#399)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  // ===== 1. 冒頭ディレクティブ（背景 / BGM）が開始直後に実行される =====
+
+  it('399-1: 先頭が [背景:]→[BGM:]→Dialog のシーンを startFrom すると、backgroundPath / currentBgmPath が開始直後に立ち、eventIndex が最初のテキスト（Dialog）まで進む', () => {
+    const r = makeRenderer(SCENES_INTRO_DIRECTIVES)
+    r.startFrom({ sceneId: 'intro' })
+
+    const s = r.getSnapshot()
+    // 冒頭の Background / Bgm ディレクティブが fresh-start で実行され、state に立っている。
+    expect(s.backgroundPath).toBe('room.png')
+    expect(s.currentBgmPath).toBe('theme.mp3')
+    // eventIndex は 2 つの冒頭ディレクティブを越え、最初のテキストイベント（Dialog, index 2）に到達。
+    expect(s.eventIndex).toBe(2)
+    expect(s.storyEnded).toBe(false)
+  })
+
+  // ===== 2. 最初の話者の立ち絵が開始直後に characters に載る =====
+
+  it('399-2: 最初の Dialog が character+expression+position を持つシーンを startFrom すると、その 1 体が characters に載る', () => {
+    const r = makeRenderer(SCENES_PORTRAIT)
+    r.startFrom({ sceneId: 'stage' })
+
+    // CharacterLayer.show は sprite を同期生成して Map に登録する（テクスチャ実ロードは待たない）。
+    // getSnapshot().characters は Map から renderOnly/退場中を除いて返すので、開始直後に 1 体入る。
+    const chars = r.getSnapshot().characters
+    expect(chars).toHaveLength(1)
+    expect(chars[0]).toMatchObject({ name: 'ヒロイン', expression: 'smile', position: 'center' })
+  })
+
+  // ===== 3. fresh-start（index=0）は冒頭ディレクティブを実行、DEV（index>0）は restoreToScene で不実行 =====
+
+  it('399-3: 同じシーンでも eventIndex=0 は冒頭 [背景:] を実行し、eventIndex 指定ありは restoreToScene 経路（冒頭ディレクティブ不実行）に分岐する', () => {
+    // fresh-start（index 省略 = 0）: 冒頭 Background を実行 → backgroundPath が立ち、Dialog(index 1) まで進む。
+    const rFresh = makeRenderer(SCENES_BG_THEN_DIALOG)
+    rFresh.startFrom({ sceneId: 'bg' })
+    const fresh = rFresh.getSnapshot()
+    expect(fresh.backgroundPath).toBe('sky.png')
+    expect(fresh.eventIndex).toBe(1)
+
+    // DEV（eventIndex=1 指定）: restoreToScene の宣言的復元。冒頭 Background は実行されないため
+    // backgroundPath は null のまま、eventIndex は指定値 1 が保たれる（fresh reset されない）。
+    const rDev = makeRenderer(SCENES_BG_THEN_DIALOG)
+    rDev.startFrom({ sceneId: 'bg', eventIndex: 1 })
+    const dev = rDev.getSnapshot()
+    expect(dev.backgroundPath).toBeNull()
+    expect(dev.eventIndex).toBe(1)
   })
 })

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -3479,12 +3479,39 @@ export class NovelRenderer {
       return
     }
 
-    // 最小 NovelGameState を構築して共通コアで復元
+    const eventIndex = opts.eventIndex ?? 0
+    const textIndex = opts.textIndex ?? 0
+    const sentenceIndex = opts.sentenceIndex ?? 0
+
+    // #399: シーン先頭からの新規開始（本番の `?scene=` deep-link は常に eventIndex=0 固定）は、
+    // 通常入場（jumpToScene → startScene）と同じ fresh-start 経路に乗せる。startScene →
+    // resetAndStartEvents は末尾で processUntilNextTextEvent（冒頭の [背景:]/[BGM:] 等の
+    // ディレクティブを最初のテキストまで実行）と showCharacterThenRender（最初の話者の立ち絵を
+    // 表示）を通すため、開始直後に背景と立ち絵が出る。
+    //
+    // これに対し restoreToScene は「完成済み state を applyState で宣言的に復元する」経路で、
+    // 冒頭ディレクティブを一切実行しない（eventIndex=0 のまま render するだけ）。だから従来の
+    // startFrom は背景も立ち絵も出ず eventIndex=0 で止まっていた（#399 の症状）。restoreToScene
+    // は save/load 復元専用（完成状態を持つ SaveSlotData を渡す loadFromSaveData）として残す。
+    //
+    // eventIndex/textIndex/sentenceIndex が指定されるのは DEV の debug_scene（シーン途中からの
+    // 起動）だけ。fresh-start 経路は resetAndStartEvents が index を 0 にリセットしてしまうため
+    // 途中局面を再現できない。そのため index 指定がある場合だけ従来どおり restoreToScene の
+    // 宣言的復元にフォールバックする（production は常に 0 なのでこの分岐には入らない）。
+    if (eventIndex === 0 && textIndex === 0 && sentenceIndex === 0) {
+      // フラグを先に確定させる（resetAndStartEvents 内の resolveEvents が this.gameState の
+      // flags に依存するため）。fromJSON は置換セマンティクス（restoreToScene と同じ）。
+      this.gameState.fromJSON(flags)
+      this.startScene(opts.sceneId, scene)
+      return
+    }
+
+    // DEV（debug_scene で index 指定あり）: 最小 NovelGameState を構築して共通コアで宣言的復元。
     const state: NovelGameState = {
       sceneId: opts.sceneId,
-      eventIndex: opts.eventIndex ?? 0,
-      textIndex: opts.textIndex ?? 0,
-      sentenceIndex: opts.sentenceIndex ?? 0,
+      eventIndex,
+      textIndex,
+      sentenceIndex,
       flags,
       backgroundPath: null,
       backgroundColor: null,

--- a/frontend/src/game/NovelRenderer.ts
+++ b/frontend/src/game/NovelRenderer.ts
@@ -2579,6 +2579,19 @@ export class NovelRenderer {
     if ('Choice' in event) {
       // Choice に到達した時点で、そこまでの本文を読み終えた scene とみなす (#366)。
       this.markCurrentSceneRead()
+      // #398: `?scene=` 単独埋め込み（confinement 設定時）で、全 option が圏外を指す choice は
+      // 描画せずに終劇へ倒す。jumpToScene は「選んだ jump 先」でしか圏外判定できないため、
+      // クリックするまで endStory に到達せず、その結果 #395/#397 の story-ended postMessage が
+      // 発火せず theo 側で既読化されなかった。既読化（上の markCurrentSceneRead）を済ませてから
+      // ここで先回りして終劇する＝選択肢を出さずに完読を通知できる。通常のハブ経由フロー
+      // （confinedSceneIds === null）では isSceneIdConfined が常に true を返すため短絡しない。
+      if (
+        this.confinedSceneIds !== null &&
+        event.Choice.options.every((o) => !isSceneIdConfined(o.jump, this.confinedSceneIds))
+      ) {
+        this.endStory()
+        return
+      }
       // 選択肢に到達したらスキップモードを解除（手動選択が必要） (#140)
       this.setSkipMode(false)
       // 複数埋め込みで他インスタンスが読んだ scene を、選択肢表示直前に反映する (#366)。


### PR DESCRIPTION
## 関連 Issue
Closes #398
Closes #399

## 変更内容（埋め込みプレイヤーの2バグ・TSのみ・wasm不要）

### #398 圏外choiceの終劇直行＋既読化
`?scene=` 単独埋め込み（confinement）で、全 option がファイル外（圏外）を指す `[選択]` が "to be continued" の手前で描画されていた。クリックするまで `endStory()` に到達せず、#395/#397 の `story-ended` postMessage が発火せず theo 側で既読化されなかった。
- `processDirective` の Choice ブロックで `markCurrentSceneRead()` の直後に短絡: `confinedSceneIds!==null && 全option圏外` なら `endStory()`+return。既読化を維持しつつ choice を描画せず終劇へ倒し、postMessage を発火。通常フロー（`confinedSceneIds===null`）は短絡しない。

### #399 開始直後の背景/立ち絵表示
`startFrom`（`?scene=` deep-link）が `restoreToScene` の宣言的復元に直行し、シーン冒頭の `[背景:]`/`[BGM:]` を実行しないため開始直後に背景・立ち絵が出なかった。
- `eventIndex=0`（本番の deep-link は常に0）を通常入場と同じ fresh-start 経路（`startScene`→`resetAndStartEvents`→`processUntilNextTextEvent`+`showCharacterThenRender`）に乗せ、冒頭ディレクティブを実行して背景＋最初の話者の立ち絵を表示。
- `restoreToScene` は save/load 復元専用として維持。`eventIndex>0`（DEV `debug_scene`）は従来の宣言的復元にフォールバック。
- fold/経路復元は不採用（各 md が冒頭で舞台を宣言する方針。無言立ち絵 #401＋theo#39 で担保）。

## テスト
- `NovelRenderer.confinement.test.ts` +3（全圏外短絡・混在・後方互換）、`NovelRenderer.startFrom.test.ts` +3（冒頭ディレクティブ実行・最初の話者立ち絵・DEV回帰）。全 **1854 tests green**、type-check/lint 通過。
- WebGL/実描画・postMessage 受信・"to be continued" 見た目は実機 golden path（theo 埋め込み）で確認。

## docs 追従
`architecture.md`（終劇判定2箇所・startFrom fresh-start）、`adr/0002`（startFrom 2経路分岐）、`guide/debugger.md`。`spec/markdown-v0.1.md` は runtime 挙動につき変更不要。
